### PR TITLE
Fixes indentation issues which caused lint errors.

### DIFF
--- a/mkdocs/gh_deploy.py
+++ b/mkdocs/gh_deploy.py
@@ -9,9 +9,9 @@ def gh_deploy(config):
 
     print "Copying '%s' to `gh-pages` branch and pushing to GitHub." % config['site_dir']
     try:
-       subprocess.check_call(['ghp-import', '-p', config['site_dir']])
+        subprocess.check_call(['ghp-import', '-p', config['site_dir']])
     except:
-       return
+        return
 
     # TODO: Also check for CNAME file
     url = subprocess.check_output(["git", "config", "--get", "remote.origin.url"])


### PR DESCRIPTION
There was no issue for this, but there were indentation errors which were causing the `runtests` script to fail.
