### PR TITLE
Only include the build date and version on the homepage.

### DIFF
--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -93,10 +93,11 @@
             </div>
         </div>
 
-        <!--
-        MkDocs version      : {{ mkdocs_version }}
-        Docs Build Date UTC : {{ build_date_utc }}
-        -->
-
     </body>
 </html>
+{% if current_page and current_page.is_homepage %}
+<!--
+MkDocs version : {{ mkdocs_version }}
+Build Date UTC : {{ build_date_utc }}
+-->
+{% endif %}

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -107,9 +107,11 @@
     </span>
 </div>
 
-<!--
-MkDocs version      : {{ mkdocs_version }}
-Docs Build Date UTC : {{ build_date_utc }}
--->
 </body>
 </html>
+{% if current_page and current_page.is_homepage %}
+<!--
+MkDocs version : {{ mkdocs_version }}
+Build Date UTC : {{ build_date_utc }}
+-->
+{% endif %}


### PR DESCRIPTION
We only really need it on one place.

Fixes #489