### PR TITLE
Remove reference to the `config` variable in the template files for custom themes

### DIFF
--- a/mkdocs/themes/amelia/base.html
+++ b/mkdocs/themes/amelia/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/bootstrap/base.html
+++ b/mkdocs/themes/bootstrap/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/cerulean/base.html
+++ b/mkdocs/themes/cerulean/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/cosmo/base.html
+++ b/mkdocs/themes/cosmo/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/cyborg/base.html
+++ b/mkdocs/themes/cyborg/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/flatly/base.html
+++ b/mkdocs/themes/flatly/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/journal/base.html
+++ b/mkdocs/themes/journal/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/readable/base.html
+++ b/mkdocs/themes/readable/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/simplex/base.html
+++ b/mkdocs/themes/simplex/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/slate/base.html
+++ b/mkdocs/themes/slate/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/spacelab/base.html
+++ b/mkdocs/themes/spacelab/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/united/base.html
+++ b/mkdocs/themes/united/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>

--- a/mkdocs/themes/yeti/base.html
+++ b/mkdocs/themes/yeti/base.html
@@ -22,20 +22,6 @@
             <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-
-        {% if config.theme_center_lead %}
-        <style>
-            div.col-md-9 h1:first-of-type {
-                text-align: center;
-                font-size: 60px;
-                font-weight: 300;
-            }
-
-            div.col-md-9 p:first-of-type {
-                text-align: center;
-            }
-        </style>
-        {% endif %}
     </head>
 
     <body>


### PR DESCRIPTION
It looks like https://github.com/tomchristie/mkdocs/commit/7167406bc9410410ea7617cd3ed30848636c45d8 broke the various custom themes because `config` is no longer a variable exposed to the templates. This removes the reference to that variable, making the custom themes more in-line with the base theme.

https://github.com/tomchristie/mkdocs/pull/90 will bring things further in line, allowing people using these themes to add this CSS to their extra_css if they want.
