### PR TITLE
Refactor Markdown Extension Options Config.

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -8,7 +8,7 @@ Guide to all available configuration settings.
 
 Project settings are always configured by using a YAML configuration file in the project directory named `mkdocs.yml`.
 
-As a miniumum this configuration file must contain the `site_name` setting.  All other settings are optional.
+As a minimum this configuration file must contain the `site_name` setting.  All other settings are optional.
 
 ## Project information
 
@@ -16,7 +16,7 @@ As a miniumum this configuration file must contain the `site_name` setting.  All
 
 This is a **required setting**, and should be a string that is used as the main title for the project documentation.  For example:
 
-    site_name: Mashmallow Generator
+    site_name: Marshmallow Generator
 
 When rendering the theme this setting will be passed as the `site_name` context variable.
 
@@ -109,9 +109,9 @@ If you have a lot of project documentation you might choose to use headings to b
     pages:
     - Introduction: 'index.md'
     - User Guide:
-        - 'Creating a new Mashmallow project': 'user-guide/creating.md'
-        - 'Mashmallow API guide': 'user-guide/api.md'
-        - 'Configuring Mashmallow': 'user-guide/configuration.md'
+        - 'Creating a new Marshmallow project': 'user-guide/creating.md'
+        - 'Marshmallow API guide': 'user-guide/api.md'
+        - 'Configuring Marshmallow': 'user-guide/configuration.md'
     - About:
         - License: 'about/license.md'
 
@@ -150,16 +150,21 @@ Lets you set the directory where the output HTML and other files are created.  T
 
 **default**: `'site'`
 
-**Note**: If you are using source code control you will normally want to ensure that your *build output* files are not commited into the repository, and only keep the *source* files under version control.  For example, if using `git` you might add the following line to your `.gitignore` file:
+!!! note "Note:"
+    If you are using source code control you will normally want to ensure
+    that your *build output* files are not committed into the repository, and only
+    keep the *source* files under version control. For example, if using `git` you
+    might add the following line to your `.gitignore` file:
 
-    site/
+        site/
 
-If you're using another source code control you'll want to check its documentation on how to ignore specific directories.
+    If you're using another source code control you'll want to check its
+    documentation on how to ignore specific directories.
 
 
 ### extra_css
 
-Set a list of css files to be included by the theme.
+Set a list of CSS files to be included by the theme.
 
 **default**: By default `extra_css` will contain a list of all the CSS files found within the `docs_dir`, if none are found it will be `[]` (an empty list).
 
@@ -207,7 +212,7 @@ Determines if a broken link to a page within the documentation is considered a w
 
 Determines the address used when running `mkdocs serve`.  Setting this allows you to use another port, or allows you to make the service accessible over your local network by using the `0.0.0.0` address.
 
-As with all settings, you can set this from the command line, which can be usful, for example:
+As with all settings, you can set this from the command line, which can be useful, for example:
 
     mkdocs serve --dev-addr=0.0.0.0:80  # Run on port 80, accessible over the local network.
 
@@ -217,30 +222,62 @@ As with all settings, you can set this from the command line, which can be usful
 
 ### markdown_extensions
 
-MkDocs uses the [Python Markdown][pymkd] library to translate Markdown files into HTML. Python Markdown supports a variety of [extensions][pymdk-extensions] that customize how pages are formatted. This setting lets you enable a list of extensions beyond the ones that MkDocs uses by default (`meta`, `toc`, `tables`, and `fenced_code`).
+MkDocs uses the [Python Markdown][pymkd] library to translate Markdown files
+into HTML. Python Markdown supports a variety of [extensions][pymdk-extensions]
+that customize how pages are formatted. This setting lets you enable a list of
+extensions beyond the ones that MkDocs uses by default (`meta`, `toc`, `tables`,
+and `fenced_code`).
 
 For example, to enable the [SmartyPants typography extension][smarty], use:
 
-    markdown_extensions: [smartypants]
+    markdown_extensions:
+        - smarty
 
-Some extensions provide configuration options of their own. If you would like to set any configuration options, then you can define `markdown_extensions` as a key/value mapping rather than a list. The key must be the name of the extension and the value must be a key/value pair (option name/option value) for the configuration option.
+Some extensions provide configuration options of their own. If you would like to
+set any configuration options, then you can nest a key/value mapping
+(`option_name: option value`) of any options that a given extension supports.
+See the documentation for the extension you are using to determine what options
+they support.
 
 For example, to enable permalinks in the (included) `toc` extension, use:
 
     markdown_extensions:
