### PR TITLE
Loading all Markdown in memory

### DIFF
--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -10,7 +10,9 @@ from jinja2.exceptions import TemplateNotFound
 import jinja2
 import json
 
-from mkdocs import nav, search, utils
+from mkdocs import nav
+from mkdocs import search
+from mkdocs import utils
 from mkdocs.relative_path_ext import RelativePathExtension
 import mkdocs
 
@@ -164,30 +166,16 @@ def build_template(template_name, env, config, site_navigation=None):
 
 def _build_page(page, config, site_navigation, env, dump_json):
 
-    # Read the input file
-    input_path = os.path.join(config['docs_dir'], page.input_path)
-
-    try:
-        input_content = io.open(input_path, 'r', encoding='utf-8').read()
-    except IOError:
-        log.error('file not found: %s', input_path)
-        raise
-
-    # Process the markdown text
-    html_content, table_of_contents, meta = convert_markdown(
-        markdown_source=input_content,
-        config=config,
-        site_navigation=site_navigation
-    )
+    html_content, toc = convert_markdown(page.markdown, config, site_navigation)
 
     context = get_global_context(site_navigation, config)
     context.update(get_page_context(
-        page, html_content, table_of_contents, meta, config
+        page, html_content, toc, page.meta, config
     ))
 
     # Allow 'template:' override in md source files.
-    if 'template' in meta:
-        template = env.get_template(meta['template'][0])
+    if 'template' in page.meta:
+        template = env.get_template(page.meta['template'][0])
     else:
         template = env.get_template('base.html')
 
@@ -208,7 +196,7 @@ def _build_page(page, config, site_navigation, env, dump_json):
     else:
         utils.write_file(output_content.encode('utf-8'), output_path)
 
-    return html_content, table_of_contents, meta
+    return html_content, toc, page.meta
 
 
 def build_extra_templates(extra_templates, config, site_navigation=None):

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -3,6 +3,7 @@ import os
 
 from mkdocs import utils, legacy
 from mkdocs.config.base import Config, ValidationError
+from mkdocs import nav
 
 
 class BaseConfigOption(object):
@@ -393,19 +394,18 @@ class Pages(Extras):
 
     def post_validation(self, config, key_name):
 
-        if config[key_name] is not None:
-            return
+        if config[key_name] is None:
+            pages = []
+            for filename in self.walk_docs_dir(config['docs_dir']):
+                if os.path.splitext(filename)[0] == 'index':
+                    pages.insert(0, filename)
+                else:
+                    pages.append(filename)
+            config[key_name] = utils.nest_pages(pages)
 
-        pages = []
-
-        for filename in self.walk_docs_dir(config['docs_dir']):
-
-            if os.path.splitext(filename)[0] == 'index':
-                pages.insert(0, filename)
-            else:
-                pages.append(filename)
-
-        config[key_name] = utils.nest_paths(pages)
+        config[key_name] = nav.paths_to_pages(config[key_name],
+                                              config['use_directory_urls'],
+                                              config['docs_dir'])
 
 
 class NumPages(OptionallyRequired):

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1,4 +1,8 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
+
 import os
 
 from mkdocs import utils, legacy
@@ -209,10 +213,10 @@ class Dir(Type):
 
     def run_validation(self, value):
 
-        value = super(Dir, self).run_validation(value)
+        value = os.path.abspath(super(Dir, self).run_validation(value))
 
         if self.exists and not os.path.isdir(value):
-            raise ValidationError("The path {0} doesn't exist".format(value))
+            raise ValidationError("The path '{0}' doesn't exist".format(value))
 
         return os.path.abspath(value)
 
@@ -381,10 +385,10 @@ class Pages(Extras):
         # TODO: Remove in 1.0
         config_types = set(type(l) for l in value)
 
-        if config_types.issubset(set([utils.text_type, dict, str])):
+        if config_types.issubset(set([utils.text_type, dict])):
             return value
 
