### PR TITLE
feat(theme/mkdocs): add autofocus for search input when modal opens

### DIFF
--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -14,10 +14,17 @@ function getSearchTerm()
 
 $(document).ready(function() {
 
-    var search_term = getSearchTerm();
+    var search_term = getSearchTerm(),
+        $search_modal = $('#mkdocs_search_modal');
+
     if(search_term){
-        $('#mkdocs_search_modal').modal();
+        $search_modal.modal();
     }
+
+    // make sure search input gets autofocus everytime modal opens.
+    $search_modal.on('shown.bs.modal', function () {
+        $search_modal.find('#mkdocs-search-query').focus();
+    });
 
     // Highlight.js
     hljs.initHighlightingOnLoad();

--- a/mkdocs/themes/readthedocs/search.html
+++ b/mkdocs/themes/readthedocs/search.html
@@ -11,7 +11,7 @@
 
   <form id="content_search" action="search.html">
     <span role="status" aria-live="polite" class="ui-helper-hidden-accessible"></span>
-    <input name="q" id="mkdocs-search-query" type="text" class="search_input search-query ui-autocomplete-input" placeholder="Search the Docs" autocomplete="off">
+    <input name="q" id="mkdocs-search-query" type="text" class="search_input search-query ui-autocomplete-input" placeholder="Search the Docs" autocomplete="off" autofocus>
   </form>
 
   <div id="mkdocs-search-results">


### PR DESCRIPTION
After clicking the `Search` link, the search input in modal should be 
autoselected for easier input.

> Due to how HTML5 defines its semantics, the autofocus HTML attribute has no effect in Bootstrap modals. To achieve the same effect, use some custom JavaScript:

```
$('#myModal').on('shown.bs.modal', function () {
  $('#myInput').focus()
})
```

__Ref:__
http://getbootstrap.com/javascript/#modals