### PR TITLE
Change the order of the Navigation processing to improve child_titles

### DIFF
--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -209,13 +209,16 @@ def _generate_site_navigation(pages_config, url_context, use_directory_urls=True
             )
             raise exceptions.ConfigurationError(msg)
 
+        # If both the title and child_title are None, then we
+        # have just been given a path. If that path contains a /
+        # then lets automatically nest it.
+        if title is None and child_title is None and os.path.sep in path:
+            filename = path.split(os.path.sep)[-1]
+            child_title = filename_to_title(filename)
+
         if title is None:
             filename = path.split(os.path.sep)[0]
             title = filename_to_title(filename)
-
-        if child_title is None and os.path.sep in path:
-            filename = path.split(os.path.sep)[-1]
-            child_title = filename_to_title(filename)
 
         url = utils.get_url_path(path, use_directory_urls)
 

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -63,6 +63,39 @@ class SiteNavigationTests(unittest.TestCase):
         self.assertEqual(len(site_navigation.nav_items), 3)
         self.assertEqual(len(site_navigation.pages), 6)
 
+    def test_nested_ungrouped(self):
+        pages = [
+            ('index.md', 'Home'),
+            ('about/contact.md', 'Contact'),
+            ('about/sub/license.md', 'License Title')
+        ]
+        expected = dedent("""
+        Home - /
+        Contact - /about/contact/
+        License Title - /about/sub/license/
+        """)
+        site_navigation = nav.SiteNavigation(pages)
+        self.assertEqual(str(site_navigation).strip(), expected)
+        self.assertEqual(len(site_navigation.nav_items), 3)
+        self.assertEqual(len(site_navigation.pages), 3)
+
+    def test_nested_ungrouped_no_titles(self):
+        pages = [
+            ('index.md',),
+            ('about/contact.md'),
+            ('about/sub/license.md')
+        ]
+        expected = dedent("""
+        Home - /
+        About
+            Contact - /about/contact/
+            License - /about/sub/license/
+        """)
+        site_navigation = nav.SiteNavigation(pages)
+        self.assertEqual(str(site_navigation).strip(), expected)
+        self.assertEqual(len(site_navigation.nav_items), 2)
+        self.assertEqual(len(site_navigation.pages), 3)
+
     def test_walk_simple_toc(self):
         pages = [
             ('index.md', 'Home'),


### PR DESCRIPTION
The current code was incorrectly processing titles for pages when an
explicit title was provided but the path to the file was nested in a
directory.

Fixes #392