### PR TITLE
Added bottom padding to all bootstrap themes

### DIFF
--- a/mkdocs/themes/amelia/css/base.css
+++ b/mkdocs/themes/amelia/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/bootstrap/css/base.css
+++ b/mkdocs/themes/bootstrap/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/cerulean/css/base.css
+++ b/mkdocs/themes/cerulean/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/cosmo/css/base.css
+++ b/mkdocs/themes/cosmo/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/cyborg/css/base.css
+++ b/mkdocs/themes/cyborg/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/flatly/css/base.css
+++ b/mkdocs/themes/flatly/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/journal/css/base.css
+++ b/mkdocs/themes/journal/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -17,6 +17,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/readable/css/base.css
+++ b/mkdocs/themes/readable/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/simplex/css/base.css
+++ b/mkdocs/themes/simplex/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/slate/css/base.css
+++ b/mkdocs/themes/slate/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/spacelab/css/base.css
+++ b/mkdocs/themes/spacelab/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/united/css/base.css
+++ b/mkdocs/themes/united/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }

--- a/mkdocs/themes/yeti/css/base.css
+++ b/mkdocs/themes/yeti/css/base.css
@@ -10,6 +10,10 @@ div.col-md-3 {
     padding-left: 0;
 }
 
+div.col-md-9 {
+    padding-bottom: 100px;
+}
+
 div.source-links {
     float: right;
 }


### PR DESCRIPTION
As discussed in issue #251 I added padding to the main document area to all bootstrap themes.

I have updated the Base.css to have 100px padding, like this:

```
div.col-md-9 {
    padding-bottom: 100px;
}
```

Normally, I would choose to do it differently - like to assign a specific class to the sidebar and main area, but I followed the convention in the CSS, since I saw there was already this:

```
div.col-md-3 {
    padding-left: 0;
}
```

Screenshots of the Yeti theme, before (top) and after:
![beforeafter](https://cloud.githubusercontent.com/assets/2405099/5235874/c99359de-7820-11e4-93c4-490dcd4f550a.png)
