### PR TITLE
Make all internal imports relative.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -15,6 +15,7 @@ You can determine your currently installed version using `mkdocs --version`:
 
 ## Version 0.14.0 (2015-??-??)
 
+* Made all internal imports relative imports.
 * Improve Unicode handling by ensuring that all YAML strings are loaded as Unicode.
 * Remove dependancy on the six library. (#583)
 * Add `--quiet` and `--verbose` options to all subcommands.

--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -10,9 +10,9 @@ from jinja2.exceptions import TemplateNotFound
 import jinja2
 import json
 
-from mkdocs import nav, search, utils
-from mkdocs.relative_path_ext import RelativePathExtension
-import mkdocs
+from . import nav, search, utils
+from .relative_path_ext import RelativePathExtension
+from . import __version__
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ def get_global_context(nav, config):
         'copyright': config['copyright'],
         'google_analytics': config['google_analytics'],
 
-        'mkdocs_version': mkdocs.__version__,
+        'mkdocs_version': __version__,
         'build_date_utc': datetime.utcnow(),
 
         'config': config

--- a/mkdocs/cli.py
+++ b/mkdocs/cli.py
@@ -6,14 +6,14 @@ import logging
 import click
 import socket
 
-from mkdocs import __version__
-from mkdocs import build
-from mkdocs import gh_deploy
-from mkdocs import new
-from mkdocs import serve
-from mkdocs import utils
-from mkdocs import exceptions
-from mkdocs.config import load_config
+from . import __version__
+from . import build
+from . import gh_deploy
+from . import new
+from . import serve
+from . import utils
+from . import exceptions
+from .config import load_config
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/config/__init__.py
+++ b/mkdocs/config/__init__.py
@@ -1,5 +1,5 @@
-from mkdocs.config.base import load_config
-from mkdocs.config.config_options import Config
-from mkdocs.config.defaults import DEFAULT_SCHEMA
+from .base import load_config
+from .config_options import Config
+from .defaults import DEFAULT_SCHEMA
 
 __all__ = ["load_config", 'Config', 'DEFAULT_SCHEMA']

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from mkdocs import exceptions
-from mkdocs import utils
+from .. import exceptions
+from .. import utils
 
 
 log = logging.getLogger('mkdocs.config')

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 import os
 
-from mkdocs import utils, legacy
-from mkdocs.config.base import Config, ValidationError
+from .. import utils, legacy
+from .base import Config, ValidationError
 
 
 class BaseConfigOption(object):

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from mkdocs import utils
-from mkdocs.config import config_options
+from .. import utils
+from . import config_options
 
 # NOTE: The order here is important. During validation some config options
 # depend on others. So, if config option A depends on B, then A should be

--- a/mkdocs/legacy.py
+++ b/mkdocs/legacy.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 import logging
 
-from mkdocs import utils
-from mkdocs.exceptions import ConfigurationError
+from . import utils
+from .exceptions import ConfigurationError
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -11,7 +11,7 @@ import datetime
 import logging
 import os
 
-from mkdocs import utils, exceptions
+from . import utils, exceptions
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/relative_path_ext.py
+++ b/mkdocs/relative_path_ext.py
@@ -41,8 +41,8 @@ import logging
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
 
-from mkdocs import utils
-from mkdocs.exceptions import MarkdownNotFound
+from . import utils
+from .exceptions import MarkdownNotFound
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/search.py
+++ b/mkdocs/search.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import json
-from mkdocs import utils
+from . import utils
 
 try:                                    # pragma: no cover
     from html.parser import HTMLParser  # noqa

--- a/mkdocs/serve.py
+++ b/mkdocs/serve.py
@@ -3,8 +3,8 @@ import logging
 import shutil
 import tempfile
 
-from mkdocs.build import build
-from mkdocs.config import load_config
+from .build import build
+from .config import load_config
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import textwrap
 import markdown
 
-from mkdocs import toc
+from .. import toc
 
 
 def dedent(text):

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -15,9 +15,9 @@ except ImportError:
     pass
 
 
-from mkdocs import build, nav, config
-from mkdocs.exceptions import MarkdownNotFound
-from mkdocs.tests.base import dedent
+from .. import build, nav, config
+from ..exceptions import MarkdownNotFound
+from .base import dedent
 
 
 def load_config(cfg=None):

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -7,7 +7,7 @@ import mock
 
 from click.testing import CliRunner
 
-from mkdocs import cli
+from .. import cli
 
 
 class CLITests(unittest.TestCase):

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -3,8 +3,8 @@ import os
 import tempfile
 import unittest
 
-from mkdocs import exceptions
-from mkdocs.config import base, defaults
+from ... import exceptions
+from ...config import base, defaults
 
 
 class ConfigBaseTests(unittest.TestCase):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -5,8 +5,8 @@ import unittest
 
 import six
 
-from mkdocs import utils
-from mkdocs.config import config_options
+from ... import utils
+from ...config import config_options
 
 
 class OptionallyRequiredTest(unittest.TestCase):

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -9,10 +9,10 @@ import unittest
 
 import six
 
-from mkdocs import config
-from mkdocs.config import config_options
-from mkdocs.exceptions import ConfigurationError
-from mkdocs.tests.base import dedent
+from ... import config
+from ...config import config_options
+from ...exceptions import ConfigurationError
+from ...tests.base import dedent
 
 
 def ensure_utf(string):

--- a/mkdocs/tests/integration.py
+++ b/mkdocs/tests/integration.py
@@ -20,7 +20,7 @@ import click
 import os
 import subprocess
 
-from mkdocs import utils
+from .. import utils
 
 DIR = os.path.dirname(__file__)
 MKDOCS_CONFIG = os.path.abspath(os.path.join(DIR, '../../mkdocs.yml'))

--- a/mkdocs/tests/legacy_tests.py
+++ b/mkdocs/tests/legacy_tests.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 import unittest
 
-from mkdocs import legacy, utils
+from .. import legacy, utils
 
 
 class TestCompatabilityShim(unittest.TestCase):

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -6,9 +6,9 @@ import mock
 import os
 import unittest
 
-from mkdocs import nav, legacy
-from mkdocs.exceptions import ConfigurationError
-from mkdocs.tests.base import dedent
+from .. import nav, legacy
+from ..exceptions import ConfigurationError
+from .base import dedent
 
 
 class SiteNavigationTests(unittest.TestCase):

--- a/mkdocs/tests/new_tests.py
+++ b/mkdocs/tests/new_tests.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 import os
 
-from mkdocs import new
+from .. import new
 
 
 class NewTests(unittest.TestCase):

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -4,9 +4,9 @@
 from __future__ import unicode_literals
 import unittest
 
-from mkdocs import nav
-from mkdocs import search
-from mkdocs.tests.base import dedent, markdown_to_toc
+from .. import nav
+from .. import search
+from .base import dedent, markdown_to_toc
 
 
 def strip_whitespace(string):

--- a/mkdocs/tests/toc_tests.py
+++ b/mkdocs/tests/toc_tests.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import unittest
 
-from mkdocs.tests.base import dedent, markdown_to_toc
+from .base import dedent, markdown_to_toc
 
 
 class TableOfContentsTests(unittest.TestCase):

--- a/mkdocs/tests/utils_tests.py
+++ b/mkdocs/tests/utils_tests.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 import os
 import unittest
 
-from mkdocs import nav, utils
-from mkdocs.tests.base import dedent
+from .. import nav, utils
+from .base import dedent
 
 
 class UtilsTests(unittest.TestCase):

--- a/mkdocs/utils.py
+++ b/mkdocs/utils.py
@@ -14,7 +14,7 @@ import shutil
 import markdown
 import yaml
 
-from mkdocs import toc
+from . import toc
 
 try:                                                        # pragma: no cover
     from urllib.parse import urlparse, urlunparse, urljoin  # noqa


### PR DESCRIPTION
Let's make MkDocs a better citizen. Relative imports were added in
Python 2.6 and there is no reason to not be using them. See [pep-0328][1].

Also updated the Release Notes.

[1]: https://www.python.org/dev/peps/pep-0328/