### PR TITLE
Implement #163: Reload webpage when editing docs

### DIFF
--- a/mkdocs/serve.py
+++ b/mkdocs/serve.py
@@ -1,10 +1,11 @@
 # coding: utf-8
 from __future__ import print_function
 
+from livereload import Server
 from watchdog import events
 from watchdog.observers.polling import PollingObserver
 from mkdocs.build import build
-from mkdocs.compat import httpserver, socketserver, urlunquote
+from mkdocs.compat import httpserver, urlunquote
 from mkdocs.config import load_config
 import os
 import posixpath
@@ -95,22 +96,14 @@ def serve(config, options=None):
     observer.schedule(config_event_handler, '.')
     observer.start()
 
-    class TCPServer(socketserver.TCPServer):
-        allow_reuse_address = True
-
-    class DocsDirectoryHandler(FixedDirectoryHandler):
-        base_dir = config['site_dir']
-
     host, port = config['dev_addr'].split(':', 1)
-    server = TCPServer((host, int(port)), DocsDirectoryHandler)
+    server = Server()
+    server.watch(config['site_dir'])
+    server.serve(port=port, root=config['site_dir'])
 
     print('Running at: http://%s:%s/' % (host, port))
     print('Live reload enabled.')
     print('Hold ctrl+c to quit.')
-    try:
-        server.serve_forever()
-    except KeyboardInterrupt:
-        print('Stopping server...')
 
     # Clean up
     observer.stop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Markdown>=2.3.1,<2.5
 PyYAML>=3.10
 watchdog>=0.7.0
 ghp-import>=0.4.1
+livereload>=2.0.0


### PR DESCRIPTION
This is the first pass at this feature request -
when running mkdocs using `mkdocs serve`, changes to the documentation
will cause a reload of the webpage, essentially live feedback.
We make use of python-livereload, a convenient wrapper around
LiveReload.
For this to work you need to install the browser extensions for your
browser.

The current implementation relies on watchdog to watch for changes in
the files in the `docs_dir`, which will then build to `site_dir`.
This will trigger the webpage reload because we have python-reload
watching `site_dir`.
A downside to this is that the static server gets a bit noisy when
serving, because when mkdocs builds the documentation, triggering the
python-livereload's handlers too many times, causing a lot of 'Ignore'
messages to be generated.
