### PR TITLE
Fix the custom-themes

### DIFF
--- a/mkdocs/themes/amelia/base.html
+++ b/mkdocs/themes/amelia/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/bootstrap/base.html
+++ b/mkdocs/themes/bootstrap/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/cerulean/base.html
+++ b/mkdocs/themes/cerulean/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/cosmo/base.html
+++ b/mkdocs/themes/cosmo/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/cyborg/base.html
+++ b/mkdocs/themes/cyborg/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/flatly/base.html
+++ b/mkdocs/themes/flatly/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/journal/base.html
+++ b/mkdocs/themes/journal/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/readable/base.html
+++ b/mkdocs/themes/readable/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/simplex/base.html
+++ b/mkdocs/themes/simplex/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/slate/base.html
+++ b/mkdocs/themes/slate/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/spacelab/base.html
+++ b/mkdocs/themes/spacelab/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/united/base.html
+++ b/mkdocs/themes/united/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;

--- a/mkdocs/themes/yeti/base.html
+++ b/mkdocs/themes/yeti/base.html
@@ -23,7 +23,7 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if config.theme_center_lead %}
+        {% if theme_center_lead %}
         <style>
             div.col-md-9 h1:first-of-type {
                 text-align: center;


### PR DESCRIPTION
  These did not build because the config object does not exist. An `mkdocs build` stopped with:

```
Building documentation to directory: html-new
Traceback (most recent call last):
  File "/home/lieter/.virtualenvs/mkdocs/bin/mkdocs", line 9, in <module>
    load_entry_point('mkdocs==0.9', 'console_scripts', 'mkdocs')()
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/mkdocs/main.py", line 52, in run_main
    main(cmd, args=sys.argv[2:], options=dict(opts))
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/mkdocs/main.py", line 32, in main
    build(config)
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/mkdocs/build.py", line 201, in build
    build_pages(config)
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/mkdocs/build.py", line 186, in build_pages
    output_content = template.render(context)
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/mkdocs/themes/cosmo/base.html", line 26, in top-level template code
    {% if config.theme_center_lead %}
  File "/home/lieter/.virtualenvs/mkdocs/local/lib/python2.7/site-packages/jinja2/environment.py", line 397, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'config' is undefined
```
