### PR TITLE
Disable the warning for unicode_literals in Click and Python 2

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -14,6 +14,11 @@ from mkdocs.commands import build, gh_deploy, new, serve
 
 log = logging.getLogger(__name__)
 
+# Disable the warning that Click displays (as of Click version 5.0) when users
+# use unicode_literals in Python 2.
+# See http://click.pocoo.org/dev/python3/#unicode-literals for more details.
+click.disable_unicode_literals_warning = True
+
 
 class State(object):
     ''' Maintain logging level.'''


### PR DESCRIPTION
Closes #703