### PR TITLE
Fix cross-platform encoding issues.

### DIFF
--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -6,13 +6,14 @@ from datetime import datetime
 from jinja2.exceptions import TemplateNotFound
 import mkdocs
 from mkdocs import nav, toc, utils
-from mkdocs.compat import urljoin, PY2
+from mkdocs.compat import urljoin
 from mkdocs.relative_path_ext import RelativePathExtension
 import jinja2
 import json
 import markdown
 import os
 import logging
+from io import open
 
 log = logging.getLogger('mkdocs')
 
@@ -161,13 +162,10 @@ def _build_page(page, config, site_navigation, env, dump_json):
     input_path = os.path.join(config['docs_dir'], page.input_path)
 
     try:
-        input_content = open(input_path, 'r').read()
+        input_content = open(input_path, 'r', encoding='utf-8').read()
     except IOError:
         log.error('file not found: %s', input_path)
         return
-
-    if PY2:
-        input_content = input_content.decode('utf-8')
 
     # Process the markdown text
     html_content, table_of_contents, meta = convert_markdown(

--- a/mkdocs/config.py
+++ b/mkdocs/config.py
@@ -7,6 +7,7 @@ from mkdocs.exceptions import ConfigurationError
 import logging
 import os
 import yaml
+from io import open
 
 log = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ def load_config(filename='mkdocs.yml', options=None):
         options['config'] = filename
     if not os.path.exists(filename):
         raise ConfigurationError("Config file '%s' does not exist." % filename)
-    with open(filename, 'r') as fp:
+    with open(filename, 'r', encoding='utf-8') as fp:
         user_config = yaml.load(fp)
         if not isinstance(user_config, dict):
             raise ConfigurationError("The mkdocs.yml file is invalid. See http://www.mkdocs.org/user-guide/configuration/ for more information.")

--- a/mkdocs/new.py
+++ b/mkdocs/new.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import print_function
 import os
+from io import open
 
 config_text = 'site_name: My Docs\n'
 index_text = """# Welcome to MkDocs
@@ -43,7 +44,7 @@ def new(args, options):
         os.mkdir(output_dir)
 
     print('Writing config file: %s' % config_path)
-    open(config_path, 'w').write(config_text)
+    open(config_path, 'w', encoding='utf-8').write(config_text)
 
     if os.path.exists(index_path):
         return
@@ -51,4 +52,4 @@ def new(args, options):
     print('Writing initial docs: %s' % index_path)
     if not os.path.exists(docs_dir):
         os.mkdir(docs_dir)
-    open(index_path, 'w').write(index_text)
+    open(index_path, 'w', encoding='utf-8').write(index_text)


### PR DESCRIPTION
By using io.open and explicitly defining the encoding on the call to
open every time, we should get consistant behavior across platforms
as open will not rely on each individual system's local settings
to determine what encoding to use. Note that io.open is an alias
to the built-in open function in Python 3. In Python 2.6+ it is a
Python 3 compatable implementation which works in Python 2. In the
future when all support for Python 2 is dropped, simply delete the
import statements with no additional changes to the code.

I expect this will fix both #239 and #352.