### PR TITLE
This is a really confusing test failure, I can't figure out what is going wrong.

### DIFF
--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -29,8 +29,6 @@ class Config(six.moves.UserDict):
         self.set_defaults()
         self.user_configs = []
 
-        self.config_file_path = None
-
     def set_defaults(self):
         """
         Set the base config by going through each validator and getting the
@@ -72,7 +70,7 @@ class Config(six.moves.UserDict):
 
         return failed, warnings
 
-    def update(self, patch):
+    def load_dict(self, patch):
 
         if not isinstance(patch, dict):
             raise exceptions.ConfigurationError(
@@ -84,8 +82,7 @@ class Config(six.moves.UserDict):
         self.data.update(patch)
 
     def load_file(self, config_file):
-        self.config_file_path = config_file.name
-        return self.update(utils.yaml_load(config_file))
+        return self.load_dict(utils.yaml_load(config_file))
 
 
 def _open_config_file(config_file):
@@ -127,14 +124,14 @@ def load_config(config_file=None, **kwargs):
             options.pop(key)
 
     config_file = _open_config_file(config_file)
-    options['config_file_path'] = config_file.name
+    options['config_file_path'] = getattr(config_file, 'name', '')
 
     # Initialise the config with the default schema .
     config = Config(schema=defaults.DEFAULT_SCHEMA)
     # First load the config file
     config.load_file(config_file)
     # Then load the options to overwrite anything in the config.
-    config.update(options)
+    config.load_dict(options)
 
     errors, warnings = config.validate()
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -215,10 +215,18 @@ class Theme(BaseConfigOption):
     """
 
     def run_validation(self, value):
-
         themes = utils.get_theme_names()
 
         if value in themes:
+            if value in ['mkdocs', 'readthedocs']:
+                return value
+
+            self.warnings.append((
+                'theme',
+                ("The theme '{0}' will be removed in an upcoming MkDocs "
+                 "release. See http://www.mkdocs.org/about/release-notes/ "
+                 "for more details").format(value)
+            ))
             return value
 
         raise ValidationError("Unrecognised theme.")

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -282,7 +282,7 @@ class BuildTests(unittest.TestCase):
             open(os.path.join(docs_dir, '.git/hidden'), 'w').close()
 
             conf = config_base.Config(schema=config_defaults.DEFAULT_SCHEMA)
