### PR TITLE
on windows machines, extra_javascript & extra_css config variables were ...

### DIFF
--- a/mkdocs/config.py
+++ b/mkdocs/config.py
@@ -90,9 +90,9 @@ def validate_config(user_config):
                 else:
                     pages.append(relpath)
             elif utils.is_css_file(filename):
-                extra_css.append(relpath)
+                extra_css.append(relpath.replace("\\", "/")) # css & js paths are consumed by templates, so they need to be posix paths regardless of os
             elif utils.is_javascript_file(filename):
-                extra_javascript.append(relpath)
+                extra_javascript.append(relpath.replace("\\", "/"))
 
     if config['pages'] is None:
         config['pages'] = pages


### PR DESCRIPTION
...passing windows paths to templates instead of passing posix paths (as the templates expects).

If the doc was generated on windows, it would be broken on Firefox due to missing css & js files.
