### PR TITLE
Ensure consistent order of auto-populated pages.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -19,6 +19,7 @@ You can determine your currently installed version using `mkdocs --version`:
 * Fix issues when using absolute links to Markdown files. (#628)
 * Add support for [site_description] and [site_author] to the [ReadTheDocs]
   theme. (#631)
+* Bugfix: Ensure consistent ordering of auto-populated pages. (#638)
 
 [site_description]: /user-guide/configuration.md#site_description
 [site_author]: /user-guide/configuration.md#site_author

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -328,7 +328,8 @@ class Extras(OptionallyRequired):
         if self.file_match is None:
             raise StopIteration
 
-        for (dirpath, _, filenames) in os.walk(docs_dir):
+        for (dirpath, dirs, filenames) in os.walk(docs_dir):
+            dirs.sort()
             for filename in sorted(filenames):
                 fullpath = os.path.join(dirpath, filename)
                 relpath = os.path.normpath(os.path.relpath(fullpath, docs_dir))

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -146,11 +146,16 @@ class ConfigTests(unittest.TestCase):
         tmp_dir = tempfile.mkdtemp()
         try:
             open(os.path.join(tmp_dir, 'index.md'), 'w').close()
+            open(os.path.join(tmp_dir, 'getting-started.md'), 'w').close()
             open(os.path.join(tmp_dir, 'about.md'), 'w').close()
-            os.makedirs(os.path.join(tmp_dir, 'sub'))
-            open(os.path.join(tmp_dir, 'sub', 'sub.md'), 'w').close()
-            os.makedirs(os.path.join(tmp_dir, 'sub', 'sub2'))
-            open(os.path.join(tmp_dir, 'sub', 'sub2', 'sub2.md'), 'w').close()
+            os.makedirs(os.path.join(tmp_dir, 'subA'))
+            open(os.path.join(tmp_dir, 'subA', 'index.md'), 'w').close()
+            os.makedirs(os.path.join(tmp_dir, 'subA', 'subA1'))
+            open(os.path.join(tmp_dir, 'subA', 'subA1', 'index.md'), 'w').close()
+            os.makedirs(os.path.join(tmp_dir, 'subC'))
+            open(os.path.join(tmp_dir, 'subC', 'index.md'), 'w').close()
+            os.makedirs(os.path.join(tmp_dir, 'subB'))
+            open(os.path.join(tmp_dir, 'subB', 'index.md'), 'w').close()
             conf = config.Config(schema=config.DEFAULT_SCHEMA)
             conf.load_dict({
                 'site_name': 'Example',
@@ -160,11 +165,18 @@ class ConfigTests(unittest.TestCase):
             self.assertEqual([
                 'index.md',
                 'about.md',
-                {'Sub': [
-                    os.path.join('sub', 'sub.md'),
-                    {'Sub2': [
-                        os.path.join('sub', 'sub2', 'sub2.md'),
+                'getting-started.md',
+                {'subA': [
+                    os.path.join('subA', 'index.md'),
+                    {'subA1': [
+                        os.path.join('subA', 'subA1', 'index.md')
                     ]}
+                ]},
+                {'subB': [
+                    os.path.join('subB', 'index.md')
+                ]},
+                {'subC': [
+                    os.path.join('subC', 'index.md')
                 ]}
             ], conf['pages'])
         finally:


### PR DESCRIPTION
Both files and directories should be sorted to ensure consistent ordering of
pages in the menus across builds and systems. Turns out to be a simple fix.
As `os.walk` provides a reference to the list of dirs it uses internally,
we can modify that list in place and it will use the modified list.

While this may not give proper alphanumeric ordering for all languages,
it goes ensure consistent ordering. For more control over ordering,
it is expected that a plugin could be used once that API becomes available.

This fixes #638.