### PR TITLE
Fix #183: Don't add classes to code blocks

### DIFF
--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -83,8 +83,6 @@ def post_process_html(html_content, nav=None):
     img_sub = PathToURL('src="%s"', nav)
     html_content = re.sub(r'src="([^"]*)"', img_sub, html_content)
 
-    html_content = html_content.replace('<pre>', '<pre class="prettyprint well">')
-
     return html_content
 
 

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -1,6 +1,7 @@
 
 /* Prettyify */
 $( document ).ready(function() {
+    $('pre code').parent().addClass('prettyprint well')
     prettyPrint();
 });
 


### PR DESCRIPTION
Previously, MkDocs will add classes to the <pre><code> blocks generated
from the md file to allow for the prettify library to work its magic.
This commit moves the translation into base.js under mkdocs, so now the
theme handles the prettify instead of assuming in the build process.
This allows users to use other libraries, such as highlight.js.
