### PR TITLE
Fixes #65 - Links to other files within documentation are broken on Pyth...

### DIFF
--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -67,6 +67,9 @@ class URLContext(object):
         given the context of the current page.
         """
         suffix = '/' if (url.endswith('/') and len(url) > 1) else ''
+        # Workaround for bug on `posixpath.relpath()` in Python 2.6
+        if self.base_path == '/':
+            return url.lstrip('/') + suffix
         return posixpath.relpath(url, start=self.base_path) + suffix
 
 


### PR DESCRIPTION
...on 2.6

There was a bug in `posixpath.relpath()` in this version of Python. The
bug was worked around by a verification of the corner case were the
`start` argument is the root directory.
