### PR TITLE
Display images inline in MkDocs theme

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -27,7 +27,7 @@ div.source-links {
 
 div.col-md-9 img {
     max-width: 100%;
-    display: block;
+    display: inline;
     padding: 4px;
     line-height: 1.428571429;
     background-color: #fff;


### PR DESCRIPTION
Images now display more as you would expect but can be broken up to
create the previous result by putting a blank image between them.