### PR TITLE
Added URL decoding to `getSearchTerm()`

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -19,6 +19,7 @@ You can determine your currently installed version using `mkdocs --version`:
 * Add `--quiet` and `--verbose` options to all subcommands.
 * Add short options (`-a`) to most command line options.
 * Add copyright footer for readthedocs theme.
+* Bugfix: Fix a JavaScript encoding problem when searching with spaces. (#586)
 
 ## Version 0.13.3 (2015-06-02)
 

--- a/mkdocs/assets/search/mkdocs/js/search.js
+++ b/mkdocs/assets/search/mkdocs/js/search.js
@@ -15,7 +15,7 @@ require([
             var sParameterName = sURLVariables[i].split('=');
             if (sParameterName[0] == 'q')
             {
-                return sParameterName[1];
+                return decodeURIComponent(sParameterName[1].replace(/\+/g, '%20'));
             }
         }
     }


### PR DESCRIPTION
Including decoding of '+' to ' '.

Fixes #586.