### PR TITLE
Add MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include mkdocs/themes *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
The MANIFEST.in file includes all of the files used by the themes we
ship with MkDocs and excludes **pycache** (py3) and py[co](py2).

Fixes #196
