### PR TITLE
Fix rendering of tables in the Read The Docs theme

### DIFF
--- a/mkdocs/themes/readthedocs/js/theme.js
+++ b/mkdocs/themes/readthedocs/js/theme.js
@@ -16,6 +16,8 @@ $( document ).ready(function() {
     $("table.docutils:not(.field-list)").wrap("<div class='wy-table-responsive'></div>");
 
     hljs.initHighlightingOnLoad();
+
+    $('table').addClass('docutils');
 });
 
 window.SphinxRtdTheme = (function (jquery) {


### PR DESCRIPTION
For the Read The Docs theme to render tables correctly it expects them
to have the docutils class (which is present in Sphinx projects).

Fixes #106
