### PR TITLE
Change to active status should recursively move up tree

### DIFF
--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -200,6 +200,7 @@ class Header(object):
         for ancestor in self.ancestors:
             ancestor.set_active(active)
 
+
 def _path_to_page(path, title, url_context, use_directory_urls):
     if title is None:
         title = filename_to_title(path.split(os.path.sep)[-1])

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -171,7 +171,7 @@ class Page(object):
     def set_active(self, active=True):
         self.active = active
         for ancestor in self.ancestors:
-            ancestor.active = active
+            ancestor.set_active(active)
 
 
 class Header(object):
@@ -195,6 +195,10 @@ class Header(object):
             ret += item.indent_print(depth + 1)
         return ret
 
+    def set_active(self, active=True):
+        self.active = active
+        for ancestor in self.ancestors:
+            ancestor.set_active(active)
 
 def _path_to_page(path, title, url_context, use_directory_urls):
     if title is None:


### PR DESCRIPTION
Now that the page configuration can include multiple levels of headers and pages setting an item to active should recursively set all items in that tree to active.