### PR TITLE
Add Dockerfile for docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,17 @@
+
+FROM ubuntu:12.04
+MAINTAINER tomchristie <https://twitter.com/_tomchristie>
+
+RUN apt-get update
+
+RUN apt-get install -y python-pip
+
+RUN pip install mkdocs
+
+ADD . /docs
+
+WORKDIR /docs
+
+EXPOSE 8000
+
+CMD ["mkdocs", "serve"]


### PR DESCRIPTION
This Dockerfile works for all mkdocs projects. It would be great to add in docs so that everyone can reuse that.

Usage:
- `docker build -t docs .` 
- `docker run -d -p 8000:8000 docs`
