### PR TITLE
Handle (pass-through) character and entity references in TOC parser

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -24,6 +24,7 @@ You can determine your currently installed version using `mkdocs --version`:
 * Stack traces are no longer displayed on socket errors, just an error message.
 * Bugfix: Fix a JavaScript encoding problem when searching with spaces. (#586)
 * Bugfix: gh-deploy now works if the mkdocs.yml is not in the git repo root (#578)
+* Bugfix: Handle (pass-through instead of dropping) HTML entities while parsing TOC.
 
 ## Version 0.13.3 (2015-06-02)
 

--- a/mkdocs/tests/toc_tests.py
+++ b/mkdocs/tests/toc_tests.py
@@ -118,3 +118,17 @@ class TableOfContentsTests(unittest.TestCase):
         """)
         toc = markdown_to_toc(md)
         self.assertEqual(str(toc).strip(), expected)
+
+    def test_entityref(self):
+        md = dedent("""
+        # Heading & 1
+        ## Heading > 2
+        ### Heading < 3
+        """)
+        expected = dedent("""
+        Heading &amp; 1 - #heading-1
+            Heading &gt; 2 - #heading-2
+                Heading &lt; 3 - #heading-3
+        """)
+        toc = markdown_to_toc(md)
+        self.assertEqual(str(toc).strip(), expected)

--- a/mkdocs/toc.py
+++ b/mkdocs/toc.py
@@ -81,6 +81,12 @@ class TOCParser(HTMLParser):
         if self.in_anchor:
             self.title += data
 
+    def handle_charref(self, ref):
+        self.handle_entityref("#" + ref)
+
+    def handle_entityref(self, ref):
+        self.handle_data("&%s;" % ref)
+
 
 def _parse_html_table_of_contents(html):
     """


### PR DESCRIPTION
I have noticed the ampersand in a header like this:
```
### Tips & tricks
```
converted to `&amp;` by markdown, is dropped in the resulting TOC:
```
Tips  tricks
```

This patch fixes this by adding `handle_entityref` (and `handle_charref`, while we're at it) to `mkdocs.toc.TOCParser` which pass through such entities unchanged.