### PR TITLE
Make 'use_directory_urls' configuration option work from command line

### DIFF
--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -136,7 +136,7 @@ def build_pages(config):
     """
     Builds all the pages and writes them into the build directory.
     """
-    site_navigation = nav.SiteNavigation(config['pages'])
+    site_navigation = nav.SiteNavigation(config['pages'], config['use_directory_urls'])
     loader = jinja2.FileSystemLoader(config['theme_dir'])
     env = jinja2.Environment(loader=loader)
 

--- a/mkdocs/config.py
+++ b/mkdocs/config.py
@@ -26,7 +26,7 @@ DEFAULT_CONFIG = {
     # If `True`, use `<page_name>/index.hmtl` style files with hyperlinks to the directory.
     # If `False`, use `<page_name>.html style file with hyperlinks to the file.
     # True generates nicer URLs, but False is useful if browsing the output on a filesystem.
-    'use_direcory_urls': True,
+    'use_directory_urls': True,
 
     # Specify a link to the project source repo to be included
     # in the documentation pages.
@@ -121,6 +121,12 @@ def validate_config(user_config):
 
     if config['include_nav'] is None:
         config['include_nav'] = len(config['pages']) > 1
+
+    if not isinstance(config['use_directory_urls'], bool):
+        use_directory_urls = config['use_directory_urls']
+        assert isinstance(use_directory_urls, str)
+        config['use_directory_urls'] = { "true"  : True,
+                                         "false" : False}[use_directory_urls.lower()]
 
     # To Do:
 


### PR DESCRIPTION
**Common changes**
- There is a typo in the option name defined in config.py
- The value of 'use_directory_urls' is not passed through to SiteNavigation

**Notes**

I have not extracted the logic responsible for conversion from string to bool to a standalone function for the sake to preserve the current style. Most probably this code should be extracted to the independent function when other clients (I mean _'include__*' options which marked currently as 'TODO') are implemented.
