### PR TITLE
Ensure all errors and warnings are logged before exiting.

### DIFF
--- a/mkdocs/cli.py
+++ b/mkdocs/cli.py
@@ -10,6 +10,7 @@ from mkdocs import gh_deploy
 from mkdocs import new
 from mkdocs import serve
 from mkdocs import utils
+from mkdocs import exceptions
 from mkdocs.config import load_config
 
 log = logging.getLogger(__name__)
@@ -71,13 +72,17 @@ def serve_command(dev_addr, config_file, strict, theme, livereload):
 
     logging.getLogger('tornado').setLevel(logging.WARNING)
 
-    serve.serve(
-        config_file=config_file,
-        dev_addr=dev_addr,
-        strict=strict,
-        theme=theme,
-        livereload=livereload,
-    )
+    try:
+        serve.serve(
+            config_file=config_file,
+            dev_addr=dev_addr,
+            strict=strict,
+            theme=theme,
+            livereload=livereload,
+        )
+    except exceptions.ConfigurationError as e:
+        # Avoid ugly, unhelpful traceback
+        raise SystemExit('\n' + str(e))
 
 
 @cli.command(name="build")
@@ -88,12 +93,16 @@ def serve_command(dev_addr, config_file, strict, theme, livereload):
 @click.option('--site-dir', type=click.Path(), help=site_dir_help)
 def build_command(clean, config_file, strict, theme, site_dir):
     """Build the MkDocs documentation"""
-    build.build(load_config(
-        config_file=config_file,
-        strict=strict,
-        theme=theme,
-        site_dir=site_dir
-    ), clean_site_dir=clean)
+    try:
+        build.build(load_config(
+            config_file=config_file,
+            strict=strict,
+            theme=theme,
+            site_dir=site_dir
+        ), clean_site_dir=clean)
+    except exceptions.ConfigurationError as e:
+        # Avoid ugly, unhelpful traceback
+        raise SystemExit('\n' + str(e))
 
 
 @cli.command(name="json")
@@ -114,11 +123,15 @@ def json_command(clean, config_file, strict, site_dir):
                 "MkDocs release. For details on updating: "
                 "http://www.mkdocs.org/about/release-notes/")
 
-    build.build(load_config(
-        config_file=config_file,
-        strict=strict,
-        site_dir=site_dir
-    ), dump_json=True, clean_site_dir=clean)
+    try:
+        build.build(load_config(
+            config_file=config_file,
+            strict=strict,
+            site_dir=site_dir
+        ), dump_json=True, clean_site_dir=clean)
+    except exceptions.ConfigurationError as e:
+        # Avoid ugly, unhelpful traceback
+        raise SystemExit('\n' + str(e))
 
 
 @cli.command(name="gh-deploy")
@@ -128,12 +141,16 @@ def json_command(clean, config_file, strict, site_dir):
 @click.option('--remote-branch', '-b', help=remote_branch_help)
 def gh_deploy_command(config_file, clean, message, remote_branch):
     """Deply your documentation to GitHub Pages"""
-    config = load_config(
-        config_file=config_file,
-        remote_branch=remote_branch
-    )
-    build.build(config, clean_site_dir=clean)
-    gh_deploy.gh_deploy(config, message=message)
+    try:
+        config = load_config(
+            config_file=config_file,
+            remote_branch=remote_branch
+        )
+        build.build(config, clean_site_dir=clean)
+        gh_deploy.gh_deploy(config, message=message)
+    except exceptions.ConfigurationError as e:
+        # Avoid ugly, unhelpful traceback
+        raise SystemExit('\n' + str(e))
 
 
 @cli.command(name="new")

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -1,5 +1,5 @@
 import logging
-import os
+import os, sys
 
 import six
 import yaml
@@ -53,7 +53,7 @@ class Config(six.moves.UserDict):
                 self[key] = config_option.validate(value)
                 warnings.extend([(key, w) for w in config_option.warnings])
             except ValidationError as e:
