### PR TITLE
Don't populate extra_templates by default

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -25,6 +25,8 @@ You can determine your currently installed version using `mkdocs --version`:
 * Bugfix: Fix a JavaScript encoding problem when searching with spaces. (#586)
 * Bugfix: gh-deploy now works if the mkdocs.yml is not in the git repo root (#578)
 * Bugfix: Handle (pass-through instead of dropping) HTML entities while parsing TOC.
+* Bugfix: Default extra_templates to an empty list, don't automatically discover
+  them. (#616)
 
 ## Version 0.13.3 (2015-06-02)
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -170,7 +170,7 @@ Set a list of JavaScript files to be included by the theme.
 
 Set a list of templates to be built by MkDocs. To see more about writing templates for MkDocs read the documentation about [custom themes] and specifically the section about the [variables that are available] to templates.
 
-**default**: By default `extra_templates` will contain a list of all the HTML and XML files found within the `docs_dir`, if none are found it will be `[]` (an empty list).
+**default**: Unlike extra_css and extra_javascript, by default `extra_templates` will  be `[]` (an empty list).
 
 
 ### extra

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -311,7 +311,7 @@ class Extras(OptionallyRequired):
     if not provided.
     """
 
-    def __init__(self, file_match, **kwargs):
+    def __init__(self, file_match=None, **kwargs):
         super(Extras, self).__init__(**kwargs)
         self.file_match = file_match
 
@@ -324,6 +324,10 @@ class Extras(OptionallyRequired):
                 "Expected a list, got {0}".format(type(value)))
 
     def walk_docs_dir(self, docs_dir):
+
+        if self.file_match is None:
+            raise StopIteration
+
         for (dirpath, _, filenames) in os.walk(docs_dir):
             for filename in sorted(filenames):
                 fullpath = os.path.join(dirpath, filename)

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -84,8 +84,7 @@ DEFAULT_SCHEMA = (
 
     # Similar to the above, but each template (HTML or XML) will be build with
     # Jinja2 and the global context.
-    ('extra_templates', config_options.Extras(
-        file_match=utils.is_template_file)),
+    ('extra_templates', config_options.Extras()),
 
     # Determine if the site should include the nav and next/prev elements.
     # Default, True if the site has more than one page, False otherwise.


### PR DESCRIPTION
This is causing a number of users issues. So, this will now be a opt-in
feature only.

Fixes #616