-        toc:
+        - toc:
             permalink: True
 
-Add additonal items for each extension. If you have no configuration options to set for a specific extension, then you may leave that extensions options blank:
+Note that a colon (`:`) must follow the extension name (`toc`) and then on a new line
+the option name and value must be indented and seperated by a colon. If you would like
+to define multipe options for a single extension, each option must be defined on
+a seperate line:
 
     markdown_extensions:
-        smartypants:
-        toc:
+        - toc:
             permalink: True
+            separator: "_"
 
+Add an additional item to the list for each extension. If you have no
+configuration options to set for a specific extension, then simply omit options
+for that extension:
+
+    markdown_extensions:
+        - smarty
+        - toc:
+            permalink: True
+        - sane_lists
+
+!!! note "See Also:"
+    The Python-Markdown documentation provides a [list of extensions][exts]
+    which are available out-of-the-box. For a list of configuration options
+    available for a given extension, see the documentation for that extension.
+    
+    You may also install and use various [third party extensions][3rd]. Consult the
+    documentation provided by those extensions for installation instructions and
+    available configuration options.
 
 **default**: `[]`
 
 [pymdk-extensions]: http://pythonhosted.org/Markdown/extensions/index.html
 [pymkd]: http://pythonhosted.org/Markdown/
-[smarty]: https://pypi.python.org/pypi/mdx_smartypants
+[smarty]: https://pythonhosted.org/Markdown/extensions/smarty.html
+[exts]:https://pythonhosted.org/Markdown/extensions/index.html
+[3rd]: https://github.com/waylan/Python-Markdown/wiki/Third-Party-Extensions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,9 +5,9 @@ site_description: Project documentation with Markdown.
 repo_url: https://github.com/mkdocs/mkdocs/
 
 markdown_extensions:
-    toc:
+    - toc:
         permalink: ""
-    admonition:
+    - admonition:
 
 copyright: Copyright &copy; 2014, <a href="https://twitter.com/_tomchristie">Tom Christie</a>.
 google_analytics: ['UA-27795084-5', 'mkdocs.org']

--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -17,30 +17,17 @@ import mkdocs
 log = logging.getLogger(__name__)
 
 
-def convert_markdown(markdown_source, site_navigation=None, extensions=(), strict=False):
+def convert_markdown(markdown_source, config, site_navigation=None):
     """
-    Convert the Markdown source file to HTML content, and additionally
-    return the parsed table of contents, and a dictionary of any metadata
-    that was specified in the Markdown file.
-
-    `extensions` is an optional sequence of Python Markdown extensions to add
-    to the default set.
+    Convert the Markdown source file to HTML as per the config and site_navigation.
+    Return a tuple of the HTML as a string, the parsed table of contents,
+    and a dictionary of any metadata that was specified in the Markdown file.
     """
-
-    # Generate the HTML from the markdown source
-    if isinstance(extensions, dict):
-        user_extensions = list(extensions.keys())
-        extension_configs = dict([(k, v) for k, v in extensions.items() if isinstance(v, dict)])
-    else:
-        user_extensions = list(extensions)
-        extension_configs = {}
-    builtin_extensions = ['meta', 'toc', 'tables', 'fenced_code']
-    mkdocs_extensions = [RelativePathExtension(site_navigation, strict), ]
-    extensions = utils.reduce_list(builtin_extensions + mkdocs_extensions + user_extensions)
-
-    html_content, table_of_contents, meta = utils.convert_markdown(markdown_source, extensions, extension_configs)
-
-    return (html_content, table_of_contents, meta)
+    return utils.convert_markdown(
+        markdown_source=markdown_source,
+        extensions=[RelativePathExtension(site_navigation, config['strict'])] + config['markdown_extensions'],
+        extension_configs=config['mdx_configs']
+    )
 
 
 def get_global_context(nav, config):
@@ -182,8 +169,9 @@ def _build_page(page, config, site_navigation, env, dump_json):
 
     # Process the markdown text
     html_content, table_of_contents, meta = convert_markdown(
-        input_content, site_navigation,
-        extensions=config['markdown_extensions'], strict=config['strict']
+        markdown_source=input_content,
+        config=config,
+        site_navigation=site_navigation
     )
 
     context = get_global_context(site_navigation, config)

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -1,9 +1,9 @@
 import six
 import logging
 import os
