### PR TITLE
Relax version requirements to accept a greater version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Jinja2==2.7.1
-Markdown==2.3.1
-PyYAML==3.10
-watchdog==0.7.0
-ghp-import==0.4.1
+Jinja2>=2.7.1
+Markdown>=2.3.1,<2.5
+PyYAML>=3.10
+watchdog>=0.7.0
+ghp-import>=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ author = 'Tom Christie'
 author_email = 'tom@tomchristie.com'
 license = 'BSD'
 install_requires = [
-    'Jinja2==2.7.1',
-    'Markdown==2.3.1',
-    'PyYAML==3.10',
-    'watchdog==0.7.0',
-    'ghp-import==0.4.1'
+    'Jinja2>=2.7.1',
+    'Markdown>=2.3.1,<2.5',
+    'PyYAML>=3.10',
+    'watchdog>=0.7.0',
+    'ghp-import>=0.4.1'
 ]
 
 long_description = """Work in progress."""


### PR DESCRIPTION
The requirements are currently pinned - this is an issue as it requires very specific versions. This change updates it to be more flexible and allow anything greater than our previous minimum.

Fixes #104
