### PR TITLE
Don't load the config outside the serve command

### DIFF
--- a/mkdocs/cli.py
+++ b/mkdocs/cli.py
@@ -54,12 +54,12 @@ def cli(verbose):
 @click.option('--theme', type=click.Choice(theme_choices), help=theme_help)
 def serve_command(dev_addr, config_file, strict, theme):
     """Run the builtin development server"""
-    serve.serve(load_config(
+    serve.serve(
         config_file=config_file,
         dev_addr=dev_addr,
         strict=strict,
         theme=theme,
-    ))
+    )
 
 
 @cli.command(name="build")

--- a/mkdocs/serve.py
+++ b/mkdocs/serve.py
@@ -3,21 +3,29 @@ import tempfile
 from livereload import Server
 
 from mkdocs.build import build
+from mkdocs.config import load_config
 
 
-def serve(config):
+def serve(config_file=None, dev_addr=None, strict=None, theme=None):
     """
     Start the devserver, and rebuild the docs whenever any changes take effect.
     """
     # Create a temporary build directory, and set some options to serve it
     tempdir = tempfile.mkdtemp()
-    config['site_dir'] = tempdir
 
     def builder():
+        config = load_config(
+            config_file=config_file,
+            dev_addr=dev_addr,
+            strict=strict,
+            theme=theme,
+        )
+        config['site_dir'] = tempdir
         build(config, live_server=True)
+        return config
 
     # Perform the initial build
-    builder()
+    config = builder()
 
     server = Server()
 


### PR DESCRIPTION
This removes duplicate config loading in the serve command and fixes an
issue where the reload wasn't working with changes on the config file.