### PR TITLE
Ignore autolink email addresses.

### DIFF
--- a/mkdocs/relative_path_ext.py
+++ b/mkdocs/relative_path_ext.py
@@ -43,6 +43,7 @@ import os
 
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
+from markdown.util import AMP_SUBSTITUTE
 
 from mkdocs import utils
 from mkdocs.exceptions import MarkdownNotFound
@@ -61,12 +62,10 @@ def path_to_url(url, nav, strict):
     scheme, netloc, path, params, query, fragment = (
         utils.urlparse(url))
 
-    # Markdown encodes mailto links such that urlparse fails to identify the scheme
-    mailto = '\x02amp\x03#109;\x02amp\x03#97;\x02amp\x03#105;\x02amp\x03#108;' + \
-             '\x02amp\x03#116;\x02amp\x03#111;\x02amp\x03#58;'
-
-    if scheme or netloc or not path or url.startswith(mailto):
+    if scheme or netloc or not path or AMP_SUBSTITUTE in url:
         # Ignore URLs unless they are a relative link to a markdown file.
+        # AMP_SUBSTITUTE is used internally by Markdown only for email,which is
+        # not a relative link. As urlparse errors on them, skip explicitly
         return url
 
     if nav and not utils.is_markdown_file(path):

--- a/mkdocs/relative_path_ext.py
+++ b/mkdocs/relative_path_ext.py
@@ -61,7 +61,11 @@ def path_to_url(url, nav, strict):
     scheme, netloc, path, params, query, fragment = (
         utils.urlparse(url))
 
-    if scheme or netloc or not path:
+    # Markdown encodes mailto links such that urlparse fails to identify the scheme
+    mailto = '\x02amp\x03#109;\x02amp\x03#97;\x02amp\x03#105;\x02amp\x03#108;' + \
+             '\x02amp\x03#116;\x02amp\x03#111;\x02amp\x03#58;'
+
+    if scheme or netloc or not path or url.startswith(mailto):
         # Ignore URLs unless they are a relative link to a markdown file.
         return url
 

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -196,6 +196,18 @@ class BuildTests(unittest.TestCase):
         html, toc, meta = build.convert_markdown(md_text, load_config(), site_navigation=site_navigation)
         self.assertEqual(html.strip(), expected.strip())
 
+    def test_ignore_email_links(self):
+        md_text = 'A <autolink@example.com> and an [link](mailto:example@example.com).'
+        expected = ''.join([
+            '<p>A <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#97;&#117;&#116;',
+            '&#111;&#108;&#105;&#110;&#107;&#64;&#101;&#120;&#97;&#109;&#112;&#108;',
+            '&#101;&#46;&#99;&#111;&#109;">&#97;&#117;&#116;&#111;&#108;&#105;&#110;',
+            '&#107;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;',
+            '</a> and an <a href="mailto:example@example.com">link</a>.</p>'
+        ])
+        html, toc, meta = build.convert_markdown(md_text, load_config())
+        self.assertEqual(html.strip(), expected.strip())
+
     def test_markdown_table_extension(self):
         """
         Ensure that the table extension is supported.


### PR DESCRIPTION
Markdown encodes autolink email addresses as per the rules. However,
urlparse does not properly parse the encoded scheme. Fixes #646.