### PR TITLE
Cleaned up socket.error stack trace for mkdocs serve.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,7 @@ You can determine your currently installed version using `mkdocs --version`:
 * Add short options (`-a`) to most command line options.
 * Add copyright footer for readthedocs theme.
 * Bugfix: Fix a JavaScript encoding problem when searching with spaces. (#586)
+* Stack traces are no longer displayed on socket errors, just an error message.
 
 ## Version 0.13.3 (2015-06-02)
 

--- a/mkdocs/cli.py
+++ b/mkdocs/cli.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 import logging
 import click
+import socket
 
 from mkdocs import __version__
 from mkdocs import build
@@ -110,7 +111,7 @@ def serve_command(dev_addr, config_file, strict, theme, livereload):
             theme=theme,
             livereload=livereload,
         )
-    except exceptions.ConfigurationError as e:
+    except (exceptions.ConfigurationError, socket.error) as e:
         # Avoid ugly, unhelpful traceback
         raise SystemExit('\n' + str(e))
 


### PR DESCRIPTION
Only the error message is displayed for socket errors.