### PR TITLE
Remove italic and bold from some code highlighting in the RTD theme

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -69,3 +69,12 @@ p code {
     word-wrap: break-word;
 }
 
+/*
+ * The CSS classes from highlight.js seem to clash with the
+ * ReadTheDocs theme causing some code to be incorrectly made
+ * bold and italic.
+ */
+code.cs, code.c {
+    font-weight: inherit;
+    font-style: inherit;
+}

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -73,6 +73,8 @@ p code {
  * The CSS classes from highlight.js seem to clash with the
  * ReadTheDocs theme causing some code to be incorrectly made
  * bold and italic.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/411
  */
 code.cs, code.c {
     font-weight: inherit;


### PR DESCRIPTION
Inherit the font weight and style to avoid code being made bold by
highlight.js and RTD CSS clashing.

Fixes #411