### PR TITLE
Allow README.md to be used as the index page

### DIFF
--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -13,6 +13,7 @@ class UtilsTests(unittest.TestCase):
     def test_html_path(self):
         expected_results = {
             'index.md': 'index.html',
+            'README.md': 'index.html',
             'api-guide.md': 'api-guide/index.html',
             'api-guide/index.md': 'api-guide/index.html',
             'api-guide/testing.md': 'api-guide/testing/index.html',

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -141,12 +141,17 @@ def get_html_path(path):
     Map a source file path to an output html path.
 
     Paths like 'index.md' will be converted to 'index.html'
+    Paths like 'README.md' will be converted to 'index.html' if index.md doesn't also exist
     Paths like 'about.md' will be converted to 'about/index.html'
     Paths like 'api-guide/core.md' will be converted to 'api-guide/core/index.html'
     """
     path = os.path.splitext(path)[0]
     if os.path.basename(path) == 'index':
         return path + '.html'
+    # To match github-esque repositories where the webui renders README.md
+    # as the page index in the repository browser.
+    elif os.path.basename(path).split('.', 1)[0] == 'README':
+        return path.replace('README', 'index') + '.html'
     return "/".join((path, 'index.html'))
 
 


### PR DESCRIPTION
If index.md exists, it will be
preferenced over README.md, to match the featureset of [readthedocs](https://github.com/rtfd/readthedocs.org/blob/347104f25c82bba0c42029a2226cbbb71a0bf627/readthedocs/doc_builder/base.py#L89-L103) as the index page.

Fixes #608

I'm not sure what you require as far as documentation goes, but first wanted to make sure this, or something like it is reasonable. I used the maxsplit argument to `str.split()`, so there shouldn't be any unexpected surprises.