### PR TITLE
Make it easier to recognize as BSD license

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -15,7 +15,7 @@ Themes used under license from the Bootstrap, ReadTheDocs, GhostWriter and Boots
 
 Many thanks to the authors and contributors of those wonderful projects.
 
-#### MkDocs License
+#### MkDocs License (BSD)
 
 Copyright © 2014, Tom Christie. All rights reserved.
 


### PR DESCRIPTION
People could mistake it as a custom license instead of a generic BSD license, so I thought a tiny clarification might save readers time, effort and mostly pain.