-                failed.append((key, str(e)))
+                failed.append((key, e))
 
         for key in (set(self.keys()) - self._schema_keys):
             warnings.append((
@@ -147,20 +147,20 @@ def load_config(config_file=None, **kwargs):
 
     errors, warnings = cfg.validate()
 
-    if len(warnings) > 0:
-        for config_name, warning in warnings:
-            log.warning("Config value: %s. Warning: %s", config_name, warning)
-        if cfg['strict']:
-            raise exceptions.ConfigurationError(
-                "Warnings found in the config file")
+    for config_name, warning in warnings:
+        log.warning("Config value: %s. Warning: %s", config_name, warning)
 
-    if len(errors) > 0:
-        for config_name, error in errors:
-            log.error("Config value: %s. Error: %s", config_name, error)
-        raise exceptions.ConfigurationError("Errors found in the config file.")
+    for config_name, error in errors:
+        log.error("Config value: %s. Error: %s", config_name, error)
 
     for key, value in cfg.items():
-
         log.debug("Config value: %s = %r", key, value)
+    
+    if len(errors) > 0:
+        # Raise SystemExit to avoid an unhelpful traceback
+        raise SystemExit("Aborting with Errors...")
+    elif cfg['strict'] and len(warnings) > 0:
+        # Raise SystemExit to avoid an unhelpful traceback
+        raise SystemExit("Aborting with Warnings in `strict` mode...")
 
     return cfg

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -1,5 +1,5 @@
 import logging
-import os, sys
+import os
 
 import six
 import yaml
@@ -148,19 +148,21 @@ def load_config(config_file=None, **kwargs):
     errors, warnings = cfg.validate()
 
     for config_name, warning in warnings:
-        log.warning("Config value: %s. Warning: %s", config_name, warning)
+        log.warning("Config value: '%s'. Warning: %s", config_name, warning)
 
     for config_name, error in errors:
-        log.error("Config value: %s. Error: %s", config_name, error)
+        log.error("Config value: '%s'. Error: %s", config_name, error)
 
     for key, value in cfg.items():
-        log.debug("Config value: %s = %r", key, value)
-    
+        log.debug("Config value: '%s' = %r", key, value)
+
     if len(errors) > 0:
-        # Raise SystemExit to avoid an unhelpful traceback
-        raise SystemExit("Aborting with Errors...")
+        raise exceptions.ConfigurationError(
+            "Aborted with {0} Configuration Errors!".format(len(errors))
+        )
     elif cfg['strict'] and len(warnings) > 0:
-        # Raise SystemExit to avoid an unhelpful traceback
-        raise SystemExit("Aborting with Warnings in `strict` mode...")
+        raise exceptions.ConfigurationError(
+            "Aborted with {0} Configuration Warnings in 'strict' mode!".format(len(warnings))
+        )
 
     return cfg

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -26,13 +26,13 @@ class ConfigBaseTests(unittest.TestCase):
 
         c = base.Config(schema=defaults.DEFAULT_SCHEMA)
 
-        failed, warnings = c.validate()
+        errors, warnings = c.validate()
 
-        self.assertEqual(failed, [
-            ('site_name', 'Required configuration not provided.')
-        ])
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0][0], 'site_name')
+        self.assertEqual(str(errors[0][1]), 'Required configuration not provided.')
 
-        self.assertEqual(warnings, [])
+        self.assertEqual(len(warnings), 0)
 
     def test_load_missing_required(self):
         """

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -28,11 +28,12 @@ class ConfigTests(unittest.TestCase):
     def test_missing_site_name(self):
         c = config.Config(schema=config.DEFAULT_SCHEMA)
         c.load_dict({})
-        errors, warings = c.validate()
-        self.assertEqual([
-            ('site_name', 'Required configuration not provided.')
-        ], errors)
-        self.assertEqual([], warings)
+        errors, warnings = c.validate()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0][0], 'site_name')
+        self.assertEqual(str(errors[0][1]), 'Required configuration not provided.')
+
+        self.assertEqual(len(warnings), 0)
 
     def test_empty_config(self):
         def load_empty_config():


### PR DESCRIPTION
Also ensure all debug messages are logged. And exit without
creating a new, unhelpful traceback by raising SystemExit.
Note that `sys.exit` raises SystemExit. However, by raising it
explicitly, we can also output a helpful explaination of why
the program exited. The program exists with an exit code of 1
to indicate is failed.

Fixes #536.