### PR TITLE
Corrected lint errors in Markdown docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 See the contributing guide in the documentation for an
 introduction to contributing to MkDocs.
 
-http://www.mkdocs.org/about/contributing/
+<http://www.mkdocs.org/about/contributing/>

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -10,13 +10,12 @@ ways, a few examples are:
 - Documentation improvements
 - Bug reports and patch reviews
 
-## Reporting an Issue?
+## Reporting an Issue
 
 Please include as much detail as you can. Let us know your platform and MkDocs
 version. If the problem is visual (for example a theme or design issue) please
 add a screenshot and if you get an error please include the the full error and
 traceback.
-
 
 ## Testing the Development Version
 
@@ -42,7 +41,6 @@ pip install --editable .
 
 This will install MkDocs in development mode which binds the `mkdocs` command
 to the git repository.
-
 
 ## Running the tests
 

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -4,9 +4,10 @@ The legal stuff.
 
 ---
 
-#### Included projects
+## Included projects
 
-Themes used under license from the Bootstrap, ReadTheDocs, GhostWriter and Bootswatch projects.
+Themes used under license from the Bootstrap, ReadTheDocs, GhostWriter and
+Bootswatch projects.
 
 * Bootstrap theme - [View license](//github.com/twbs/bootstrap/blob/master/LICENSE).
 * ReadTheDocs theme - [View license](//github.com/snide/sphinx_rtd_theme/blob/master/LICENSE).
@@ -15,12 +16,26 @@ Themes used under license from the Bootstrap, ReadTheDocs, GhostWriter and Boots
 
 Many thanks to the authors and contributors of those wonderful projects.
 
-#### MkDocs License (BSD)
+## MkDocs License (BSD)
 
 Copyright © 2014, Tom Christie. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer. Redistributions in binary form must
+reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the
+distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -13,10 +13,9 @@ You can determine your currently installed version using `mkdocs --version`:
     $ mkdocs --version
     mkdocs, version 0.14.0
 
-
 ## Version 0.15.0 (2015-??-??)
 
-### Major Additions
+### Major Additions to Version 0.15.0
 
 #### Add support for installable themes
 
@@ -25,8 +24,8 @@ addition, the Bootstrap and Bootswatch themes have been moved to external git
 repositories and python packages. See their individual documentation for more
 details about these specific themes.
 
-- [MkDocs Bootstrap]
-- [MkDocs Bootswatch]
+* [MkDocs Bootstrap]
+* [MkDocs Bootswatch]
 
 [MkDocs Bootstrap]: http://mkdocs.github.io/mkdocs-bootstrap/
 [MkDocs Bootswatch]: http://mkdocs.github.io/mkdocs-bootswatch/
@@ -42,7 +41,7 @@ themes
 [Styling your docs]: /user-guide/styling-your-docs.md
 [Custom themes]: /user-guide/custom-themes.md
 
-### Other Changes and Additions
+### Other Changes and Additions to Version 0.15.0
 
 * Fix issues when using absolute links to Markdown files. (#628)
 * Deprecate support of Python 2.6, pending removal in 1.0.0. (#165)
@@ -94,10 +93,9 @@ themes
 * Bugfix: Fix a problem with minimal configurations which only contain a list
   of paths in the pages config. (#562)
 
-
 ## Version 0.13.0 (2015-05-26)
 
-### Deprecations
+### Deprecations to Version 0.13.0
 
 #### Deprecate the JSON command
 
@@ -133,8 +131,7 @@ All themes other than mkdocs and readthedocs will be moved into external
 packages in a future release of MkDocs. This will enable them to be more easily
 supported and updates outside MkDocs releases.
 
-
-### Major Additions
+### Major Additions to Version 0.13.0
 
 #### Search
 
@@ -177,7 +174,7 @@ documentation.
 [extra_templates]: /user-guide/configuration.md#extra_templates
 [global variables]: /user-guide/styling-your-docs.md#global-context
 
-### Other Changes and Additions
+### Other Changes and Additions to Version 0.13.0
 
 * Add support for [Markdown extension configuration options]. (#435)
 * MkDocs now ships Python [wheels]. (#486)
@@ -188,25 +185,23 @@ documentation.
 * Add `--no-livereload` to `mkdocs serve` for a simpler development server. (#511)
 * Add copyright display support to all themes (#549)
 * Add support for custom commit messages in a `mkdocs gh-deploy` (#516)
-* Bugfix: Fix linking to media within the same directory as a markdown file called index.md (#535)
+* Bugfix: Fix linking to media within the same directory as a markdown file
+  called index.md (#535)
 * Bugfix: Fix errors with unicode filenames (#542).
 
 [extra config]: /user-guide/configuration.md#extra
 [Markdown extension configuration options]: /user-guide/configuration.md#markdown_extensions
 [wheels]: http://pythonwheels.com/
 
-
 ## Version 0.12.2 (2015-04-22)
 
 * Bugfix: Fix a regression where there would be an error if some child titles
   were missing but others were provided in the pages config. (#464)
 
-
 ## Version 0.12.1 (2015-04-14)
 
 * Bugfix: Fixed a CSS bug in the table of contents on some browsers where the
   bottom item was not clickable.
-
 
 ## Version 0.12.0 (2015-04-14)
 
@@ -263,12 +258,10 @@ documentation.
 * Bugfix: Don't block newer verions of Python-markdown on Python >= 2.7. (#376)
 * Bugfix: Fix encoding issues when opening files across platforms. (#428)
 
-
 ## Version 0.11.1 (2014-11-20)
 
 * Bugfix: Fix a CSS wrapping issue with code highlighting in the ReadTheDocs
   theme. (#233)
-
 
 ## Version 0.11.0 (2014-11-18)
 
@@ -284,7 +277,6 @@ documentation.
 * Bugfix: Use the polling observer in watchdog so rebuilding works on
   filesystems without inotify. (#184)
 * Bugfix: Improve error output for common configuration related errors. (#176)
-
 
 ## Version 0.10.0 (2014-10-29)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,14 +11,6 @@ generator that's geared towards building project documentation. Documentation
 source files are written in Markdown, and configured with a single YAML
 configuration file.
 
-!!! warning
-
-    MkDocs is currently still in development.
-
-    We're progressing quickly, but the documentation still needs filling in, and
-    there are a few rough edges. The 1.0 release is planned to arrive in the
-    next few months.
-
 ### Host anywhere
 
 Builds completely static HTML sites that you can host on GitHub pages, Amazon

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,37 +6,47 @@ Project documentation with&nbsp;Markdown.
 
 ## Overview
 
-MkDocs is a **fast**, **simple** and **downright gorgeous** static site generator that's geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file.
+MkDocs is a **fast**, **simple** and **downright gorgeous** static site
+generator that's geared towards building project documentation. Documentation
+source files are written in Markdown, and configured with a single YAML
+configuration file.
 
----
+!!! warning
 
-**MkDocs is currently still in development.**
+    MkDocs is currently still in development.
 
-We're progressing quickly, but the documentation still needs filling in, and there are a few rough edges.  The 1.0 release is planned to arrive in the next few months.
+    We're progressing quickly, but the documentation still needs filling in, and
+    there are a few rough edges. The 1.0 release is planned to arrive in the
+    next few months.
 
----
+### Host anywhere
 
-#### Host anywhere.
+Builds completely static HTML sites that you can host on GitHub pages, Amazon
+S3, or anywhere else you choose.
 
-Builds completely static HTML sites that you can host on GitHub pages, Amazon S3, or anywhere else you choose.
+### Great themes available
 
-#### Great themes available.
+There's a stack of good looking themes included by default. Choose from
+bootstrap, readthedocs, or any of the 12 bootswatch themes.
 
-There's a stack of good looking themes included by default. Choose from bootstrap, readthedocs, or any of the 12 bootswatch themes.
+### Preview your site as you work
 
-#### Preview your site as you work.
+The built-in devserver allows you to preview your documentation as you're
+writing it. It will even auto-reload whenever you save any changes, so all you
+need to do to see your latest edits is refresh your browser.
 
-The built-in devserver allows you to preview your documentation as you're writing it. It will even auto-reload whenever you save any changes, so all you need to do to see your latest edits is refresh your browser.
+### Easy to customize
 
-#### Easy to customize.
-
-Get your project documentation looking just the way you want it by customizing the theme.
+Get your project documentation looking just the way you want it by customizing
+the theme.
 
 ---
 
 ## Installation
 
-In order to install MkDocs you'll need [Python] installed on your system, as well as the Python package manager, [pip].  You can check if you have these already installed like so:
+In order to install MkDocs you'll need [Python] installed on your system, as
+well as the Python package manager, [pip]. You can check if you have these
+already installed like so:
 
 ```bash
 $ python --version
@@ -52,10 +62,11 @@ On Windows we recommend that you install Python and pip with [Chocolatey].
 Install the `mkdocs` package using pip:
 
 ```bash
-$ pip install mkdocs
+pip install mkdocs
 ```
 
-You should now have the `mkdocs` command installed on your system.  Run `mkdocs --version` to check that everything worked okay.
+You should now have the `mkdocs` command installed on your system. Run `mkdocs
+--version` to check that everything worked okay.
 
 ```bash
 $ mkdocs --version
@@ -64,38 +75,47 @@ mkdocs, version 0.14.0
 
 ---
 
-
 ## Getting started
 
 Getting started is super easy.
 
 ```bash
-$ mkdocs new my-project
-$ cd my-project
+mkdocs new my-project
+cd my-project
 ```
 
 Let's take a moment to review the initial project that's been created for us.
 
 ![The initial MkDocs layout](img/initial-layout.png)
 
-There's a single configuration file named `mkdocs.yml`, and a folder named `docs` that will contain our documentation source files.  Right now the `docs` folder just contains a single documentation page, named `index.md`.
+There's a single configuration file named `mkdocs.yml`, and a folder named
+`docs` that will contain our documentation source files. Right now the `docs`
+folder just contains a single documentation page, named `index.md`.
 
-MkDocs comes with a built-in webserver that lets you preview your documentation as you work on it. We start the webserver by making sure we're in the same directory as the `mkdocs.yml` config file, and then running the `mkdocs serve` command:
+MkDocs comes with a built-in webserver that lets you preview your documentation
+as you work on it. We start the webserver by making sure we're in the same
+directory as the `mkdocs.yml` config file, and then running the `mkdocs serve`
+command:
 
 ```bash
 $ mkdocs serve
 Running at: http://127.0.0.1:8000/
 ```
 
-Open up [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your browser, and you'll see the index page being displayed:
+Open up [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your browser, and
+you'll see the index page being displayed:
 
 ![The MkDocs live server](img/screenshot.png)
 
-The webserver also supports auto-reloading, and will rebuild your documentation whenever anything in the configuration file, documentation directory or theme directory changes.
+The webserver also supports auto-reloading, and will rebuild your documentation
+whenever anything in the configuration file, documentation directory or theme
+directory changes.
 
-Go ahead and edit the `docs/index.md` file now and save the file. Then simply hit reload in the browser and you'll see your updated documentation.
+Go ahead and edit the `docs/index.md` file now and save the file. Then simply
+hit reload in the browser and you'll see your updated documentation.
 
-Now's also a good time to edit the configuration file, `mkdocs.yml`.  Change the `site_name` setting to something else and save the file.
+Now's also a good time to edit the configuration file, `mkdocs.yml`. Change the
+`site_name` setting to something else and save the file.
 
 ![Editing the config file](img/initial-config.png)
 
@@ -105,15 +125,19 @@ Once you hit reload in the browser you'll see your new site name take effect.
 
 ## Adding pages
 
-Go ahead and edit the `doc/index.md` document, and change the initial heading to `MkLorum`, then reload the site in your browser, and you should see the change take effect immediately.
+Go ahead and edit the `doc/index.md` document, and change the initial heading to
+`MkLorum`, then reload the site in your browser, and you should see the change
+take effect immediately.
 
 Let's also add a second page to our documentation:
 
 ```bash
-$ curl 'jaspervdj.be/lorem-markdownum/markdown.txt' > docs/about.md
+curl 'jaspervdj.be/lorem-markdownum/markdown.txt' > docs/about.md
 ```
 
-We'd like our documentation site to include some navigation headers, so we'll edit the configuration file and add some information about the order and title to use for out headers:
+We'd like our documentation site to include some navigation headers, so we'll
+edit the configuration file and add some information about the order and title
+to use for out headers:
 
 ```no-highlight
 site_name: MkLorum
@@ -122,11 +146,14 @@ pages:
 - About: about.md
 ```
 
-Refresh the browser and you'll now see a navigation bar with `Home` and `About` headers.
+Refresh the browser and you'll now see a navigation bar with `Home` and `About`
+headers.
 
 ## Theming our documentation
 
-While we're here can also change the configuration file to alter how the documentation is displayed.  Let's go ahead and change the theme.  Edit the `mkdocs.yml` file to the following:
+While we're here can also change the configuration file to alter how the
+documentation is displayed. Let's go ahead and change the theme. Edit the
+`mkdocs.yml` file to the following:
 
 ```no-highlight
 site_name: MkLorum
@@ -142,48 +169,56 @@ Refresh the browser again, and you'll now see the ReadTheDocs theme being used.
 
 ## Building the site
 
-That's looking good.  We're ready to deploy the first pass of our `MkLorum` documentation now.  Let's build the documentation.
+That's looking good. We're ready to deploy the first pass of our `MkLorum`
+documentation now. Let's build the documentation.
 
 ```bash
-$ mkdocs build
+mkdocs build
 ```
 
-This will create a new directory, named `site`.  Let's take a look inside the directory:
+This will create a new directory, named `site`. Let's take a look inside the
+directory:
 
 ```bash
-$ ls site
+ls site
 about css fonts img index.html js
 ```
 
-Notice that our source documentation has been output as two HTML files named `index.html` and `about/index.html`.  We also have various other media that's been copied into the `site` directory as part of the documentation theme.
+Notice that our source documentation has been output as two HTML files named
+`index.html` and `about/index.html`. We also have various other media that's
+been copied into the `site` directory as part of the documentation theme.
 
-If you're using source code control such as `git` you probably don't want to check your documentation builds into the repository.  Add a line containing `site/` to your `.gitignore` file.
-
-```bash
-$ echo "site/" >> .gitignore
-```
-
-If you're using another source code control you'll want to check it's documentation on how to ignore specific directories.
-
-After some time, files may be removed from the documentation but they will still reside in the `site` directory. To remove those stale files, just run mkdocs with the `--clean` switch.
+If you're using source code control such as `git` you probably don't want to
+check your documentation builds into the repository. Add a line containing
+`site/` to your `.gitignore` file.
 
 ```bash
-$ mkdocs build --clean
+echo "site/" >> .gitignore
 ```
 
+If you're using another source code control you'll want to check it's
+documentation on how to ignore specific directories.
+
+After some time, files may be removed from the documentation but they will still
+reside in the `site` directory. To remove those stale files, just run mkdocs
+with the `--clean` switch.
+
+```bash
+mkdocs build --clean
+```
 
 ## Deploying
 
 The documentation site that we've just built only uses static files so you'll be
 able to host it from pretty much anywhere. [GitHub project pages] and [Amazon
 S3] are good hosting options. Upload the contents of the entire `site` directory
-to wherever you're hosting your website from and you're done. For specific instructions
-for a number of common hosts, see the [Deploying your Docs] page.
-
+to wherever you're hosting your website from and you're done. For specific
+instructions for a number of common hosts, see the [Deploying your Docs] page.
 
 ## Getting help
 
-To get help with MkDocs, please use the [discussion group], [GitHub issues] or the MkDocs IRC channel `#mkdocs` on freenode.
+To get help with MkDocs, please use the [discussion group], [GitHub issues] or
+the MkDocs IRC channel `#mkdocs` on freenode.
 
 [Amazon S3]: http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html
 [Chocolatey]: https://chocolatey.org/

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -6,23 +6,30 @@ Guide to all available configuration settings.
 
 ## Introduction
 
-Project settings are always configured by using a YAML configuration file in the project directory named `mkdocs.yml`.
+Project settings are always configured by using a YAML configuration file in the
+project directory named `mkdocs.yml`.
 
-As a minimum this configuration file must contain the `site_name` setting.  All other settings are optional.
+As a minimum this configuration file must contain the `site_name` setting. All
+other settings are optional.
 
 ## Project information
 
 ### site_name
 
-This is a **required setting**, and should be a string that is used as the main title for the project documentation.  For example:
+This is a **required setting**, and should be a string that is used as the main
+title for the project documentation. For example:
 
-    site_name: Marshmallow Generator
+```yaml
+site_name: Marshmallow Generator
+```
 
-When rendering the theme this setting will be passed as the `site_name` context variable.
+When rendering the theme this setting will be passed as the `site_name` context
+variable.
 
 ### site_url
 
-Set the canonical URL of the site. This will add a link tag with the canonical URL to the generated HTML header.
+Set the canonical URL of the site. This will add a link tag with the canonical
+URL to the generated HTML header.
 
 **default**: `null`
 
@@ -30,7 +37,9 @@ Set the canonical URL of the site. This will add a link tag with the canonical U
 
 When set, provides a link to your GitHub or Bitbucket repository on each page.
 
-    repo_url: https://github.com/example/repository/
+```yaml
+repo_url: https://github.com/example/repository/
+```
 
 **default**: `null`
 
@@ -38,22 +47,26 @@ When set, provides a link to your GitHub or Bitbucket repository on each page.
 
 When set, provides a link to your GitHub or Bitbucket repository on each page.
 
-**default**: `'GitHub'` or `'Bitbucket'` if the `repo_url` matches those domains, otherwise `null`
+**default**: `'GitHub'` or `'Bitbucket'` if the `repo_url` matches those
+domains, otherwise `null`
 
 ### site_description
 
 Set the site description. This will add a meta tag to the generated HTML header.
+
 **default**: `null`
 
 ### site_author
 
-Set the name of the author. This will add a meta tag to the generated HTML header.
+Set the name of the author. This will add a meta tag to the generated HTML
+header.
 
 **default**: `null`
 
 ### site_favicon
 
-Set the favicon to use. Putting a `favicon.ico` into the `docs/` directory, the config would look as follows:
+Set the favicon to use. Putting a `favicon.ico` into the `docs/` directory, the
+config would look as follows:
 
 ```yaml
 site_favicon: favicon.ico
@@ -61,13 +74,11 @@ site_favicon: favicon.ico
 
 **default**: `null`
 
-
 ### copyright
 
 Set the copyright information to be included in the documentation by the theme.
 
 **default**: `null`
-
 
 ### google_analytics
 
@@ -79,36 +90,41 @@ google_analytics: ['UA-36723568-3', 'mkdocs.org']
 
 **default**: `null`
 
-
 ### remote_branch
 
-Set the remote branch to commit to when using `gh-deploy` to deploy to Github Pages. This option can be overridden by a command line option in `gh-deploy`.
+Set the remote branch to commit to when using `gh-deploy` to deploy to Github
+Pages. This option can be overridden by a command line option in `gh-deploy`.
 
 **default**: `gh-pages`
-
 
 ### remote_name
 
-Set the remote name to push to when using `gh-deploy` to deploy to Github Pages. This option can be overridden by a command line option in `gh-deploy`.
+Set the remote name to push to when using `gh-deploy` to deploy to Github Pages.
+This option can be overridden by a command line option in `gh-deploy`.
 
 **default**: `gh-pages`
-
 
 ## Documentation layout
 
 ### pages
 
-This setting is used to determine the set of pages that should be built for the documentation. For example, the following would create Introduction, User Guide and About pages, given the three source files `index.md`, `user-guide.md` and `about.md`, respectively.
+This setting is used to determine the set of pages that should be built for the
+documentation. For example, the following would create Introduction, User Guide
+and About pages, given the three source files `index.md`, `user-guide.md` and
+`about.md`, respectively.
 
-    pages:
+```yaml
+pages:
     - 'Introduction': 'index.md'
     - 'User Guide': 'user-guide.md'
     - 'About': 'about.md'
+```
 
-See the section on [configuring pages and navigation](/user-guide/writing-your-docs.md#configure-pages-and-navigation) for a more detailed breakdown, including how to create sub-sections.
+See the section on [configuring pages and
+navigation](/user-guide/writing-your-docs.md#configure-pages-and-navigation) for
+a more detailed breakdown, including how to create sub-sections.
 
 ## Build directories
-
 
 ### theme
 
@@ -117,38 +133,44 @@ Sets the theme of your documentation site, for a list of available themes visit
 
 **default**: `'mkdocs'`
 
-
 ### theme_dir
 
-Lets you set a directory to a custom theme.  This can either be a relative directory, in which case it is resolved relative to the directory containing your configuration file, or it can be an absolute directory path.
+Lets you set a directory to a custom theme. This can either be a relative
+directory, in which case it is resolved relative to the directory containing
+your configuration file, or it can be an absolute directory path.
 
-See [styling your docs](styling-your-docs.md#custom-themes) for an explanation of custom themes.
+See [styling your docs](styling-your-docs.md#custom-themes) for an explanation
+of custom themes.
 
 **default**: `null`
 
-
 ### docs_dir
 
-Lets you set the directory containing the documentation source markdown files.  This can either be a relative directory, in which case it is resolved relative to the directory containing you configuration file, or it can be an absolute directory path.
+Lets you set the directory containing the documentation source markdown files.
+This can either be a relative directory, in which case it is resolved relative
+to the directory containing you configuration file, or it can be an absolute
+directory path.
 
 **default**: `'docs'`
 
-
 ### site_dir
 
-Lets you set the directory where the output HTML and other files are created.  This can either be a relative directory, in which case it is resolved relative to the directory containing you configuration file, or it can be an absolute directory path.
+Lets you set the directory where the output HTML and other files are created.
+This can either be a relative directory, in which case it is resolved relative
+to the directory containing you configuration file, or it can be an absolute
+directory path.
 
 **default**: `'site'`
 
 !!! note "Note:"
-    If you are using source code control you will normally want to ensure
-    that your *build output* files are not committed into the repository, and only
-    keep the *source* files under version control. For example, if using `git` you
-    might add the following line to your `.gitignore` file:
+    If you are using source code control you will normally want to ensure that
+    your *build output* files are not committed into the repository, and only
+    keep the *source* files under version control. For example, if using `git`
+    you might add the following line to your `.gitignore` file:
 
         site/
 
-    If you're using another source code control you'll want to check its
+    If you're using another source code control tool, you'll want to check its
     documentation on how to ignore specific directories.
 
 
@@ -158,36 +180,47 @@ Set a list of CSS files to be included by the theme. For example, the
 following example will include the the extra.css file within the css
 subdirectory in your [docs_dir](#docs_dir).
 
-    extra_css:
+```yaml
+extra_css:
     - css/extra.css
     - css/second_extra.css
+```
 
-**default**: By default `extra_css` will contain a list of all the CSS files found within the `docs_dir`, if none are found it will be `[]` (an empty list).
-
+**default**: By default `extra_css` will contain a list of all the CSS files
+found within the `docs_dir`, if none are found it will be `[]` (an empty list).
 
 ### extra_javascript
 
 Set a list of JavaScript files to be included by the theme. See the example
 in [extra_css](#extra_css) for usage.
 
-**default**: By default `extra_javascript` will contain a list of all the JavaScript files found within the `docs_dir`, if none are found it will be `[]` (an empty list).
-
+**default**: By default `extra_javascript` will contain a list of all the
+JavaScript files found within the `docs_dir`, if none are found it will be `[]`
+(an empty list).
 
 ### extra_templates
 
-Set a list of templates to be built by MkDocs. To see more about writing templates for MkDocs read the documentation about [custom themes] and specifically the section about the [variables that are available] to templates. See the example in [extra_css](#extra_css) for usage.
+Set a list of templates to be built by MkDocs. To see more about writing
+templates for MkDocs read the documentation about [custom themes] and
+specifically the section about the [variables that are available] to templates.
+See the example in [extra_css](#extra_css) for usage.
 
-**default**: Unlike extra_css and extra_javascript, by default `extra_templates` will  be `[]` (an empty list).
-
+**default**: Unlike extra_css and extra_javascript, by default `extra_templates`
+will be `[]` (an empty list).
 
 ### extra
 
-A set of key value pairs, where the values can be any valid YAML construct, that will be passed to the template. This allows for great flexibility when creating custom themes.
+A set of key value pairs, where the values can be any valid YAML construct, that
+will be passed to the template. This allows for great flexibility when creating
+custom themes.
 
-For example, if you are using a theme that supports displaying the project version, you can pass it to the theme like this:
+For example, if you are using a theme that supports displaying the project
+version, you can pass it to the theme like this:
 
-    extra:
-        version: 1.0
+```yaml
+extra:
+    version: 1.0
+```
 
 **default**: By default `extra` will be an empty key value mapping.
 
@@ -195,9 +228,11 @@ For example, if you are using a theme that supports displaying the project versi
 
 ### use_directory_urls
 
-This setting controls the style used for linking to pages within the documentation.
+This setting controls the style used for linking to pages within the
+documentation.
 
-The following table demonstrates how the URLs used on the site differ when setting `use_directory_urls` to `true` or `false`.
+The following table demonstrates how the URLs used on the site differ when
+setting `use_directory_urls` to `true` or `false`.
 
 Source file  | Generated HTML       | use_directory_urls=true  | use_directory_urls=false
 ------------ | -------------------- | ------------------------ | ------------------------
@@ -205,25 +240,36 @@ index.md     | index.html           | /                        | /index.html
 api-guide.md | api-guide/index.html | /api-guide/              | /api-guide/index.html
 about.md     | about/index.html     | /about/                  | /about/index.html
 
-The default style of `use_directory_urls=true` creates more user friendly URLs, and is usually what you'll want to use.
+The default style of `use_directory_urls=true` creates more user friendly URLs,
+and is usually what you'll want to use.
 
-The alternate style can occasionally be useful if you want your documentation to remain properly linked when opening pages directly from the file system, because it create links that point directly to the target *file* rather than the target *directory*.
+The alternate style can occasionally be useful if you want your documentation to
+remain properly linked when opening pages directly from the file system, because
+it create links that point directly to the target *file* rather than the target
+*directory*.
 
 **default**: `true`
 
 ### strict
 
-Determines if a broken link to a page within the documentation is considered a warning or an error (link to a page not listed in the pages setting).  Set to true to halt processing when a broken link is found, false prints a warning.
+Determines if a broken link to a page within the documentation is considered a
+warning or an error (link to a page not listed in the pages setting). Set to
+true to halt processing when a broken link is found, false prints a warning.
 
 **default**: `false`
 
 ### dev_addr
 
-Determines the address used when running `mkdocs serve`.  Setting this allows you to use another port, or allows you to make the service accessible over your local network by using the `0.0.0.0` address.
+Determines the address used when running `mkdocs serve`. Setting this allows you
+to use another port, or allows you to make the service accessible over your
+local network by using the `0.0.0.0` address.
 
-As with all settings, you can set this from the command line, which can be useful, for example:
+As with all settings, you can set this from the command line, which can be
+useful, for example:
 
-    mkdocs serve --dev-addr=0.0.0.0:80  # Run on port 80, accessible over the local network.
+```bash
+mkdocs serve --dev-addr=0.0.0.0:80  # Run on port 80, on the local network.
+```
 
 **default**: `'127.0.0.1:8000'`
 
@@ -239,8 +285,10 @@ and `fenced_code`).
 
 For example, to enable the [SmartyPants typography extension][smarty], use:
 
-    markdown_extensions:
-        - smarty
+```yaml
+markdown_extensions:
+    - smarty
+```
 
 Some extensions provide configuration options of their own. If you would like to
 set any configuration options, then you can nest a key/value mapping
@@ -250,38 +298,44 @@ they support.
 
 For example, to enable permalinks in the (included) `toc` extension, use:
 
-    markdown_extensions:
-        - toc:
-            permalink: True
+```yaml
+markdown_extensions:
+    - toc:
+        permalink: True
+```
 
-Note that a colon (`:`) must follow the extension name (`toc`) and then on a new line
-the option name and value must be indented and seperated by a colon. If you would like
-to define multipe options for a single extension, each option must be defined on
-a seperate line:
+Note that a colon (`:`) must follow the extension name (`toc`) and then on a new
+line the option name and value must be indented and seperated by a colon. If you
+would like to define multipe options for a single extension, each option must be
+defined on a seperate line:
 
-    markdown_extensions:
-        - toc:
-            permalink: True
-            separator: "_"
+```yaml
+markdown_extensions:
+    - toc:
+        permalink: True
+        separator: "_"
+```
 
 Add an additional item to the list for each extension. If you have no
 configuration options to set for a specific extension, then simply omit options
 for that extension:
 
-    markdown_extensions:
-        - smarty
-        - toc:
-            permalink: True
-        - sane_lists
+```yaml
+markdown_extensions:
+    - smarty
+    - toc:
+        permalink: True
+    - sane_lists
+```
 
 !!! note "See Also:"
     The Python-Markdown documentation provides a [list of extensions][exts]
     which are available out-of-the-box. For a list of configuration options
     available for a given extension, see the documentation for that extension.
 
-    You may also install and use various [third party extensions][3rd]. Consult the
-    documentation provided by those extensions for installation instructions and
-    available configuration options.
+    You may also install and use various [third party extensions][3rd]. Consult
+    the documentation provided by those extensions for installation instructions
+    and available configuration options.
 
 **default**: `[]`
 

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -316,13 +316,7 @@ full search implementation to your theme.
 <h1 id="search">Search Results</h1>
 
 <form action="search.html">
-  <input
-      name="q"
-      id="mkdocs-search-query"
-      type="text"
-      class="search_input search-query ui-autocomplete-input"
-      placeholder="Search the Docs"
-      autocomplete="off">
+  <input name="q" id="mkdocs-search-query" type="text" >
 </form>
 
 <div id="mkdocs-search-results">

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -110,6 +110,7 @@ google_analytics  | [google_analytics]    |
 The following variables provide information about the navigation and location.
 
 #### nav
+
 The `nav` variable is used to create the navigation for the documentation.
 Following is a basic usage example which outputs the first and second level
 navigation as a nested list.
@@ -138,6 +139,7 @@ navigation as a nested list.
 ```
 
 #### base_url
+
 The `base_url` provides a relative path to the root of the MkDocs project.
 This makes it easy to include links to static assets in your theme. For
 example, if your theme includes a `js` folder, to include `theme.js` from that
@@ -148,32 +150,39 @@ folder on all pages you would do this:
 ```
 
 #### homepage_url
+
 Provides a relative path to the documentation homepage.
 
 #### mkdocs_version
+
 Contains the current MkDocs version.
 
 #### build_date_utc
+
 A Python datetime object that represents the date and time the documentation
 was built in UTC. This is useful for showing how recently the documentation
 was updated.
 
-
 ### Page Context
+
 The page context includes all of the above Global context and the following
 additional variables.
 
 #### page_title
+
 Contains the Title for the current page.
 
 #### page_description
+
 Contains the description for the current page on the homepage, it is blank on
 other pages.
 
 #### content
+
 The rendered Markdown as HTML, this is the contents of the documentation.
 
 #### toc
+
 An object representing the Table of contents for a page. Displaying the table
 of contents as a simple list can be achieved like this.
 
@@ -189,6 +198,7 @@ of contents as a simple list can be achieved like this.
 ```
 
 #### meta
+
 A mapping of the metadata included at the top of the markdown page. In this
 example we define a `source` property above the page title.
 
@@ -214,10 +224,12 @@ documentation page.
 ```
 
 #### canonical_url
+
 The full, canonical URL to the current page. This includes the site_url from
 the configuration.
 
 #### current_page
+
 The page object for the current page. The page path and url properties can be
 displayed like this.
 
@@ -227,17 +239,19 @@ displayed like this.
 ```
 
 #### previous_page
+
 The page object for the previous  page. The usage is the same as for
 `current_page`.
 
 #### next_page
+
 The page object for the next page.The usage is the same as for `current_page`.
 
 ### Extra Context
 
 Additional variables can be passed to the template with the
-[`extra`](/user-guide/configuration.md#extra) configuration option. This is a set of key value
-pairs that can make custom templates far more flexible.
+[`extra`](/user-guide/configuration.md#extra) configuration option. This is a
+set of key value pairs that can make custom templates far more flexible.
 
 For example, this could be used to include the project version of all pages
 and a list of links related to the project. This can be achieved with the
@@ -302,7 +316,13 @@ full search implementation to your theme.
 <h1 id="search">Search Results</h1>
 
 <form action="search.html">
-  <input name="q" id="mkdocs-search-query" type="text" class="search_input search-query ui-autocomplete-input" placeholder="Search the Docs" autocomplete="off">
+  <input
+      name="q"
+      id="mkdocs-search-query"
+      type="text"
+      class="search_input search-query ui-autocomplete-input"
+      placeholder="Search the Docs"
+      autocomplete="off">
 </form>
 
 <div id="mkdocs-search-results">
@@ -314,11 +334,9 @@ This works by looking for the specific ID's used in the above HTML. The input
 for the user to type the search query must have the ID `mkdocs-search-query`
 and `mkdocs-search-results` is the directory where the results will be placed.
 
-
 [Jinja2 template]: http://jinja.pocoo.org/docs/dev/
 [built-in themes]: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/themes
 [lunr.js]: http://lunrjs.com/
-
 
 ## Packaging Themes
 
@@ -403,7 +421,6 @@ it includes a `base.html` for the theme. It **must** also include a
 `__init__.py` file which should be empty, this file tells Python that the
 directory is a package.
 
-
 ### Distributing Themes
 
 With the above changes, your theme should now be ready to install. This can be
@@ -422,5 +439,4 @@ If you don't have an account setup, you should be prompted to create one.
 For a much more detailed guide, see the official Python packaging
 documentation for [Packaging and Distributing Projects].
 
-[Packaging and Distributing Projects]:
-https://packaging.python.org/en/latest/distributing.html
+[Packaging and Distributing Projects]: https://packaging.python.org/en/latest/distributing.html

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -32,8 +32,6 @@ files locally.
     You should never edit files in your gh-pages branch by hand if you're using
     the `gh-deploy` command because you will lose your work.
 
-
-
 [GitHub]: https://github.com/
 [GitHub Pages]: https://pages.github.com/
 [ghp-import]: https://github.com/davisp/ghp-import
@@ -77,15 +75,16 @@ where `<projectname>` is the name you used to register your project with PyPI.
 
 There are a few prerequisites for the above to work:
 
-1. You must be using [Setuptools] in your `setup.py` script ([Distutils] does not
-offer an `upload_docs` command).
-2. Your project must already be registered with PyPI (use `python setup.py register`).
-3. Your `mkdocs.yml` config file and your "docs" directory (value assigned to
-the [docs_dir] configuration option) are presumed to be in the root directory of
-your project alongside your `setup.py` script.
-4. It is assumed that the default value (`"site"`) is assigned to the [site_dir]
-configuration option in your `mkdocs.yaml` config file. If you have set a
-different value, assign that value to the `--upload-dir` option.
+1. You must be using [Setuptools] in your `setup.py` script ([Distutils] does
+   not offer an `upload_docs` command).
+1. Your project must already be registered with PyPI (use `python setup.py
+   register`).
+1. Your `mkdocs.yml` config file and your "docs" directory (value assigned to
+   the [docs_dir] configuration option) are presumed to be in the root directory
+   of your project alongside your `setup.py` script.
+1. It is assumed that the default value (`"site"`) is assigned to the [site_dir]
+   configuration option in your `mkdocs.yaml` config file. If you have set a
+   different value, assign that value to the `--upload-dir` option.
 
 [Python]: http://www.python.org/
 [PyPI]: https://pypi.python.org/pypi

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -20,7 +20,6 @@ in-themes) listed below.
 To create a new custom theme or more heavily customise an existing theme, see
 the [custom themes](#custom-themes) section below.
 
-
 ## Built-in themes
 
 ### mkdocs
@@ -49,58 +48,57 @@ the [Bootswatch] project.
 [MkDocs Bootstrap]: http://mkdocs.github.io/mkdocs-bootstrap/
 [MkDocs Bootswatch]: http://mkdocs.github.io/mkdocs-bootswatch/
 
-#### Bootstrap
+### Bootstrap
 
 ![Bootstrap](http://bootstrapdocs.com/v2.3.1/docs/assets/img/examples/bootstrap-example-fluid.png)
 
-#### Amelia
+### Amelia
 
 ![Amelia](http://bootswatch.com/2/amelia/thumbnail.png)
 
-#### Cerulean
+### Cerulean
 
 ![Cerulean](http://bootswatch.com/cerulean/thumbnail.png)
 
-#### Cosmo
+### Cosmo
 
 ![Cosmo](http://bootswatch.com/cosmo/thumbnail.png)
 
-#### Cyborg
+### Cyborg
 
 ![Cyborg](http://bootswatch.com/cyborg/thumbnail.png)
 
-#### Flatly
+### Flatly
 
 ![Flatly](http://bootswatch.com/flatly/thumbnail.png)
 
-#### Journal
+### Journal
 
 ![Journal](http://bootswatch.com/journal/thumbnail.png)
 
-#### Readable
+### Readable
 
 ![Readable](http://bootswatch.com/readable/thumbnail.png)
 
-#### Simplex
+### Simplex
 
 ![Simplex](http://bootswatch.com/simplex/thumbnail.png)
 
-#### Slate
+### Slate
 
 ![Slate](http://bootswatch.com/slate/thumbnail.png)
 
-#### Spacelab
+### Spacelab
 
 ![Spacelab](http://bootswatch.com/spacelab/thumbnail.png)
 
-#### United
+### United
 
 ![United](http://bootswatch.com/united/thumbnail.png)
 
-#### Yeti
+### Yeti
 
 ![Yeti](http://bootswatch.com/yeti/thumbnail.png)
-
 
 ## Customising a Theme
 
@@ -119,17 +117,17 @@ h1 {
 }
 ```
 
-!!! Warning
+!!! note
 
     If you are deploying your documentation with [ReadTheDocs]. You will need
-    to explicitly list the CSS and JavaScript files you want to include inf
+    to explicitly list the CSS and JavaScript files you want to include in
     your config. To do this, add the following to your mkdocs.yml.
 
         extra_css: [extra.css]
 
-After making these changes, they should be visible when you run `mkdocs serve`
-- if you already had this running, you should see that the CSS changes were
-automatically picked up and the documentation will be updated.
+After making these changes, they should be visible when you run
+`mkdocs serve` - if you already had this running, you should see that the CSS
+changes were automatically picked up and the documentation will be updated.
 
 [ReadTheDocs]: ./deploying-your-docs.md#readthedocs
 [documentation directory]: /user-guide/configuration/#docs_dir

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -6,7 +6,11 @@ How to write and layout your markdown source files.
 
 ## Configure Pages and Navigation
 
-The [pages configuration](/user-guide/configuration.md#pages) in your `mkdocs.yml` defines which pages are built by MkDocs and how they appear in the documentation navigation. If not provided, the pages configuration will be automatically created by discovering all the Markdown files in the [documentation directory](/user-guide/configuration.md#docs_dir).
+The [pages configuration](/user-guide/configuration.md#pages) in your
+`mkdocs.yml` defines which pages are built by MkDocs and how they appear in the
+documentation navigation. If not provided, the pages configuration will be
+automatically created by discovering all the Markdown files in the
+[documentation directory](/user-guide/configuration.md#docs_dir).
 
 A simple pages configuration looks like this:
 
@@ -16,7 +20,11 @@ pages:
 - 'about.md'
 ```
 
-With this example we will build two pages at the top level and they will automatically have their titles inferred from the filename. Assuming `docs_dir` has the default value, `docs`, the source files for this documentation would be `docs/index.md` and `docs/about.md`. To provide a custom name for these pages, they can be added before the filename.
+With this example we will build two pages at the top level and they will
+automatically have their titles inferred from the filename. Assuming `docs_dir`
+has the default value, `docs`, the source files for this documentation would be
+`docs/index.md` and `docs/about.md`. To provide a custom name for these pages,
+they can be added before the filename.
 
 ```no-highlight
 pages:
@@ -26,7 +34,8 @@ pages:
 
 ### Multilevel documentation
 
-Subsections can be created by listing related pages together under a section title. For example:
+Subsections can be created by listing related pages together under a section
+title. For example:
 
 ```no-highlight
 pages:
@@ -39,12 +48,17 @@ pages:
     - 'Release Notes': 'about/release-notes.md'
 ```
 
-With the above configuration we have three top level sections: Home, User Guide and About. Then under User Guide we have two pages, Writing your docs and Styling your docs. Under the About section we also have two pages, License and Release Notes.
-
+With the above configuration we have three top level sections: Home, User Guide
+and About. Then under User Guide we have two pages, Writing your docs and
+Styling your docs. Under the About section we also have two pages, License and
+Release Notes.
 
 ## File layout
 
-Your documentation source should be written as regular Markdown files, and placed in a directory somewhere in your project.  Normally this directory will be named `docs` and will exist at the top level of your project, alongside the `mkdocs.yml` configuration file.
+Your documentation source should be written as regular Markdown files, and
+placed in a directory somewhere in your project. Normally this directory will be
+named `docs` and will exist at the top level of your project, alongside the
+`mkdocs.yml` configuration file.
 
 The simplest project you can create will look something like this:
 
@@ -54,9 +68,12 @@ docs/
     index.md
 ```
 
-By convention your project homepage should always be named `index`.  Any of the following extensions may be used for your Markdown source files: `markdown`, `mdown`, `mkdn`, `mkd`, `md`.
+By convention your project homepage should always be named `index`. Any of the
+following extensions may be used for your Markdown source files: `markdown`,
+`mdown`, `mkdn`, `mkd`, `md`.
 
-You can also create multi-page documentation, by creating several markdown files:
+You can also create multi-page documentation, by creating several markdown
+files:
 
 ```no-highlight
 mkdocs.yml
@@ -66,8 +83,8 @@ docs/
     license.md
 ```
 
-The file layout you use determines the URLs that are used for the generated pages.
-Given the above layout, pages would be generated for the following URLs:
+The file layout you use determines the URLs that are used for the generated
+pages. Given the above layout, pages would be generated for the following URLs:
 
 ```no-highlight
 /
@@ -75,7 +92,8 @@ Given the above layout, pages would be generated for the following URLs:
 /license/
 ```
 
-You can also include your Markdown files in nested directories if that better suits your documentation layout.
+You can also include your Markdown files in nested directories if that better
+suits your documentation layout.
 
 ```no-highlight
 docs/
@@ -85,7 +103,8 @@ docs/
     license.md
 ```
 
-Source files inside nested directories will cause pages to be generated with nested URLs, like so:
+Source files inside nested directories will cause pages to be generated with
+nested URLs, like so:
 
 ```no-highlight
 /
@@ -94,34 +113,47 @@ Source files inside nested directories will cause pages to be generated with nes
 /license/
 ```
 
-
 ## Linking documents
 
-MkDocs allows you to interlink your documentation by using regular Markdown hyperlinks.
+MkDocs allows you to interlink your documentation by using regular Markdown
+hyperlinks.
 
-#### Internal hyperlinks
+### Internal hyperlinks
 
-When linking between pages in the documentation you can simply use the regular Markdown hyperlinking syntax, including the relative path to the Markdown document you wish to link to.
+When linking between pages in the documentation you can simply use the regular
+Markdown hyperlinking syntax, including the relative path to the Markdown
+document you wish to link to.
 
     Please see the [project license](license.md) for further details.
 
-When the MkDocs build runs, these hyperlinks will automatically be transformed into a hyperlink to the appropriate HTML page.
+When the MkDocs build runs, these hyperlinks will automatically be transformed
+into a hyperlink to the appropriate HTML page.
 
-When working on your documentation you should be able to open the linked Markdown document in a new editor window simply by clicking on the link.
+When working on your documentation you should be able to open the linked
+Markdown document in a new editor window simply by clicking on the link.
 
-If the target documentation file is in another directory you'll need to make sure to include any relative directory path in the hyperlink.
+If the target documentation file is in another directory you'll need to make
+sure to include any relative directory path in the hyperlink.
 
     Please see the [project license](../about/license.md) for further details.
 
-You can also link to a section within a target documentation page by using an anchor link.  The generated HTML will correctly transform the path portion of the hyperlink, and leave the anchor portion intact.
+You can also link to a section within a target documentation page by using an
+anchor link. The generated HTML will correctly transform the path portion of the
+hyperlink, and leave the anchor portion intact.
 
     Please see the [project license](about.md#license) for further details.
 
 ## Images and media
 
-As well as the Markdown source files, you can also include other file types in your documentation, which will be copied across when generating your documentation site.  These might include images and other media.
+As well as the Markdown source files, you can also include other file types in
+your documentation, which will be copied across when generating your
+documentation site. These might include images and other media.
 
-For example, if your project documentation needed to include a [GitHub pages CNAME file](https://help.github.com/articles/setting-up-a-custom-domain-with-pages#setting-the-domain-in-your-repo) and a PNG formatted screenshot image then your file layout might look as follows:
+For example, if your project documentation needed to include a [GitHub pages
+CNAME
+file](https://help.github.com/articles/setting-up-a-custom-domain-with-pages#setting-the-domain-in-your-repo)
+and a PNG formatted screenshot image then your file layout might look as
+follows:
 
 ```no-highlight
 mkdocs.yml
@@ -134,7 +166,8 @@ docs/
         screenshot.png
 ```
 
-To include images in your documentation source files, simply use any of the regular Markdown image syntaxes:
+To include images in your documentation source files, simply use any of the
+regular Markdown image syntaxes:
 
 ```Markdown
 Cupcake indexer is a snazzy new project for indexing small cakes.
@@ -144,13 +177,14 @@ Cupcake indexer is a snazzy new project for indexing small cakes.
 *Above: Cupcake indexer in progress*
 ```
 
-You image will now be embedded when you build the documentation, and should also be previewed if you're working on the documentation with a Markdown editor.
+You image will now be embedded when you build the documentation, and should also
+be previewed if you're working on the documentation with a Markdown editor.
 
 ## Markdown extensions
 
 MkDocs supports the following Markdown extensions.
 
-#### Tables
+### Tables
 
 A simple table looks like this:
 
@@ -179,25 +213,27 @@ Left         | Center        | Right
 Left         | Center        | Right
 ```
 
-#### Fenced code blocks
+### Fenced code blocks
 
-Start with a line containing 3 or more backtick \` characters, and ends with the first line with the same number of backticks \`:
+The first line should contain 3 or more backtick (`` ` ``) characters, and the
+last line should contain the same number of backtick characters (`` ` ``):
 
-```no-highlight
- ```
- Fenced code blocks are like Stardard
- Markdown’s regular code blocks, except that
- they’re not indented and instead rely on a
- start and end fence lines to delimit the code
- block.
- ```
+~~~no-highlight
 ```
-
-With the approach, the language can be specified on the first line after the backticks:
-
-```no-highlight
- ```python
- def fn():
-     pass
- ```
+Fenced code blocks are like Stardard
+Markdown’s regular code blocks, except that
+they’re not indented and instead rely on
+start and end fence lines to delimit the
+code block.
 ```
+~~~
+
+With this approach, the language can optionally be specified on the first line
+after the backticks:
+
+~~~no-highlight
+```python
+def fn():
+    pass
+```
+~~~

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ commands={envbindir}/flake8 mkdocs --max-line-length=119 --exclude=mkdocs/compat
 [testenv:markdown-lint]
 whitelist_externals = mdl
 passenv = *
-commands=mdl docs
+commands=mdl README.md CONTRIBUTING.md docs/


### PR DESCRIPTION
Also added README.md and CONTRIBUTING.md to the linter.

Note, that I am still getting one failer (in two locations). However
I consider that failer a bug in the linter and have reported it
upstream. We could disable that Rule (MD031), but as we are not
requiring the lint rules to pass presently, I just left it alone.

Also, while the code linter is set to allow lines 119 chars long,
I am using the Markdown linter's default of 80. Prose is easier to
read with shorter line lenghts, so I think it makes more sense to
use the default. Also, changing the default would have required
adding a config file. Adding a Ruby file for only one minor setting
seems silly, so I left it alone.