-            conf.update({
+            conf.load_dict({
                 'site_name': 'Example',
                 'docs_dir': docs_dir,
                 'site_dir': site_dir
@@ -349,7 +349,7 @@ class BuildTests(unittest.TestCase):
 
         # Same as the default schema, but don't verify the docs_dir exists.
         config = config_base.Config(schema=config_defaults.DEFAULT_SCHEMA)
-        config.update({
+        config.load_dict({
             'site_name': "Site",
             'extra': {
                 'a': 1

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -45,14 +45,9 @@ class ConfigBaseTests(unittest.TestCase):
             config_file.write(
                 "site_dir: output\nsite_uri: http://www.mkdocs.org\n")
             config_file.flush()
-
-            with open(config_file.name, 'rb') as config:
-                self.assertRaises(exceptions.ConfigurationError,
-                                  base.load_config, config_file=config)
             config_file.close()
+
+            self.assertRaises(exceptions.ConfigurationError,
+                              base.load_config, config_file=config_file.name)
         finally:
-            try:
-                os.remove(config_file.name)
-            except Exception:
-                # This fails on Windows for some reason
-                pass
+            os.remove(config_file.name)

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -11,7 +11,7 @@ class ConfigBaseTests(unittest.TestCase):
     def test_unrecognised_keys(self):
 
         c = base.Config(schema=defaults.DEFAULT_SCHEMA)
-        c.update({
+        c.load_dict({
             'not_a_valid_config_option': "test"
         })
 

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -6,8 +6,7 @@ import shutil
 import tempfile
 import unittest
 
-from six import PY2
-from six.moves import zip
+import six
 
 from mkdocs import config
 from mkdocs.config import base, defaults, config_options
@@ -16,7 +15,7 @@ from mkdocs.tests.base import dedent
 
 
 def ensure_utf(string):
-    return string.encode('utf-8') if PY2 else string
+    return string.encode('utf-8') if six.PY2 else string
 
 
 class ConfigTests(unittest.TestCase):
@@ -28,7 +27,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_missing_site_name(self):
         c = base.Config(schema=defaults.DEFAULT_SCHEMA)
-        c.update({})
+        c.load_dict({})
         errors, warings = c.validate()
         self.assertEqual([
             ('site_name', 'Required configuration not provided.')
@@ -106,18 +105,11 @@ class ConfigTests(unittest.TestCase):
         mytheme = tempfile.mkdtemp()
         custom = tempfile.mkdtemp()
 
-        base_config = dedent("""
-        site_name: Example
-        pages:
-        - ['index.md', 'Introduction']
-        %s
-        """)
-
         configs = [
-            "site_name: Example",  # default theme
-            "theme: readthedocs",  # builtin theme
-            "theme_dir: {0}".format(mytheme),  # custom only
-            "theme: cosmo\ntheme_dir: {0}".format(custom)  # builtin and custom
+            dict(),  # default theme
+            {"theme": "readthedocs"},  # builtin theme
+            {"theme_dir": mytheme},  # custom only
+            {"theme": "cosmo", "theme_dir": custom},  # builtin and custom
         ]
 
         abs_path = os.path.abspath(os.path.dirname(__file__))
@@ -133,20 +125,15 @@ class ConfigTests(unittest.TestCase):
             [custom, os.path.join(theme_dir, 'cosmo'), search_asset_dir],
         )
 
-        for config_contents, expected_result in zip(configs, results):
-            try:
-                config_file = tempfile.NamedTemporaryFile('w', delete=False)
-                config_file.write(ensure_utf(base_config % config_contents))
-                config_file.flush()
-                result = config.load_config(config_file=config_file.name)
-                self.assertEqual(expected_result, result['theme_dir'])
-            finally:
-                try:
-                    config_file.close()
-                    os.remove(config_file.name)
-                except:
-                    # This failed on Windows for some reason?
-                    pass
+        for config_contents, result in six.moves.zip(configs, results):
+
+            c = base.Config(schema=(
+                ('theme', config_options.Theme(default='mkdocs')),
+                ('theme_dir', config_options.ThemeDir(exists=True)),
+            ))
+            c.load_dict(config_contents)
+            c.validate()
+            self.assertEqual(c['theme_dir'], result)
 
     def test_default_pages(self):
         tmp_dir = tempfile.mkdtemp()
@@ -154,7 +141,7 @@ class ConfigTests(unittest.TestCase):
             open(os.path.join(tmp_dir, 'index.md'), 'w').close()
             open(os.path.join(tmp_dir, 'about.md'), 'w').close()
             conf = base.Config(schema=defaults.DEFAULT_SCHEMA)
-            conf.update({
+            conf.load_dict({
                 'site_name': 'Example',
                 'docs_dir': tmp_dir
             })
@@ -173,7 +160,7 @@ class ConfigTests(unittest.TestCase):
             os.makedirs(os.path.join(tmp_dir, 'sub', 'sub2'))
             open(os.path.join(tmp_dir, 'sub', 'sub2', 'sub2.md'), 'w').close()
             conf = base.Config(schema=defaults.DEFAULT_SCHEMA)
-            conf.update({
+            conf.load_dict({
                 'site_name': 'Example',
                 'docs_dir': tmp_dir
             })
@@ -221,6 +208,6 @@ class ConfigTests(unittest.TestCase):
                 ('docs_dir', config_options.Dir(default='docs')),
                 ('site_dir', config_options.SiteDir(default='site')),
             ))
-            c.update(patch)
+            c.load_dict(patch)
 
             self.assertRaises(config_options.ValidationError, c.validate)

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -54,19 +54,14 @@ class ConfigTests(unittest.TestCase):
         try:
             config_file.write(ensure_utf(file_contents))
             config_file.flush()
+            config_file.close()
 
             self.assertRaises(
                 ConfigurationError,
                 config.load_config, config_file=open(config_file.name, 'rb')
             )
-
-            config_file.close()
         finally:
-            try:
-                os.remove(config_file.name)
-            except Exception:
-                # This fails on Windows for some reason
-                pass
+            os.remove(config_file.name)
 
     def test_config_option(self):
         """
@@ -88,17 +83,13 @@ class ConfigTests(unittest.TestCase):
         try:
             config_file.write(ensure_utf(file_contents))
             config_file.flush()
-            result = config.load_config(
-                config_file=open(config_file.name, 'rb'))
+            config_file.close()
+
+            result = config.load_config(config_file=config_file.name)
             self.assertEqual(result['site_name'], expected_result['site_name'])
             self.assertEqual(result['pages'], expected_result['pages'])
-            config_file.close()
         finally:
-            try:
-                os.remove(config_file.name)
-            except Exception:
-                # This fails on Windows for some reason
-                pass
+            os.remove(config_file.name)
 
     def test_theme(self):
 


### PR DESCRIPTION
I was making this change, to start warning users about #201. We don't have a concrete plan yet but the earlier we start warning them, the earlier we can start making the move.

I didn't get very far with it, because It causes this error, which almost makes sense except that it doesn't at all...

```
======================================================================
FAIL: test_extra_context (mkdocs.tests.build_tests.BuildTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dougalmatthews/Code/python/mkdocs/mkdocs/tests/build_tests.py", line 359, in test_extra_context
    self.assertEqual(config.validate(), ([], []))
AssertionError: Tuples differ: ([], [('theme', "The theme 'cosmo' will be remo[97 chars]s")]) != ([], [])

First differing element 1:
[('theme', "The theme 'cosmo' will be removed in an upcoming MkDocs release. See http://www.mkdocs.org/about/release-notes/ for more details")]
[]

+ ([], [])
- ([],
-  [('theme',
-    "The theme 'cosmo' will be removed in an upcoming MkDocs release. See "
-    'http://www.mkdocs.org/about/release-notes/ for more details')])
```

There are two big issues here.

- This test doesn't provide a theme, so it should use the default, `mkdocs`. The error is about cosmo.
- cosmo is only used in [this test](https://github.com/mkdocs/mkdocs/blob/cb3a24cff44f22bfd9295bb3decedb855c6ba3a5/mkdocs/tests/config/config_tests.py#L120), which should be totally unrelated. Updating that test causes the one above to fail with the new theme.

So, there must be some leaky global state. I can't figure out where it is coming from. Ideas?