### PR TITLE
There is a hidden garbage char breaking mkdocs new

### DIFF
--- a/mkdocs/new.py
+++ b/mkdocs/new.py
@@ -16,7 +16,7 @@ For full documentation visit [mkdocs.org](http://mkdocs.org).
 
 ## Project layout
 
-    mkdocs.yml    # The configuration file.
+    mkdocs.yml    # The configuration file.
     docs/
         index.md  # The documentation homepage.
         ...       # Other markdown pages, images and other files.


### PR DESCRIPTION
Well its not garbage... but its not in ascii, and is causing new to die like

(py3)➜  repo  mkdocs new snail
Writing config file: snail/mkdocs.yml
Writing initial docs: snail/docs/index.md
Traceback (most recent call last):
  File "/Users/szabel/.virtualenvs/py3/bin/mkdocs", line 9, in <module>
    load_entry_point('mkdocs==0.11.1', 'console_scripts', 'mkdocs')()
  File "/Users/szabel/.virtualenvs/py3/lib/python3.4/site-packages/mkdocs-0.11.1-py3.4.egg/mkdocs/main.py", line 62, in run_mai
n
    main(cmd, args=sys.argv[2:], options=dict(opts))
  File "/Users/szabel/.virtualenvs/py3/lib/python3.4/site-packages/mkdocs-0.11.1-py3.4.egg/mkdocs/main.py", line 46, in main
    new(args, options)
  File "/Users/szabel/.virtualenvs/py3/lib/python3.4/site-packages/mkdocs-0.11.1-py3.4.egg/mkdocs/new.py", line 51, in new
    open(index_path, 'w').write(index_text)
UnicodeEncodeError: 'ascii' codec can't encode character '\xa0' in position 335: ordinal not in range(128)

Cheers,
Stephen
