### PR TITLE
Added Pygments extension

### DIFF
--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -53,7 +53,7 @@ def convert_markdown(markdown_source):
     markdown_source = toc.pre_process(markdown_source)
 
     # Generate the HTML from the markdown source
-    md = markdown.Markdown(extensions=['meta', 'toc', 'tables', 'fenced_code'])
+    md = markdown.Markdown(extensions=['meta', 'toc', 'tables', 'fenced_code', 'codehilite'])
     html_content = md.convert(markdown_source)
     meta = md.Meta
 


### PR DESCRIPTION
Python's Markdown package allows for using [Pygments](http://pygments.org/) - and I'd like to use 'em in mkdocs!  Let me know if there's something I'm missing to make this work.
