### PR TITLE
add link to release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Background: https://groups.google.com/forum/#!topic/django-rest-framework/YJ6J3j
 
 **See in progress docs: [www.mkdocs.org](http://www.mkdocs.org)**
 
+Release notes: http://www.mkdocs.org/about/release-notes/
+
 Project roadmap: [https://github.com/tomchristie/mkdocs/wiki](https://github.com/tomchristie/mkdocs/wiki)
 
 IRC channel: `#mkdocs` on freenode.


### PR DESCRIPTION
I counted on github url autolink
