### PR TITLE
Replace inotify with polling observer

### DIFF
--- a/mkdocs/serve.py
+++ b/mkdocs/serve.py
@@ -85,7 +85,9 @@ def serve(config, options=None):
     #       can re-apply them if the config file is reloaded.
     event_handler = BuildEventHandler(options)
     config_event_handler = ConfigEventHandler(options)
-    # Use highly universal `PollingObserver`
+
+    # We could have used `Observer()`, which can be faster, but
+    # `PollingObserver()` works more universally.
     observer = PollingObserver()
     observer.schedule(event_handler, config['docs_dir'], recursive=True)
     for theme_dir in config['theme_dir']:


### PR DESCRIPTION
I opened #178 to discuss my issues running mkdocs inside Docker/Vagrant setups. After talking to a watchdog developer, he suggested using a `PollingObserver` which is a more universal approach but likely also a little bit slower.

I believe these changes will allow auto-reload to work inside shared folders. My brief testing suggests so anyhow. Existing users shouldn't notice any difference.

I absolutely couldn't figure out any sensible way to unit test my four line pull request. I also didn't find any place in the project documentation to write about it.