+import yaml
 
 from mkdocs import exceptions
-from mkdocs import utils
 from mkdocs.config import config_options, defaults
 
 log = logging.getLogger('mkdocs.config')
@@ -82,7 +82,7 @@ class Config(six.moves.UserDict):
         self.data.update(patch)
 
     def load_file(self, config_file):
-        return self.load_dict(utils.yaml_load(config_file))
+        return self.load_dict(yaml.load(config_file))
 
 
 def _open_config_file(config_file):

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -90,8 +90,12 @@ DEFAULT_SCHEMA = (
     ('include_next_prev', config_options.NumPages()),
 
     # PyMarkdown extension names.
-    ('markdown_extensions', config_options.Type(
-        (list, dict, tuple), default=())),
+    ('markdown_extensions', config_options.MarkdownExtensions(
+        builtins=['meta', 'toc', 'tables', 'fenced_code'],
+        configkey='mdx_configs', default=[])),
+
+    # PyMarkdown Extension Configs. For internal use only.
+    ('mdx_configs', config_options.Private()),
 
     # enabling strict mode causes MkDocs to stop the build when a problem is
     # encountered rather than display an error.

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -325,3 +325,170 @@ class NumPagesTest(unittest.TestCase):
             'key': True,
             'pages': None
         }, config)
+
+
+class PrivateTest(unittest.TestCase):
+
+    def test_defined(self):
+
+        option = config_options.Private()
+        self.assertRaises(config_options.ValidationError,
+                          option.validate, 'somevalue')
+
+
+class MarkdownExtensionsTest(unittest.TestCase):
+
+    def test_simple_list(self):
+        option = config_options.MarkdownExtensions()
+        config = {
+            'markdown_extensions': ['foo', 'bar']
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': ['foo', 'bar'],
+            'mdx_configs': {}
+        }, config)
+
+    def test_list_dicts(self):
+        option = config_options.MarkdownExtensions()
+        config = {
+            'markdown_extensions': [
+                {'foo': {'foo_option': 'foo value'}},
+                {'bar': {'bar_option': 'bar value'}},
+                {'baz': None}
+            ]
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': ['foo', 'bar', 'baz'],
+            'mdx_configs': {
+                'foo': {'foo_option': 'foo value'},
+                'bar': {'bar_option': 'bar value'}
+            }
+        }, config)
+
+    def test_mixed_list(self):
+        option = config_options.MarkdownExtensions()
+        config = {
+            'markdown_extensions': [
+                'foo',
+                {'bar': {'bar_option': 'bar value'}}
+            ]
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': ['foo', 'bar'],
+            'mdx_configs': {
+                'bar': {'bar_option': 'bar value'}
+            }
+        }, config)
+
+    def test_builtins(self):
+        option = config_options.MarkdownExtensions(builtins=['meta', 'toc'])
+        config = {
+            'markdown_extensions': ['foo', 'bar']
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': ['meta', 'toc', 'foo', 'bar'],
+            'mdx_configs': {}
+        }, config)
+
+    def test_duplicates(self):
+        option = config_options.MarkdownExtensions(builtins=['meta', 'toc'])
+        config = {
+            'markdown_extensions': ['meta', 'toc']
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': ['meta', 'toc'],
+            'mdx_configs': {}
+        }, config)
+
+    def test_builtins_config(self):
+        option = config_options.MarkdownExtensions(builtins=['meta', 'toc'])
+        config = {
+            'markdown_extensions': [
+                {'toc': {'permalink': True}}
+            ]
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': ['meta', 'toc'],
+            'mdx_configs': {'toc': {'permalink': True}}
+        }, config)
+
+    def test_configkey(self):
+        option = config_options.MarkdownExtensions(configkey='bar')
+        config = {
+            'markdown_extensions': [
+                {'foo': {'foo_option': 'foo value'}}
+            ]
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': ['foo'],
+            'bar': {
+                'foo': {'foo_option': 'foo value'}
+            }
+        }, config)
+
+    def test_none(self):
+        option = config_options.MarkdownExtensions(default=[])
+        config = {
+            'markdown_extensions': None
+        }
+        config['markdown_extensions'] = option.validate(config['markdown_extensions'])
+        option.post_validation(config, 'markdown_extensions')
+        self.assertEqual({
+            'markdown_extensions': [],
+            'mdx_configs': {}
+        }, config)
+
+    def test_not_list(self):
+        option = config_options.MarkdownExtensions()
+        self.assertRaises(config_options.ValidationError,
+                          option.validate, 'not a list')
+
+    def test_invalid_config_option(self):
+        option = config_options.MarkdownExtensions()
+        config = {
+            'markdown_extensions': [
+                {'foo': 'not a dict'}
+            ]
+        }
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, config['markdown_extensions']
+        )
+
+    def test_invalid_config_item(self):
+        option = config_options.MarkdownExtensions()
+        config = {
+            'markdown_extensions': [
+                ['not a dict']
+            ]
+        }
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, config['markdown_extensions']
+        )
+
+    def test_invalid_dict_item(self):
+        option = config_options.MarkdownExtensions()
+        config = {
+            'markdown_extensions': [
+                {'key1': 'value', 'key2': 'too many keys'}
+            ]
+        }
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, config['markdown_extensions']
+        )