-        if config_types.issubset(set([utils.text_type, list, str])):
+        if config_types.issubset(set([utils.text_type, list])):
             return legacy.pages_compat_shim(value)
 
         raise ValidationError("Invalid pages config. {0} {1}".format(
@@ -394,18 +398,23 @@ class Pages(Extras):
 
     def post_validation(self, config, key_name):
 
-        if config[key_name] is None:
-            pages = []
-            for filename in self.walk_docs_dir(config['docs_dir']):
-                if os.path.splitext(filename)[0] == 'index':
-                    pages.insert(0, filename)
-                else:
-                    pages.append(filename)
-            config[key_name] = utils.nest_pages(pages)
+        if config[key_name] is not None:
+            config[key_name] = nav.paths_to_pages(config[key_name],
+                                                  config['use_directory_urls'],
+                                                  config['docs_dir'])
+            return
 
-        config[key_name] = nav.paths_to_pages(config[key_name],
-                                              config['use_directory_urls'],
-                                              config['docs_dir'])
+        paths = []
+        for filename in self.walk_docs_dir(config['docs_dir']):
+            filename = utils.text_type(filename)
+            if os.path.splitext(filename)[0] == 'index':
+                paths.insert(0, filename)
+            else:
+                paths.append(filename)
+
+        pages = nav.paths_to_pages(paths, config['use_directory_urls'],
+                                   config['docs_dir'])
+        config[key_name] = utils.nest_pages(pages)
 
 
 class NumPages(OptionallyRequired):

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -10,13 +10,16 @@ from __future__ import unicode_literals
 import datetime
 import logging
 import os
+import io
 
 from mkdocs import utils, exceptions
+from mkdocs.utils import mdutils
+from mkdocs.utils import meta
 
 log = logging.getLogger(__name__)
 
 
-def filename_to_title(filename):
+def _filename_to_title(filename):
     """
     Automatically generate a default title, given a filename.
     """
@@ -24,6 +27,35 @@ def filename_to_title(filename):
         return 'Home'
 
     return utils.filename_to_title(filename)
+
+
+def _path_to_page(path, use_directory_urls, docs_dir, title=None):
+    url = utils.get_url_path(path, use_directory_urls)
+    return Page(title=title, url=url, path=path, docs_dir=docs_dir)
+
+
+def paths_to_pages(pages_config, use_directory_urls, docs_dir):
+
+    for i, entry in enumerate(pages_config):
+
+        if isinstance(entry, utils.text_type):
+            pages_config[i] = _path_to_page(entry, use_directory_urls, docs_dir)
+            continue
+        elif not isinstance(entry, dict):
+            raise Exception("Broken 1")
+
+        next_cat_or_title, subpages_or_path = next(iter(entry.items()))
+
+        if isinstance(subpages_or_path, list):
+            paths_to_pages(subpages_or_path, use_directory_urls, docs_dir)
+        elif isinstance(subpages_or_path, utils.text_type):
+            pages_config[i] = _path_to_page(subpages_or_path,
+                                            use_directory_urls, docs_dir,
+                                            title=next_cat_or_title)
+        else:
+            raise Exception('Broken 2')
+
+    return pages_config
 
 
 class SiteNavigation(object):
@@ -34,6 +66,9 @@ class SiteNavigation(object):
             pages_config, self.url_context, use_directory_urls)
         self.homepage = self.pages[0] if self.pages else None
         self.use_directory_urls = use_directory_urls
+
+        for page in self.pages:
+            page.url_context = self.url_context
 
     def __str__(self):
         return ''.join([str(item) for item in self])
@@ -131,12 +166,13 @@ class FileContext(object):
 
 
 class Page(object):
-    def __init__(self, title, url, path, url_context):
+    def __init__(self, title, url, path, docs_dir):
 
-        self.title = title
+        self._title = title
         self.abs_url = url
         self.active = False
-        self.url_context = url_context
+        self.url_context = None
+        self.docs_dir = docs_dir
         self.update_date = datetime.datetime.now().strftime("%Y-%m-%d")
 
         # Relative paths to the input markdown file and output html file.
@@ -147,6 +183,44 @@ class Page(object):
         self.previous_page = None
         self.next_page = None
         self.ancestors = []
+
+        self.load_markdown()
+
+    def load_markdown(self):
+
+        input_path = os.path.join(self.docs_dir, self.input_path)
+
+        try:
+            input_content = io.open(input_path, 'r', encoding='utf-8').read()
+        except IOError:
+            log.error('file not found: %s', input_path)
+            raise
+
+        self.markdown, self.meta = meta.get_data(input_content)
+
+    @property
+    def title(self):
+        """
+        Get the title for a Markdown document
+
+        Check these in order and return the first that has a valid title:
+
+        - self._title which is populated from the mkdocs.yml
+        - self.meta['title'] which comes from the page metadata
+        - self.markdown - look for the first H1
+        - self.input_path - create a title based on the filename
+        """
+        if self._title is not None:
+            return self._title
+        elif 'title' in self.meta:
+            return self.meta['title'][0]
+
+        title = mdutils.get_markdown_title(self.markdown)
+
+        if title is not None:
+            return title
+
+        return _filename_to_title(self.input_path.split(os.path.sep)[-1])
 
     @property
     def url(self):
@@ -162,6 +236,10 @@ class Page(object):
 
     def __str__(self):
         return self.indent_print()
+
+    def __repr__(self):
+        return "nav.Page(title='{0}', input_path='{1}')".format(self.title,
+                                                                self.input_path)
 
     def indent_print(self, depth=0):
         indent = '    ' * depth
@@ -202,24 +280,14 @@ class Header(object):
             ancestor.set_active(active)
 
 
-def _path_to_page(path, title, url_context, use_directory_urls):
-    if title is None:
-        title = filename_to_title(path.split(os.path.sep)[-1])
-    url = utils.get_url_path(path, use_directory_urls)
-    return Page(title=title, url=url, path=path,
-                url_context=url_context)
-
-
 def _follow(config_line, url_context, use_dir_urls, header=None, title=None):
 
-    if isinstance(config_line, utils.string_types):
-        path = os.path.normpath(config_line)
-        page = _path_to_page(path, title, url_context, use_dir_urls)
+    if isinstance(config_line, Page):
 
+        page = config_line
         if header:
             page.ancestors = [header]
             header.children.append(page)
-
         yield page
         raise StopIteration
 

--- a/mkdocs/serve.py
+++ b/mkdocs/serve.py
@@ -71,7 +71,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             theme=theme,
         )
         config['site_dir'] = tempdir
