### PR TITLE
Add the homepage to SiteNavigation.__str__

### DIFF
--- a/mkdocs/mkdocs
+++ b/mkdocs/mkdocs
@@ -6,7 +6,6 @@ from mkdocs.config import load_config
 from mkdocs.gh_deploy import gh_deploy
 from mkdocs.new import new
 from mkdocs.serve import serve
-import shutil
 import sys
 
 

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -20,7 +20,7 @@ def filename_to_title(filename):
 
     title = os.path.splitext(filename)[0]
     title = title.replace('-', ' ').replace('_', ' ')
-    # Captialize if the filename was all lowercase, otherwise leave it as-is.
+    # Captialize if the filename was all lowercase, otherwise leave it as-is.
     if title.lower() == title:
         title = title.capitalize()
     return title
@@ -35,7 +35,7 @@ class SiteNavigation(object):
         self.homepage = self.pages[0] if self.pages else None
 
     def __str__(self):
-        return ''.join([str(item) for item in self])
+        return str(self.homepage) + ''.join([str(item) for item in self])
 
     def __iter__(self):
         return iter(self.nav_items)

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -180,7 +180,7 @@ class SiteNavigationTests(unittest.TestCase):
         """)
         site_navigation = nav.SiteNavigation(pages)
         self.assertEqual(str(site_navigation).strip(), expected)
-        self.assertEqual(len(site_navigation.nav_items), 2)
+        self.assertEqual(len(site_navigation.nav_items), 1)
         self.assertEqual(len(site_navigation.pages), 2)
 
     def test_empty_toc_item(self):
@@ -189,6 +189,7 @@ class SiteNavigationTests(unittest.TestCase):
             ('about.md', 'About')
         ]
         expected = dedent("""
+        Home - /
         About - /about/
         """)
         site_navigation = nav.SiteNavigation(pages)
@@ -217,7 +218,7 @@ class SiteNavigationTests(unittest.TestCase):
         """)
         site_navigation = nav.SiteNavigation(pages)
         self.assertEqual(str(site_navigation).strip(), expected)
-        self.assertEqual(len(site_navigation.nav_items), 3)
+        self.assertEqual(len(site_navigation.nav_items), 2)
         self.assertEqual(len(site_navigation.pages), 6)
 
     def test_walk_simple_toc(self):
@@ -246,9 +247,11 @@ class SiteNavigationTests(unittest.TestCase):
         ]
         expected = [
             dedent("""
+                Home - / [*]
                 About - /about/
             """),
             dedent("""
+                Home - /
                 About - /about/ [*]
             """)
         ]


### PR DESCRIPTION
A number of tests expected home to be included in the `__str__` output for
SiteNavigation. Home isn't included as it isn't stored in
SiteNavigation.nav_items with the other pages.

This change adds it to the `__str__` output and updates the expected
length for SiteNavigation.nav_items in the tests.