--- a/mkdocs/tests/utils_tests.py
+++ b/mkdocs/tests/utils_tests.py
@@ -5,7 +5,6 @@ import os
 import unittest
 
 from mkdocs import nav, utils
-from mkdocs.tests.base import dedent
 
 
 class UtilsTests(unittest.TestCase):
@@ -69,32 +68,6 @@ class UtilsTests(unittest.TestCase):
         for path, expected_result in expected_results.items():
             urls = utils.create_media_urls(site_navigation, [path])
             self.assertEqual(urls[0], expected_result)
-
-    def test_yaml_load(self):
-        try:
-            from collections import OrderedDict
-        except ImportError:
-            # Don't test if can't import OrderdDict
-            # Exception can be removed when Py26 support is removed
-            return
-
-        yaml_text = dedent('''
-            test:
-                key1: 1
-                key2: 2
-                key3: 3
-                key4: 4
-                key5: 5
-                key5: 6
-                key3: 7
-        ''')
-
-        self.assertEqual(
-            utils.yaml_load(yaml_text),
-            OrderedDict([('test', OrderedDict([('key1', 1), ('key2', 2),
-                                               ('key3', 7), ('key4', 4),
-                                               ('key5', 6)]))])
-        )
 
     def test_reduce_list(self):
         self.assertEqual(

--- a/mkdocs/utils.py
+++ b/mkdocs/utils.py
@@ -12,30 +12,8 @@ import shutil
 
 import markdown
 import six
-import yaml
 
 from mkdocs import toc
-from mkdocs.legacy import OrderedDict
-
-
-def yaml_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
-    """
-    Make all YAML dictionaries load as ordered Dicts.
-    http://stackoverflow.com/a/21912744/3609487
-    """
-    class OrderedLoader(Loader):
-        pass
-
-    def construct_mapping(loader, node):
-        loader.flatten_mapping(node)
-        return object_pairs_hook(loader.construct_pairs(node))
-
-    OrderedLoader.add_constructor(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-        construct_mapping
-    )
-
-    return yaml.load(stream, OrderedLoader)
 
 
 def reduce_list(data_set):

--- a/mkdocs/utils.py
+++ b/mkdocs/utils.py
@@ -279,12 +279,9 @@ def convert_markdown(markdown_source, extensions=None, extension_configs=None):
     `extensions` is an optional sequence of Python Markdown extensions to add
     to the default set.
     """
-    extensions = extensions or []
-    extension_configs = extension_configs or {}
-
     md = markdown.Markdown(
-        extensions=extensions,
-        extension_configs=extension_configs
+        extensions=extensions or [],
+        extension_configs=extension_configs or {}
     )
     html_content = md.convert(markdown_source)
 


### PR DESCRIPTION
Config validation now handles all extension processing:

* Builtin extensions are defined and within the default scheme.
* User extensions are defined only as a list in the config. Note, this is
  a backward incompatable change from the previous (short-lived) release.
* The users extensions are added to the list of builtins.
* Any duplicates are accounted for in validation.
* Extension options are supported by a child key/value pair on the ext name.
* All extension options are compiled into a format Markdown accepts
  within the validation process and are saved to the internal `mdx_configs`
  config setting.
* The `mdx_configs` setting is private and raises an error if set by the user.
* A whole suite of tests were added to test all aspects of ext validation.

All relevant build tests were updated to pass the config to
`build.convert_markdown` as the config now handles all extension data.

The relevant documentation was updated to reflect the changes. While I was
at it, I spellchecked the entire document and made a few additional formatting
changes.

This fixes #519 plus a lot more.