### PR TITLE
Special case media being in the same directory as the markdown files

### DIFF
--- a/mkdocs/tests/utils_tests.py
+++ b/mkdocs/tests/utils_tests.py
@@ -55,7 +55,12 @@ class UtilsTests(unittest.TestCase):
     def test_create_media_urls(self):
         pages = [
             {'Home': 'index.md'},
-            {'About': 'about.md'}
+            {'About': 'about.md'},
+            {'Sub': [
+                {'Sub Home': 'index.md'},
+                {'Sub About': 'about.md'},
+
+            ]}
         ]
         expected_results = {
             'https://media.cdn.org/jq.js': 'https://media.cdn.org/jq.js',
@@ -63,11 +68,35 @@ class UtilsTests(unittest.TestCase):
             '//media.cdn.org/jquery.js': '//media.cdn.org/jquery.js',
             'media.cdn.org/jquery.js': './media.cdn.org/jquery.js',
             'local/file/jquery.js': './local/file/jquery.js',
+            'image.png': './image.png',
         }
         site_navigation = nav.SiteNavigation(pages)
         for path, expected_result in expected_results.items():
             urls = utils.create_media_urls(site_navigation, [path])
             self.assertEqual(urls[0], expected_result)
+
+    def test_create_relative_media_url_sub_index(self):
+        '''
+        test special case where there's a sub/index.md page
+        '''
+
+        site_navigation = nav.SiteNavigation([
+            {'Home': 'index.md'},
+            {'Sub': [
+                {'Sub Home': '/subpage/index.md'},
+
+            ]}
+        ])
+        site_navigation.url_context.set_current_url('/subpage/')
+        site_navigation.file_context.current_file = "subpage/index.md"
+
+        def assertPathGenerated(declared, expected):
+            url = utils.create_relative_media_url(site_navigation, declared)
+            self.assertEqual(url, expected)
+
+        assertPathGenerated("img.png", "./img.png")
+        assertPathGenerated("./img.png", "./img.png")
+        assertPathGenerated("/img.png", "../img.png")
 
     def test_reduce_list(self):
         self.assertEqual(

--- a/mkdocs/utils.py
+++ b/mkdocs/utils.py
@@ -210,9 +210,13 @@ def create_relative_media_url(nav, url):
         image.png -> ./image.png
         /image.png -> ./image.png
 
-    on sub/page.md (which becomes /sub/page/index.html):
+    On sub/page.md (which becomes /sub/page/index.html):
         image.png -> ../image.png
         /image.png -> ../../image.png
+
+    On sub/index.md (which becomes /sub/index.html):
+        image.png -> ./image.png
+        /image.png -> ./image.png
 
     """
 
@@ -229,12 +233,18 @@ def create_relative_media_url(nav, url):
     else:
         base = nav.url_context.base_path
 
-    relative_url = '%s/%s' % (nav.url_context.make_relative(base), url)
+    relative_base = nav.url_context.make_relative(base)
+    if relative_base == "." and url.startswith("./"):
+        relative_url = url
+    else:
+        relative_url = '%s/%s' % (relative_base, url)
 
     # TODO: Fix this, this is a hack. Relative urls are not being calculated
     # correctly for images in the same directory as the markdown. I think this
     # is due to us moving it into a directory with index.html, but I'm not sure
-    if nav.url_context.base_path is not '/' and relative_url.startswith("./"):
+    if (nav.file_context.current_file.endswith("/index.md") is False
+            and nav.url_context.base_path is not '/'
+            and relative_url.startswith("./")):
         relative_url = ".%s" % relative_url
 
     return relative_url


### PR DESCRIPTION
This is based on the code in #495, but squashed and rebased and some changes removed.

Closes #495
Closes #494