### PR TITLE
Added padding to the bottom of index for the readthedocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -29,6 +29,16 @@
 }
 
 /*
+* readthedocs theme hides nav items when the window height is 
+* too small to contain them.
+*
+* https://github.com/tomchristie/mkdocs/issues/#348
+*/
+.wy-menu-vertical ul {
+  margin-bottom: 2em;
+}
+
+/*
  * Fix wrapping in the code highlighting
  *
  * https://github.com/tomchristie/mkdocs/issues/233


### PR DESCRIPTION
I was also running into the issue referenced in #348.  This implements the fix that @cha0s suggested—it does indeed fix the problem.