### PR TITLE
Finish removing OrderedDict code

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -3,7 +3,6 @@ import os
 import six
 
 from mkdocs import utils, legacy
-from mkdocs.legacy import OrderedDict
 
 
 class ValidationError(Exception):
@@ -297,7 +296,7 @@ class Pages(Extras):
         # TODO: Remove in 1.0
         config_types = set(type(l) for l in value)
 
-        if config_types.issubset(set([str, OrderedDict, ])):
+        if config_types.issubset(set([str, dict, ])):
             return value
 
         if config_types.issubset(set([str, list, ])):

--- a/mkdocs/legacy.py
+++ b/mkdocs/legacy.py
@@ -6,11 +6,6 @@ from mkdocs.exceptions import ConfigurationError
 
 log = logging.getLogger(__name__)
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    OrderedDict = dict
-
 
 def pages_compat_shim(original_pages):
     """

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from mkdocs import utils, legacy
+from mkdocs import utils
 from mkdocs.config import config_options
 
 
@@ -243,9 +243,7 @@ class PagesTest(unittest.TestCase):
         option = config_options.Pages()
         value = option.validate([
             'index.md',
-            legacy.OrderedDict((
-                ('Page', 'page.md', ),
-            ))
+            {"Page": "page.md"}
         ])
         self.assertEqual(['index.md', {'Page': 'page.md'}], value)
 


### PR DESCRIPTION
OrderedDict support was recently removed in #528, but there were still
some references to OrderedDict that are causing failures.  This
finishes the removal of OrderedDicts.