-        build(config, live_server=True)
+        build(config, live_server=True, clean_site_dir=True)
         return config
 
     # Perform the initial build

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -1,6 +1,13 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
+
 import textwrap
+import unittest
+
 import markdown
+import mock
 
 from mkdocs import toc, config
 
@@ -16,7 +23,7 @@ def markdown_to_toc(markdown_source):
     return toc.TableOfContents(toc_output)
 
 
-def load_config(cfg=None):
+def load_config(**cfg):
     """ Helper to build a simple config for testing. """
     cfg = cfg or {}
     if 'site_name' not in cfg:
@@ -27,3 +34,15 @@ def load_config(cfg=None):
     errors_warnings = conf.validate()
     assert(errors_warnings == ([], [])), errors_warnings
     return conf
+
+
+class MockedMarkdownLoadingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.patch_open = mock.patch("mkdocs.nav.Page.load_markdown",
+                                     autospec=True)
+        self.mock_open = self.patch_open.start()
+        self.mock_open.return_value = ("", {},)
+
+    def tearDown(self):
+        self.patch_open.stop()

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import textwrap
 import markdown
 
-from mkdocs import toc
+from mkdocs import toc, config
 
 
 def dedent(text):
@@ -14,3 +14,16 @@ def markdown_to_toc(markdown_source):
     md.convert(markdown_source)
     toc_output = md.toc
     return toc.TableOfContents(toc_output)
+
+
+def load_config(cfg=None):
+    """ Helper to build a simple config for testing. """
+    cfg = cfg or {}
+    if 'site_name' not in cfg:
+        cfg['site_name'] = 'Example'
+    conf = config.Config(schema=config.DEFAULT_SCHEMA)
+    conf.load_dict(cfg)
+
+    errors_warnings = conf.validate()
+    assert(errors_warnings == ([], [])), errors_warnings
+    return conf

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -15,22 +15,9 @@ except ImportError:
     pass
 
 
-from mkdocs import build, nav, config
+from mkdocs import build, nav
 from mkdocs.exceptions import MarkdownNotFound
-from mkdocs.tests.base import dedent
-
-
-def load_config(cfg=None):
-    """ Helper to build a simple config for testing. """
-    cfg = cfg or {}
-    if 'site_name' not in cfg:
-        cfg['site_name'] = 'Example'
-    conf = config.Config(schema=config.DEFAULT_SCHEMA)
-    conf.load_dict(cfg)
-
-    errors_warnings = conf.validate()
-    assert(errors_warnings == ([], [])), errors_warnings
-    return conf
+from mkdocs.tests.base import dedent, load_config
 
 
 class BuildTests(unittest.TestCase):

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 import unittest
 import mock
 

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -1,4 +1,8 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
+
 import os
 import tempfile
 import unittest

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
 
 import os
@@ -274,13 +277,21 @@ class ExtrasTest(unittest.TestCase):
 
 class PagesTest(unittest.TestCase):
 
+    def setUp(self):
+
+        self.config = {
+            'extra_stuff': [],
+            'use_directory_urls': False,
+            'docs_dir': 'docs',
+        }
+
     def test_provided(self):
 
         option = config_options.Pages()
         value = option.validate([['index.md', ], ])
         self.assertEqual(['index.md', ], value)
 
-        option.post_validation({'extra_stuff': []}, 'extra_stuff')
+        option.post_validation(self.config, 'extra_stuff')
 
     def test_provided_dict(self):
 
@@ -291,7 +302,7 @@ class PagesTest(unittest.TestCase):
         ])
         self.assertEqual(['index.md', {'Page': 'page.md'}], value)
 
-        option.post_validation({'extra_stuff': []}, 'extra_stuff')
+        option.post_validation(self.config, 'extra_stuff')
 
     def test_provided_empty(self):
 
@@ -299,7 +310,7 @@ class PagesTest(unittest.TestCase):
         value = option.validate([])
         self.assertEqual(None, value)
 
-        option.post_validation({'extra_stuff': []}, 'extra_stuff')
+        option.post_validation(self.config, 'extra_stuff')
 
     def test_invalid_type(self):
 

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -69,12 +69,6 @@ class ConfigTests(unittest.TestCase):
         Users can explicitly set the config file using the '--config' option.
         Allows users to specify a config other than the default `mkdocs.yml`.
         """
-        expected_result = {
-            'site_name': 'Example',
-            'pages': [
-                {'Introduction': 'index.md'}
-            ],
-        }
         file_contents = dedent("""
         site_name: Example
         pages:
@@ -87,8 +81,9 @@ class ConfigTests(unittest.TestCase):
             config_file.close()
 
             result = config.load_config(config_file=config_file.name)
