### PR TITLE
Expose the full config to templates rather than `extra` directly.

### DIFF
--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -252,11 +252,11 @@ extra:
 And then displayed with this HTML in the custom theme.
 
 ```html
-{{ extra.version }}
+{{ config.extra.version }}
 
-{% if extra.links %}
+{% if config.extra.links %}
   <ul>
-  {% for link in extra.links %}
+  {% for link in config.extra.links %}
       <li>{{ link }}</li>
   {% endfor %}
   </ul>

--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -92,7 +92,7 @@ def get_global_context(nav, config):
         'mkdocs_version': mkdocs.__version__,
         'build_date_utc': datetime.utcnow(),
 
-        'extra': config['extra']
+        'config': config
     }
 
 

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -360,6 +360,6 @@ class BuildTests(unittest.TestCase):
 
         context = build.get_global_context(mock.Mock(), config)
 
-        self.assertEqual(context['extra'], {
+        self.assertEqual(context['config']['extra'], {
             'a': 1
         })

--- a/mkdocs/tests/integration.py
+++ b/mkdocs/tests/integration.py
@@ -32,7 +32,7 @@ def silence_logging(is_verbose=False):
     '''When a --verbose flag is passed, increase the verbosity of mkdocs'''
 
     logger = logging.getLogger('mkdocs')
-    logger.setLevel(logging.WARNING)
+    logger.setLevel(logging.ERROR)
 
 
 def run_build(theme_name, output, config_file, quiet):


### PR DESCRIPTION
This update changes cf10026 so that templates must now access extra with {{ config.something }} rather than just {{ extra.something }}.