### PR TITLE
Add (centered) copyright footer Bootstrap and Bootswatch themes

### DIFF
--- a/mkdocs/themes/amelia/base.html
+++ b/mkdocs/themes/amelia/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr align=center>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/bootstrap/base.html
+++ b/mkdocs/themes/bootstrap/base.html
@@ -51,9 +51,9 @@
 	<footer class="col-md-12">
 		<hr>
 		{% if copyright %}
-		<p>{{ copyright }}</p>
+		<center>{{ copyright }}</center>
 		{% endif %}
-		<p>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</p>
+		<center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
 	</footer>
 
 

--- a/mkdocs/themes/cerulean/base.html
+++ b/mkdocs/themes/cerulean/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/cosmo/base.html
+++ b/mkdocs/themes/cosmo/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/cyborg/base.html
+++ b/mkdocs/themes/cyborg/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/flatly/base.html
+++ b/mkdocs/themes/flatly/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/journal/base.html
+++ b/mkdocs/themes/journal/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/readable/base.html
+++ b/mkdocs/themes/readable/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/simplex/base.html
+++ b/mkdocs/themes/simplex/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/slate/base.html
+++ b/mkdocs/themes/slate/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/spacelab/base.html
+++ b/mkdocs/themes/spacelab/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/united/base.html
+++ b/mkdocs/themes/united/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>

--- a/mkdocs/themes/yeti/base.html
+++ b/mkdocs/themes/yeti/base.html
@@ -48,6 +48,14 @@
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
 
+        <footer class="col-md-12">
+            <hr>
+            {% if copyright %}
+                <center>{{ copyright }}</center>
+            {% endif %}
+            <center>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</center>
+        </footer>
+
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>


### PR DESCRIPTION
This also includes a note that the documentation was built with MkDocs

This is related with a suggestion in #375 