-            self.assertEqual(result['site_name'], expected_result['site_name'])
-            self.assertEqual(result['pages'], expected_result['pages'])
+            self.assertEqual(result['site_name'], 'Example')
+            self.assertEqual(len(result['pages']), 1)
+            self.assertEqual(result['pages'][0].title, "Introduction")
         finally:
             os.remove(config_file.name)
 

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -2,23 +2,24 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 import os
 import shutil
 import tempfile
-import unittest
 
 from mkdocs import config
+from mkdocs import nav
 from mkdocs import utils
 from mkdocs.config import config_options
 from mkdocs.exceptions import ConfigurationError
-from mkdocs.tests.base import dedent
+from mkdocs.tests.base import dedent, MockedMarkdownLoadingTestCase
 
 
 def ensure_utf(string):
     return string.encode('utf-8') if not utils.PY3 else string
 
 
-class ConfigTests(unittest.TestCase):
+class ConfigTests(MockedMarkdownLoadingTestCase):
     def test_missing_config_file(self):
 
         def load_missing_config():
@@ -133,11 +134,14 @@ class ConfigTests(unittest.TestCase):
                 'docs_dir': tmp_dir
             })
             conf.validate()
-            self.assertEqual(['index.md', 'about.md'], conf['pages'])
+            self.assertEqual(['index.md', 'about.md'],
+                             [p.input_path for p in conf['pages']])
         finally:
             shutil.rmtree(tmp_dir)
 
     def test_default_pages_nested(self):
+
+        self.maxDiff = None
         tmp_dir = tempfile.mkdtemp()
         try:
             open(os.path.join(tmp_dir, 'index.md'), 'w').close()
@@ -146,32 +150,33 @@ class ConfigTests(unittest.TestCase):
             os.makedirs(os.path.join(tmp_dir, 'subA'))
             open(os.path.join(tmp_dir, 'subA', 'index.md'), 'w').close()
             os.makedirs(os.path.join(tmp_dir, 'subA', 'subA1'))
-            open(os.path.join(tmp_dir, 'subA', 'subA1', 'index.md'), 'w').close()
+            open(os.path.join(tmp_dir, 'subA', 'subA1', 'page.md'), 'w').close()
             os.makedirs(os.path.join(tmp_dir, 'subC'))
             open(os.path.join(tmp_dir, 'subC', 'index.md'), 'w').close()
             os.makedirs(os.path.join(tmp_dir, 'subB'))
-            open(os.path.join(tmp_dir, 'subB', 'index.md'), 'w').close()
+            open(os.path.join(tmp_dir, 'subB', 'page2.md'), 'w').close()
             conf = config.Config(schema=config.DEFAULT_SCHEMA)
             conf.load_dict({
                 'site_name': 'Example',
                 'docs_dir': tmp_dir
             })
             conf.validate()
+
             self.assertEqual([
-                'index.md',
-                'about.md',
-                'getting-started.md',
+                nav.Page(None, '/', 'index.md', tmp_dir),
+                nav.Page(None, '/about/', 'about.md', tmp_dir),
+                nav.Page(None, '/getting-started/', 'getting-started.md', tmp_dir),
                 {'subA': [
-                    os.path.join('subA', 'index.md'),
+                    nav.Page(None, '/subA/', os.path.join('subA', 'index.md'), tmp_dir),
                     {'subA1': [
-                        os.path.join('subA', 'subA1', 'index.md')
+                        nav.Page(None, '/subA/subA1/page/', os.path.join('subA', 'subA1', 'page.md'), tmp_dir)
                     ]}
                 ]},
                 {'subB': [
-                    os.path.join('subB', 'index.md')
+                    nav.Page(None, '/subB/page2/', os.path.join('subB', 'page2.md'), tmp_dir)
                 ]},
                 {'subC': [
-                    os.path.join('subC', 'index.md')
+                    nav.Page(None, '/subC/', os.path.join('subC', 'index.md'), tmp_dir)
                 ]}
             ], conf['pages'])
         finally:

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
 
 import unittest

--- a/mkdocs/tests/integration.py
+++ b/mkdocs/tests/integration.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 """
 # MkDocs Integration tests
 

--- a/mkdocs/tests/legacy_tests.py
+++ b/mkdocs/tests/legacy_tests.py
@@ -1,4 +1,8 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
+
 import unittest
 
 from mkdocs import legacy, utils

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -2,46 +2,48 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 import mock
 import os
-import unittest
 
 from mkdocs import nav, legacy
 from mkdocs.exceptions import ConfigurationError
-from mkdocs.tests.base import dedent
+from mkdocs.tests.base import (dedent, load_config,
+                               MockedMarkdownLoadingTestCase)
 
 
-class SiteNavigationTests(unittest.TestCase):
+class SiteNavigationTests(MockedMarkdownLoadingTestCase):
+
     def test_simple_toc(self):
-        pages = [
+        config = load_config(pages=[
             {'Home': 'index.md'},
-            {'About': 'about.md'}
-        ]
+            {'About': 'about/license.md'}
+        ])
         expected = dedent("""
         Home - /
