### PR TITLE
Implement Homepage badges for default theme

### DIFF
--- a/mkdocs/themes/mkdocs/content.html
+++ b/mkdocs/themes/mkdocs/content.html
@@ -1,3 +1,21 @@
+{% if current_page.is_homepage %}
+<div class="badges">
+    {% if config.github_buttons %}
+    <iframe src="http://ghbtns.com/github-btn.html?user={{ config.github_buttons[0] }}&amp;repo={{ config.github_buttons[1] }}&amp;type={{ config.github_buttons[2] }}&amp;count={{ config.github_buttons[3] }}&amp;size={{ config.github_buttons[4] }}" class="github-star-button" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
+    {% endif %}
+
+    {% if config.travis_ci %}
+    <a href="https://travis-ci.org/{{ config.travis_ci[0] }}/{{ config.travis_ci[1] }}">
+        <img src="https://travis-ci.org/{{ config.travis_ci[0] }}/{{ config.travis_ci[1] }}.png?branch={{ config.travis_ci[2] }}" class="travis-badge-image">
+    </a>
+    {% endif %}
+
+    {% if config.coveralls %}
+    <a href='https://coveralls.io/r/{{ config.coveralls[0] }}/{{ config.coveralls[1] }}?branch={{ config.coveralls[2] }}'><img src="https://coveralls.io/repos/{{ config.coveralls[0] }}/{{ config.coveralls[1] }}/badge.png?branch={{ config.coveralls[2] }}" alt="Coverage Status" class="coveralls-badge-image" /></a>
+    {% endif %}
+</div>
+{% endif %}
+
 {% if meta.source %}
 <div class="source-links">
 {% for filename in meta.source %}

--- a/mkdocs/themes/mkdocs/content.html
+++ b/mkdocs/themes/mkdocs/content.html
@@ -1,7 +1,7 @@
 {% if current_page.is_homepage %}
 <div class="badges">
     {% if config.github_buttons %}
-    <iframe src="http://ghbtns.com/github-btn.html?user={{ config.github_buttons[0] }}&amp;repo={{ config.github_buttons[1] }}&amp;type={{ config.github_buttons[2] }}&amp;count={{ config.github_buttons[3] }}&amp;size={{ config.github_buttons[4] }}" class="github-star-button" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
+    <iframe src="http://ghbtns.com/github-btn.html?user={{ config.github_buttons[0] }}&amp;repo={{ config.github_buttons[1] }}&amp;type={{ config.github_buttons[2] }}&amp;count={{ config.github_buttons[3] }}" class="github-star-button" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
     {% endif %}
 
     {% if config.travis_ci %}

--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -156,3 +156,27 @@ footer {
         width: 263px;
     }
 }
+
+/* Homepage badges */
+.badges {
+  padding-bottom: 1px;
+  margin-top: 10px;
+}
+
+/* GitHub 'Star' badge */
+.badges iframe.github-star-button {
+    float: right;
+    margin-top: -12px;
+    margin-right: -15px;
+}
+
+/* Travis CI badge */
+.badges img.travis-badge-image,
+.badges img.coveralls-badge-image {
+    float: right;
+    margin-right: 8px;
+    margin-top: -11px;
+    margin-bottom: 0px;
+    padding: 0;
+    border: 0;
+}


### PR DESCRIPTION
Add the following badges to the homepage.
- GitHub buttons
- Travis CI
- Coveralls

Example use case mkdocs.yml
```
github_buttons: ['tomchristie', 'flask-api', 'watch', 'true']
travis_ci: ['tomchristie', 'flask-api', 'master']
coveralls: ['tomchristie', 'flask-api', 'master']
```