### PR TITLE
Update mkdocs utils coverage

### DIFF
--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -101,6 +101,7 @@ class UtilsTests(unittest.TestCase):
         assertPathGenerated("img.png", "./img.png")
         assertPathGenerated("./img.png", "./img.png")
         assertPathGenerated("/img.png", "../img.png")
+        assertPathGenerated("https://www.example.com/img.png", "https://www.example.com/img.png")
 
     def test_reduce_list(self):
         self.assertEqual(

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from __future__ import unicode_literals
-
 import mock
+from __future__ import unicode_literals, with_statement
 import os
 import unittest
 

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -4,11 +4,17 @@
 import mock
 from __future__ import unicode_literals, with_statement
 import os
+import sys
 import unittest
 
 from mkdocs import nav, utils, exceptions
 from mkdocs.tests.base import dedent
-from mock import patch
+from mock import mock_open, patch
+
+if sys.version_info.major == 2:
+    import __builtin__ as builtins
+else:
+    import builtins
 
 
 class UtilsTests(unittest.TestCase):
@@ -209,7 +215,7 @@ class UtilsTests(unittest.TestCase):
                 self.assertIsNone(utils.clean_directory('/etc'))
                 self.assertEqual(deleted, [])
 
-    def test_clean_directory_noop(self):
+    def test_clean_directory(self):
         deleted = []
         directory = '/BOGUSPATH'
         directory_contents = ['README.md', '.sekret_password_file', 'old_crappy_file']
@@ -220,3 +226,11 @@ class UtilsTests(unittest.TestCase):
                 with patch('mkdocs.utils.os.listdir', lambda x: directory_contents):
                     utils.clean_directory(directory)
                     self.assertEqual(sorted(deleted), sorted(expected))
+
+    def test_write_file(self):
+        new_dirs = []
+        filename = '/WATWATWAT/bogus.txt'
+        with patch('mkdocs.utils.os.makedirs', lambda x: new_dirs.append(x)):
+            with patch.object(builtins, 'open', mock_open(read_data='WAT\n')):
+                utils.write_file('WAT\n', filename)
+                self.assertEqual(new_dirs, [os.path.dirname(filename)])

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -11,7 +11,7 @@ from mkdocs import nav, utils, exceptions
 from mkdocs.tests.base import dedent
 from mock import mock_open, patch
 
-if sys.version_info.major == 2:
+if not utils.PY3:
     import __builtin__ as builtins
 else:
     import builtins


### PR DESCRIPTION
I feel kind of bad making a module of such pretty table (dict) based tests look so ugly, but this does up the coverage to 100% for `mkdocs.utils`. While I was in there futzing with the README stuff related to #608, I decided to take a stab at this.

I'm relatively new to mock and normally use it as a context manager instead of a decorator like most of the rest of the tests. If you've got any better ways or strong preferences on how to do this, I'm totally happy to change things.