-        About - /about/
+        About - /about/license/
         """)
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 2)
         self.assertEqual(len(site_navigation.pages), 2)
 
     def test_empty_toc_item(self):
-        pages = [
+        config = load_config(pages=[
             'index.md',
-            {'About': 'about.md'}
-        ]
+            {'About': 'about/license.md'}
+        ])
         expected = dedent("""
         Home - /
-        About - /about/
+        About - /about/license/
         """)
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 2)
         self.assertEqual(len(site_navigation.pages), 2)
 
     def test_indented_toc(self):
-        pages = [
+        config = load_config(pages=[
             {'Home': 'index.md'},
             {'API Guide': [
                 {'Running': 'api-guide/running.md'},
@@ -52,7 +54,7 @@ class SiteNavigationTests(unittest.TestCase):
                 {'Release notes': 'about/release-notes.md'},
                 {'License': 'about/license.md'}
             ]}
-        ]
+        ])
         expected = dedent("""
         Home - /
         API Guide
@@ -63,67 +65,67 @@ class SiteNavigationTests(unittest.TestCase):
             Release notes - /about/release-notes/
             License - /about/license/
         """)
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 3)
         self.assertEqual(len(site_navigation.pages), 6)
 
     def test_nested_ungrouped(self):
-        pages = [
+        config = load_config(pages=[
             {'Home': 'index.md'},
             {'Contact': 'about/contact.md'},
             {'License Title': 'about/sub/license.md'},
-        ]
+        ])
         expected = dedent("""
         Home - /
         Contact - /about/contact/
         License Title - /about/sub/license/
         """)
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 3)
         self.assertEqual(len(site_navigation.pages), 3)
 
     def test_nested_ungrouped_no_titles(self):
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'about/contact.md',
             'about/sub/license.md'
-        ]
+        ])
         expected = dedent("""
         Home - /
         Contact - /about/contact/
         License - /about/sub/license/
         """)
 
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 3)
         self.assertEqual(len(site_navigation.pages), 3)
 
     @mock.patch.object(os.path, 'sep', '\\')
     def test_nested_ungrouped_no_titles_windows(self):
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'about\\contact.md',
             'about\\sub\\license.md',
-        ]
+        ])
         expected = dedent("""
         Home - /
         Contact - /about/contact/
         License - /about/sub/license/
         """)
 
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 3)
         self.assertEqual(len(site_navigation.pages), 3)
 
     def test_walk_simple_toc(self):
-        pages = [
+        config = load_config(pages=[
             {'Home': 'index.md'},
             {'About': 'about.md'}
-        ]
+        ])
         expected = [
             dedent("""
                 Home - / [*]
@@ -134,15 +136,15 @@ class SiteNavigationTests(unittest.TestCase):
                 About - /about/ [*]
             """)
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         for index, page in enumerate(site_navigation.walk_pages()):
             self.assertEqual(str(site_navigation).strip(), expected[index])
 
     def test_walk_empty_toc(self):
-        pages = [
+        config = load_config(pages=[
             'index.md',
             {'About': 'about.md'}
-        ]
+        ])
         expected = [
             dedent("""
                 Home - / [*]
@@ -153,12 +155,12 @@ class SiteNavigationTests(unittest.TestCase):
                 About - /about/ [*]
             """)
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         for index, page in enumerate(site_navigation.walk_pages()):
             self.assertEqual(str(site_navigation).strip(), expected[index])
 
     def test_walk_indented_toc(self):
-        pages = [
+        config = load_config(pages=[
             {'Home': 'index.md'},
             {'API Guide': [
                 {'Running': 'api-guide/running.md'},
@@ -169,7 +171,7 @@ class SiteNavigationTests(unittest.TestCase):
                 {'Release notes': 'about/release-notes.md'},
                 {'License': 'about/license.md'}
             ]}
-        ]
+        ])
         expected = [
             dedent("""
                 Home - / [*]
@@ -232,26 +234,29 @@ class SiteNavigationTests(unittest.TestCase):
                     License - /about/license/ [*]
             """)
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         for index, page in enumerate(site_navigation.walk_pages()):
             self.assertEqual(str(site_navigation).strip(), expected[index])
 
     def test_base_url(self):
-        pages = [
+        config = load_config(pages=[
             'index.md'
-        ]
-        site_navigation = nav.SiteNavigation(pages, use_directory_urls=False)
+        ])
+        site_navigation = nav.SiteNavigation(config['pages'],
+                                             use_directory_urls=False)
         base_url = site_navigation.url_context.make_relative('/')
         self.assertEqual(base_url, '.')
 
     def test_relative_md_links_have_slash(self):
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'user-guide/styling-your-docs.md'
-        ]
-        site_navigation = nav.SiteNavigation(pages, use_directory_urls=False)
+        ])
+        site_navigation = nav.SiteNavigation(config['pages'],
+                                             use_directory_urls=False)
         site_navigation.url_context.base_path = "/user-guide/configuration"
-        url = site_navigation.url_context.make_relative('/user-guide/styling-your-docs/')
+        url = site_navigation.url_context.make_relative(
+            '/user-guide/styling-your-docs/')
         self.assertEqual(url, '../styling-your-docs/')
 
     def test_generate_site_navigation(self):
@@ -259,15 +264,16 @@ class SiteNavigationTests(unittest.TestCase):
         Verify inferring page titles based on the filename
         """
 
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'api-guide/running.md',
             'about/notes.md',
             'about/sub/license.md',
