### PR TITLE
autogenerate index.html for (or whatever the template: says) 

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -1,2 +1,0 @@
-
-once more about something

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,2 +1,0 @@
-
-SVENWASHERE

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ dev_addr: 0.0.0.0:8000
 pages:
 - ['index.md', 'Home']
 - ['user-guide/index.md', '**HIDDEN**']
+- ['user-guide/index2.md', '**HIDDEN**']
 - ['user-guide/writing-your-docs.md', 'User Guide', 'Writing your docs']
 - ['user-guide/styling-your-docs.md', 'User Guide', 'Styling your docs']
 - ['user-guide/configuration.md', 'User Guide', 'Configuration']

--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -143,7 +143,21 @@ def build_pages(config):
     for page in site_navigation.walk_pages():
         # Read the input file
         input_path = os.path.join(config['docs_dir'], page.input_path)
-        input_content = open(input_path, 'r').read().decode('utf-8')
+        try:
+            input_content = open(input_path, 'r').read().decode('utf-8')
+        except:
+            # Allow 'template:' override in md source files.
+            if 'template' in meta:
+                template = env.get_template(meta['template'][0])
+            else:
+                template = env.get_template('autoindex.html')
+
+            context = get_context(
+                page, 'test input', site_navigation,
+                table_of_contents, meta, config
+            )
+            # Render the template.
+            input_content = template.render(context)
 
         # Process the markdown text
         html_content, table_of_contents, meta = convert_markdown(input_content)

--- a/mkdocs/themes/mkdocs/autoindex.html
+++ b/mkdocs/themes/mkdocs/autoindex.html
@@ -1,0 +1,9 @@
+# Table of Contents
+{% for nav_item in nav %}
+{% if nav_item.children %}
+### {{ nav_item.title }} {{ nav_item.url }}
+{% for nav_item in nav_item.children %}
+#### [{{ nav_item.title }}]({{ nav_item.url }})
+{% endfor %}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
I need intermediate url's to be have valid html - a TOC is currently enough. for example, `http://mkdocs.org/about/` is not a topic, but someone may go there when typing the url.

It looks like some `nav.py` code has been broken - these pages are now listed, so I added a `**HIDDEN**` title to trigger my code
- I can raise a new PR to put this back if you like (now that i grok that code a little better)

```
                # Page config lines that do not include a title, such as:
                #    - ['index.md']
                # Will not be added to the nav items hierarchy, although they
                # are included in the full list of pages, and have the
                # appropriate 'next'/'prev' links generated.
```

`title=**HIDDEN**` makes the page not listed in the nav items hierarchy, **and** takes it out of the next/prev flow. however, those pages do have valid next/prev - so if you land on one, you can get out :).

If the `.md` file doesn't exist, then its generated using autoindex.html (ok, should really call it autoindex.md :) - and like the sitemap, might default it in a common dir, and allow over-ride in themes)

@tomchristie - would you merge this (with doc, cleanups and tests etc) or should I make it into a personal branch?
