### PR TITLE
Implement #86: Parse dir with - on command line

### DIFF
--- a/mkdocs/main.py
+++ b/mkdocs/main.py
@@ -14,10 +14,11 @@ def arg_to_option(arg):
     """
     Convert command line arguments into two-tuples of config key/value pairs.
     """
-    arg = arg.lstrip('--').replace('-', '_')
+    arg = arg.lstrip('--')
+    option = True
     if '=' in arg:
-        return arg.split('=', 1)
-    return (arg, True)
+        arg, option = arg.split('=', 1)
+    return (arg.replace('-', '_'), option)
 
 
 def main(cmd, args, options=None):

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 
-from mkdocs import build, nav, toc, utils, config
+from mkdocs import build, main, nav, toc, utils, config
 from mkdocs.compat import PY2, zip
 import markdown
 import os
@@ -18,6 +18,25 @@ def dedent(text):
 
 def ensure_utf(string):
     return string.encode('utf-8') if PY2 else string
+
+
+class MainTests(unittest.TestCase):
+    def test_arg_to_option(self):
+        """
+        Check that we parse parameters passed to mkdocs properly
+        """
+        arg, option = main.arg_to_option('--site-dir=dir')
+        self.assertEqual('site_dir', arg)
+        self.assertEqual('dir', option)
+        arg, option = main.arg_to_option('--site-dir=dir-name')
+        self.assertEqual('site_dir', arg)
+        self.assertEqual('dir-name', option)
+        arg, option = main.arg_to_option('--site-dir=dir=name')
+        self.assertEqual('site_dir', arg)
+        self.assertEqual('dir=name', option)
+        arg, option = main.arg_to_option('--use_directory_urls')
+        self.assertEqual('use_directory_urls', arg)
+        self.assertEqual(True, option)
 
 
 class ConfigTests(unittest.TestCase):


### PR DESCRIPTION
Tries to be less aggressive when parsing command line parameters, e.g.
`--site-name=a-name` should return `('site-name', 'a-name')`