-        ]
+        ])
 
         url_context = nav.URLContext()
-        nav_items, pages = nav._generate_site_navigation(pages, url_context)
+        nav_items, pages = nav._generate_site_navigation(config['pages'],
+                                                         url_context)
 
         self.assertEqual([n.title for n in nav_items],
                          ['Home', 'Running', 'Notes', 'License'])
@@ -279,15 +285,16 @@ class SiteNavigationTests(unittest.TestCase):
         """
         Verify inferring page titles based on the filename with a windows path
         """
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'api-guide\\running.md',
             'about\\notes.md',
             'about\\sub\\license.md',
-        ]
+        ])
 
         url_context = nav.URLContext()
-        nav_items, pages = nav._generate_site_navigation(pages, url_context)
+        nav_items, pages = nav._generate_site_navigation(config['pages'],
+                                                         url_context)
 
         self.assertEqual([n.title for n in nav_items],
                          ['Home', 'Running', 'Notes', 'License'])
@@ -304,6 +311,10 @@ class SiteNavigationTests(unittest.TestCase):
         for bad_page in bad_pages:
 
             def _test():
+                load_config(pages=[
+                    bad_page,
+                ])
+
                 return nav._generate_site_navigation((bad_page, ), None)
 
             self.assertRaises(ConfigurationError, _test)
@@ -319,7 +330,7 @@ class SiteNavigationTests(unittest.TestCase):
 
     def test_ancestors(self):
 
-        pages = [
+        config = load_config(pages=[
             {'Home': 'index.md'},
             {'API Guide': [
                 {'Running': 'api-guide/running.md'},
@@ -330,8 +341,8 @@ class SiteNavigationTests(unittest.TestCase):
                 {'Release notes': 'about/release-notes.md'},
                 {'License': 'about/license.md'}
             ]}
-        ]
-        site_navigation = nav.SiteNavigation(pages)
+        ])
+        site_navigation = nav.SiteNavigation(config['pages'])
 
         ancestors = (
             [],
@@ -347,7 +358,7 @@ class SiteNavigationTests(unittest.TestCase):
 
     def test_nesting(self):
 
-        pages_config = [
+        config = load_config(pages=[
             {'Home': 'index.md'},
             {'Install': [
                 {'Pre-install': 'install/install-pre.md'},
@@ -368,9 +379,9 @@ class SiteNavigationTests(unittest.TestCase):
                 {'Testing': 'guide/testing.md'},
                 {'Deploying': 'guide/deploying.md'},
             ]}
-        ]
+        ])
 
-        site_navigation = nav.SiteNavigation(pages_config)
+        site_navigation = nav.SiteNavigation(config['pages'])
 
         self.assertEqual([n.title for n in site_navigation.nav_items],
                          ['Home', 'Install', 'Guide'])
@@ -399,56 +410,56 @@ class SiteNavigationTests(unittest.TestCase):
         self.assertEqual(str(site_navigation).strip(), expected)
 
 
-class TestLegacyPagesConfig(unittest.TestCase):
+class TestLegacyPagesConfig(MockedMarkdownLoadingTestCase):
 
     def test_walk_simple_toc(self):
-        pages = legacy.pages_compat_shim([
+        config = load_config(pages=legacy.pages_compat_shim([
             ('index.md', 'Home'),
-            ('about.md', 'About')
-        ])
+            ('about/license.md', 'About')
+        ]))
         expected = [
             dedent("""
                 Home - / [*]
-                About - /about/
+                About - /about/license/
             """),
             dedent("""
                 Home - /
-                About - /about/ [*]
+                About - /about/license/ [*]
             """)
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         for index, page in enumerate(site_navigation.walk_pages()):
             self.assertEqual(str(site_navigation).strip(), expected[index])
 
     def test_walk_empty_toc(self):
-        pages = legacy.pages_compat_shim([
+        config = load_config(pages=legacy.pages_compat_shim([
             ('index.md',),
-            ('about.md', 'About')
-        ])
+            ('about/license.md', 'About')
+        ]))
 
         expected = [
             dedent("""
                 Home - / [*]
-                About - /about/
+                About - /about/license/
             """),
             dedent("""
                 Home - /
-                About - /about/ [*]
+                About - /about/license/ [*]
             """)
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         for index, page in enumerate(site_navigation.walk_pages()):
             self.assertEqual(str(site_navigation).strip(), expected[index])
 
     def test_walk_indented_toc(self):
-        pages = legacy.pages_compat_shim([
+        config = load_config(pages=legacy.pages_compat_shim([
             ('index.md', 'Home'),
             ('api-guide/running.md', 'API Guide', 'Running'),
             ('api-guide/testing.md', 'API Guide', 'Testing'),
             ('api-guide/debugging.md', 'API Guide', 'Debugging'),
             ('about/release-notes.md', 'About', 'Release notes'),
             ('about/license.md', 'About', 'License')
-        ])
+        ]))
         expected = [
             dedent("""
                 Home - / [*]
@@ -511,19 +522,19 @@ class TestLegacyPagesConfig(unittest.TestCase):
                     License - /about/license/ [*]
             """)
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         for index, page in enumerate(site_navigation.walk_pages()):
             self.assertEqual(str(site_navigation).strip(), expected[index])
 
     def test_indented_toc_missing_child_title(self):
-        pages = legacy.pages_compat_shim([
+        config = load_config(pages=legacy.pages_compat_shim([
             ('index.md', 'Home'),
             ('api-guide/running.md', 'API Guide', 'Running'),
             ('api-guide/testing.md', 'API Guide'),
             ('api-guide/debugging.md', 'API Guide', 'Debugging'),
             ('about/release-notes.md', 'About', 'Release notes'),
             ('about/license.md', 'About', 'License')
-        ])
+        ]))
         expected = dedent("""
         Home - /
         API Guide
@@ -534,7 +545,7 @@ class TestLegacyPagesConfig(unittest.TestCase):
             Release notes - /about/release-notes/
             License - /about/license/
         """)
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 3)
         self.assertEqual(len(site_navigation.pages), 6)

--- a/mkdocs/tests/new_tests.py
+++ b/mkdocs/tests/new_tests.py
@@ -2,27 +2,36 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
+import os
+import shutil
 import tempfile
 import unittest
-import os
 
 from mkdocs import new
 
 
 class NewTests(unittest.TestCase):
 
-    def test_new(self):
+    def setUp(self):
 
-        tempdir = tempfile.mkdtemp()
-        os.chdir(tempdir)
+        self.old_cwd = os.getcwd()
+        self.tempdir = tempfile.mkdtemp()
+        os.chdir(self.tempdir)
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.tempdir)
+
+    def test_new(self):
 
         new.new("myproject")
 
         expected_paths = [
-            os.path.join(tempdir, "myproject"),
-            os.path.join(tempdir, "myproject", "mkdocs.yml"),
-            os.path.join(tempdir, "myproject", "docs"),
-            os.path.join(tempdir, "myproject", "docs", "index.md"),
+            os.path.join(self.tempdir, "myproject"),
+            os.path.join(self.tempdir, "myproject", "mkdocs.yml"),
+            os.path.join(self.tempdir, "myproject", "docs"),
+            os.path.join(self.tempdir, "myproject", "docs", "index.md"),
         ]
 
         for expected_path in expected_paths:

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -6,7 +6,7 @@ import unittest
 
 from mkdocs import nav
 from mkdocs import search
-from mkdocs.tests.base import dedent, markdown_to_toc
+from mkdocs.tests.base import dedent, markdown_to_toc, load_config
 
 
 def strip_whitespace(string):
@@ -108,7 +108,7 @@ class SearchTests(unittest.TestCase):
             {'Home': 'index.md'},
             {'About': 'about.md'},
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(pages, load_config())
 
         md = dedent("""
         # Heading 1

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 import unittest
 
 from mkdocs import nav
@@ -106,9 +107,11 @@ class SearchTests(unittest.TestCase):
 
         pages = [
             {'Home': 'index.md'},
-            {'About': 'about.md'},
+            {'About': 'about/license.md'},
         ]
-        site_navigation = nav.SiteNavigation(pages, load_config())
+        site_navigation = nav.SiteNavigation(pages, load_config(
+            pages=pages
+        ))
 
         md = dedent("""
         # Heading 1

--- a/mkdocs/tests/toc_tests.py
+++ b/mkdocs/tests/toc_tests.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 import unittest
 
 from mkdocs.tests.base import dedent, markdown_to_toc

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -7,7 +7,7 @@ Nothing in this module should have an knowledge of config or the layout
 and structure of the site and pages in the site.
 """
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 
 import logging
 import markdown
@@ -15,6 +15,7 @@ import os
 import pkg_resources
 import shutil
 import sys
+
 import yaml
 
 from mkdocs import toc, exceptions
@@ -338,15 +339,14 @@ def convert_markdown(markdown_source, extensions=None, extension_configs=None):
     )
     html_content = md.convert(markdown_source)
 
-    # On completely blank markdown files, no Meta or tox properties are added
+    # On completely blank markdown files, no toc property is added
     # to the generated document.
-    meta = getattr(md, 'Meta', {})
     toc_html = getattr(md, 'toc', '')
 
     # Post process the generated table of contents into a data structure
     table_of_contents = toc.TableOfContents(toc_html)
 
-    return (html_content, table_of_contents, meta)
+    return (html_content, table_of_contents)
 
 
 def get_themes():
@@ -413,20 +413,20 @@ def find_or_create_node(branch, key):
     return new_branch
 
 
-def nest_paths(paths):
+def nest_pages(pages):
     """
-    Given a list of paths, convert them into a nested structure that will match
+    Given a list of pages, convert them into a nested structure that will match
     the pages config.
     """
     nested = []
 
-    for path in paths:
+    for page in pages:
 
-        if os.path.sep not in path:
-            nested.append(path)
+        if os.path.sep not in page.input_path:
+            nested.append(page)
             continue
 
-        directory, _ = os.path.split(path)
+        directory, _ = os.path.split(page.input_path)
         parts = directory.split(os.path.sep)
 
         branch = nested
@@ -434,6 +434,6 @@ def nest_paths(paths):
             part = filename_to_title(part)
             branch = find_or_create_node(branch, part)
 
-        branch.append(path)
+        branch.append(page)
 
     return nested

--- a/mkdocs/utils/mdutils.py
+++ b/mkdocs/utils/mdutils.py
@@ -1,0 +1,4 @@
+
+
+def get_markdown_title(markdown):
+    return

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -1,0 +1,176 @@
+"""
+Copyright (c) 2015, Waylan Limberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or other
+materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+MultiMarkdown Meta-Data
+
+Extracts, parses and transforms MultiMarkdown style data from documents.
+
+"""
+
+
+import re
+
+
+#####################################################################
+# Transformer Collection                                            #
+#####################################################################
+
+class TransformerCollection(object):
+    """
+    A collecton of transformers.
+
+    A transformer is a callable that accepts a single argument (the value to be transformed)
+    and returns a transformed value.
+    """
+
+    def __init__(self, items=None, default=None):
+        """
+        Create a transformer collection.
+
+        `items`: A dictionary which points to a transformer for each key (optional).
+
+        `default`: The default transformer (optional). If no default is provided,
+        then the values of unknown keys are returned unaltered.
+        """
+
+        self._registery = items or {}
+        self.default = default or (lambda v: v)
+
+    def register(self, key=None):
+        """
+        Decorator which registers a transformer for the given key.
+
+        If no key is provided, a "default" transformer is registered.
+        """
+
+        def wrap(fn):
+            if key:
+                self._registery[key] = fn
+            else:
+                self.default = fn
+            return fn
+        return wrap
+
+    def transform(self, key, value):
+        """
+        Calls the transformer for the given key and returns the transformed value.
+        """
+
+        if key in self._registery:
+            return self._registery[key](value)
+        return self.default(value)
+
+    def transform_dict(self, data):
+        """
+        Calls the transformer for each item in a dictionary and returns a new dictionary.
+        """
+
+        newdata = {}
+        for k, v in data.items():
+            newdata[k] = self.transform(k, v)
+        return newdata
+
+
+# The global default transformer collection.
+tc = TransformerCollection()
+
+
+def transformer(key=None):
+    """
+    Decorator which registers a transformer for the given key.
+
+    If no key is provided, a "default" transformer is registered.
+    """
+
+    def wrap(fn):
+        tc.register(key)(fn)
+        return fn
+    return wrap
+
+
+#####################################################################
+# Data Parser                                                       #
+#####################################################################
+
+
+BEGIN_RE = re.compile(r'^-{3}(\s.*)?')
+META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
+META_MORE_RE = re.compile(r'^([ ]{4}|\t)(\s*)(?P<value>.*)')
+END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
+
+
+def get_raw_data(doc):
+    """
+    Extract raw meta-data from a text document.
+
+    Returns a tuple of document and a data dict.
+    """
+
+    lines = doc.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+
+    if lines and BEGIN_RE.match(lines[0]):
+        lines.pop(0)
+
+    data = {}
+    key = None
+    while lines:
+        line = lines.pop(0)
+
+        if line.strip() == '' or END_RE.match(line):
+            break  # blank line or end deliminator - done
+        m1 = META_RE.match(line)
+        if m1:
+            key = m1.group('key').lower().strip()
+            value = m1.group('value').strip()
+            try:
+                data[key].append(value)
+            except KeyError:
+                data[key] = [value]
+        else:
+            m2 = META_MORE_RE.match(line)
+            if m2 and key:
+                # Add another line to existing key
+                data[key].append(m2.group('value').strip())
+            else:
+                lines.insert(0, line)
+                break  # no meta data - done
+    return '\n'.join(lines).lstrip('\n'), data
+
+
+def get_data(doc, transformers=tc):
+    """
+    Extract meta-data from a text document.
+
+    `transformers`: A TransformerCollection used to transform data values.
+
+    Returns a tuple of document and a (transformed) data dict.
+    """
+
+    doc, rawdata = get_raw_data(doc)
+    return doc, transformers.transform_dict(rawdata)


### PR DESCRIPTION
This change updates the Markdown loading to load all the documents at startup. This gives us much more flexibility when we want to reference other Markdown files or use the metadata from a Markdown file earlier in the build.

Remaining tasks:

- [ ] Fix a few test  failures on older Python versions
- [ ] Fix the code in a few places that is wonky. Commented on inline.
- [ ] Add to release notes

Original text below the line.

---

This needs a bunch of works and it breaks loads of the tests, but it works quite well. It gets the page title from the Markdown if it isn't provided in the mkdocs.yml.

Feedback very welcome, it is a bit rough at the moment tho'

See #316 