### PR TITLE
Refactor markdown loading

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -153,30 +153,16 @@ def build_template(template_name, env, config, site_navigation=None):
 
 def _build_page(page, config, site_navigation, env, dump_json):
 
-    # Read the input file
-    input_path = os.path.join(config['docs_dir'], page.input_path)
-
-    try:
-        input_content = io.open(input_path, 'r', encoding='utf-8').read()
-    except IOError:
-        log.error('file not found: %s', input_path)
-        raise
-
-    # Process the markdown text
-    html_content, table_of_contents, meta = convert_markdown(
-        markdown_source=input_content,
-        config=config,
-        site_navigation=site_navigation
-    )
+    html_content, toc = convert_markdown(page.markdown, config, site_navigation)
 
     context = get_global_context(site_navigation, config)
     context.update(get_page_context(
-        page, html_content, table_of_contents, meta, config
+        page, html_content, toc, page.meta, config
     ))
 
     # Allow 'template:' override in md source files.
-    if 'template' in meta:
-        template = env.get_template(meta['template'][0])
+    if 'template' in page.meta:
+        template = env.get_template(page.meta['template'][0])
     else:
         template = env.get_template('base.html')
 
@@ -197,7 +183,7 @@ def _build_page(page, config, site_navigation, env, dump_json):
     else:
         utils.write_file(output_content.encode('utf-8'), output_path)
 
-    return html_content, table_of_contents, meta
+    return html_content, toc, page.meta
 
 
 def build_extra_templates(extra_templates, config, site_navigation=None):

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -1,8 +1,15 @@
-from __future__ import unicode_literals
-import textwrap
-import markdown
+#!/usr/bin/env python
+# coding: utf-8
 
-from mkdocs import toc
+from __future__ import unicode_literals
+
+import textwrap
+import unittest
+
+import markdown
+import mock
+
+from mkdocs import toc, config
 
 
 def dedent(text):
@@ -14,3 +21,28 @@ def markdown_to_toc(markdown_source):
     md.convert(markdown_source)
     toc_output = md.toc
     return toc.TableOfContents(toc_output)
+
+
+def load_config(**cfg):
+    """ Helper to build a simple config for testing. """
+    cfg = cfg or {}
+    if 'site_name' not in cfg:
+        cfg['site_name'] = 'Example'
+    conf = config.Config(schema=config.DEFAULT_SCHEMA)
+    conf.load_dict(cfg)
+
+    errors_warnings = conf.validate()
+    assert(errors_warnings == ([], [])), errors_warnings
+    return conf
+
+
+class MockedMarkdownLoadingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.patch_open = mock.patch("mkdocs.nav.Page.load_markdown",
+                                     autospec=True)
+        self.mock_open = self.patch_open.start()
+        self.mock_open.return_value = ("", {},)
+
+    def tearDown(self):
+        self.patch_open.stop()

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import os
 import shutil
 import tempfile
-import unittest
 import mock
 
 try:
@@ -15,39 +14,26 @@ except ImportError:
     pass
 
 
-from mkdocs import nav, config
+from mkdocs import nav
 from mkdocs.commands import build
 from mkdocs.exceptions import MarkdownNotFound
-from mkdocs.tests.base import dedent
+from mkdocs.tests.base import (dedent, MockedMarkdownLoadingTestCase,
+                               load_config)
 
 
-def load_config(cfg=None):
-    """ Helper to build a simple config for testing. """
-    cfg = cfg or {}
-    if 'site_name' not in cfg:
-        cfg['site_name'] = 'Example'
-    conf = config.Config(schema=config.DEFAULT_SCHEMA)
-    conf.load_dict(cfg)
-
-    errors_warnings = conf.validate()
-    assert(errors_warnings == ([], [])), errors_warnings
-    return conf
-
-
-class BuildTests(unittest.TestCase):
+class BuildTests(MockedMarkdownLoadingTestCase):
 
     def test_empty_document(self):
-        html, toc, meta = build.convert_markdown("", load_config())
+        html, toc = build.convert_markdown("", load_config())
 
         self.assertEqual(html, '')
         self.assertEqual(len(list(toc)), 0)
-        self.assertEqual(meta, {})
 
     def test_convert_markdown(self):
         """
         Ensure that basic Markdown -> HTML and TOC works.
         """
-        html, toc, meta = build.convert_markdown(dedent("""
+        html, toc = build.convert_markdown(dedent("""
             page_title: custom title
 
             # Heading 1
@@ -71,45 +57,42 @@ class BuildTests(unittest.TestCase):
             Heading 2 - #heading-2
         """)
 
-        expected_meta = {'page_title': ['custom title']}
-
         self.assertEqual(html.strip(), expected_html)
         self.assertEqual(str(toc).strip(), expected_toc)
-        self.assertEqual(meta, expected_meta)
 
     def test_convert_internal_link(self):
         md_text = 'An [internal link](internal.md) to another document.'
         expected = '<p>An <a href="internal/">internal link</a> to another document.</p>'
-        html, toc, meta = build.convert_markdown(md_text, load_config())
+        html, toc = build.convert_markdown(md_text, load_config())
         self.assertEqual(html.strip(), expected.strip())
 
     def test_convert_multiple_internal_links(self):
         md_text = '[First link](first.md) [second link](second.md).'
         expected = '<p><a href="first/">First link</a> <a href="second/">second link</a>.</p>'
-        html, toc, meta = build.convert_markdown(md_text, load_config())
+        html, toc = build.convert_markdown(md_text, load_config())
         self.assertEqual(html.strip(), expected.strip())
 
     def test_convert_internal_link_differing_directory(self):
         md_text = 'An [internal link](../internal.md) to another document.'
         expected = '<p>An <a href="../internal/">internal link</a> to another document.</p>'
-        html, toc, meta = build.convert_markdown(md_text, load_config())
+        html, toc = build.convert_markdown(md_text, load_config())
         self.assertEqual(html.strip(), expected.strip())
 
     def test_convert_internal_link_with_anchor(self):
         md_text = 'An [internal link](internal.md#section1.1) to another document.'
         expected = '<p>An <a href="internal/#section1.1">internal link</a> to another document.</p>'
-        html, toc, meta = build.convert_markdown(md_text, load_config())
+        html, toc = build.convert_markdown(md_text, load_config())
         self.assertEqual(html.strip(), expected.strip())
 
     def test_convert_internal_media(self):
         """Test relative image URL's are the same for different base_urls"""
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'internal.md',
             'sub/internal.md',
-        ]
+        ])
 
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
 
         expected_results = (
             './img/initial-layout.png',
@@ -121,18 +104,18 @@ class BuildTests(unittest.TestCase):
 
         for (page, expected) in zip(site_navigation.walk_pages(), expected_results):
             md_text = '![The initial MkDocs layout](img/initial-layout.png)'
-            html, _, _ = build.convert_markdown(md_text, load_config(), site_navigation=site_navigation)
+            html, _ = build.convert_markdown(md_text, load_config(), site_navigation=site_navigation)
             self.assertEqual(html, template % expected)
 
     def test_convert_internal_asbolute_media(self):
         """Test absolute image URL's are correct for different base_urls"""
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'internal.md',
             'sub/internal.md',
-        ]
+        ])
 
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
 
         expected_results = (
             './img/initial-layout.png',
@@ -144,17 +127,17 @@ class BuildTests(unittest.TestCase):
 
         for (page, expected) in zip(site_navigation.walk_pages(), expected_results):
             md_text = '![The initial MkDocs layout](/img/initial-layout.png)'
-            html, _, _ = build.convert_markdown(md_text, load_config(), site_navigation=site_navigation)
+            html, _ = build.convert_markdown(md_text, load_config(), site_navigation=site_navigation)
             self.assertEqual(html, template % expected)
 
     def test_dont_convert_code_block_urls(self):
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'internal.md',
             'sub/internal.md',
-        ]
+        ])
 
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
 
         expected = dedent("""
         <p>An HTML Anchor::</p>
@@ -164,37 +147,41 @@ class BuildTests(unittest.TestCase):
 
         for page in site_navigation.walk_pages():
             markdown = 'An HTML Anchor::\n\n    <a href="index.md">My example link</a>\n'
-            html, _, _ = build.convert_markdown(markdown, load_config(), site_navigation=site_navigation)
+            html, _ = build.convert_markdown(markdown, load_config(), site_navigation=site_navigation)
             self.assertEqual(dedent(html), expected)
 
     def test_anchor_only_link(self):
-        pages = [
+        config = load_config(pages=[
             'index.md',
             'internal.md',
             'sub/internal.md',
-        ]
+        ])
 
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(config['pages'])
 
         for page in site_navigation.walk_pages():
             markdown = '[test](#test)'
-            html, _, _ = build.convert_markdown(markdown, load_config(), site_navigation=site_navigation)
+            html, _ = build.convert_markdown(
+                markdown, load_config(), site_navigation=site_navigation)
             self.assertEqual(html, '<p><a href="#test">test</a></p>')
 
     def test_ignore_external_link(self):
         md_text = 'An [external link](http://example.com/external.md).'
-        expected = '<p>An <a href="http://example.com/external.md">external link</a>.</p>'
-        html, toc, meta = build.convert_markdown(md_text, load_config())
+        expected = ('<p>An <a href="http://example.com/external.md">external '
+                    'link</a>.</p>')
+        html, toc = build.convert_markdown(md_text, load_config())
         self.assertEqual(html.strip(), expected.strip())
 
     def test_not_use_directory_urls(self):
         md_text = 'An [internal link](internal.md) to another document.'
-        expected = '<p>An <a href="internal/index.html">internal link</a> to another document.</p>'
-        pages = [
+        expected = ('<p>An <a href="internal/index.html">internal link</a> to '
+                    'another document.</p>')
+        config = load_config(pages=[
             'internal.md',
-        ]
-        site_navigation = nav.SiteNavigation(pages, use_directory_urls=False)
-        html, toc, meta = build.convert_markdown(md_text, load_config(), site_navigation=site_navigation)
+        ])
+        site_navigation = nav.SiteNavigation(config['pages'],
+                                             use_directory_urls=False)
+        html, toc = build.convert_markdown(md_text, config, site_navigation)
         self.assertEqual(html.strip(), expected.strip())
 
     def test_ignore_email_links(self):
@@ -206,14 +193,14 @@ class BuildTests(unittest.TestCase):
             '&#107;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;',
             '</a> and an <a href="mailto:example@example.com">link</a>.</p>'
         ])
-        html, toc, meta = build.convert_markdown(md_text, load_config())
+        html, toc = build.convert_markdown(md_text, load_config())
         self.assertEqual(html.strip(), expected.strip())
 
     def test_markdown_table_extension(self):
         """
         Ensure that the table extension is supported.
         """
-        html, toc, meta = build.convert_markdown(dedent("""
+        html, toc = build.convert_markdown(dedent("""
         First Header   | Second Header
         -------------- | --------------
         Content Cell 1 | Content Cell 2
@@ -247,7 +234,7 @@ class BuildTests(unittest.TestCase):
         """
         Ensure that the fenced code extension is supported.
         """
-        html, toc, meta = build.convert_markdown(dedent("""
+        html, toc = build.convert_markdown(dedent("""
         ```
         print 'foo'
         ```
@@ -268,26 +255,22 @@ class BuildTests(unittest.TestCase):
 
         # Check that the plugin is not active when not requested.
         expected_without_smartstrong = "<p>foo<strong>bar</strong>baz</p>"
-        html_base, _, _ = build.convert_markdown(md_input, load_config())
+        html_base, _ = build.convert_markdown(md_input, load_config())
         self.assertEqual(html_base.strip(), expected_without_smartstrong)
 
         # Check that the plugin is active when requested.
-        cfg = load_config({
-            'markdown_extensions': ['smart_strong']
-        })
+        cfg = load_config(markdown_extensions=['smart_strong'])
         expected_with_smartstrong = "<p>foo__bar__baz</p>"
-        html_ext, _, _ = build.convert_markdown(md_input, cfg)
+        html_ext, _ = build.convert_markdown(md_input, cfg)
         self.assertEqual(html_ext.strip(), expected_with_smartstrong)
 
     def test_markdown_duplicate_custom_extension(self):
         """
         Duplicated extension names should not cause problems.
         """
-        cfg = load_config({
-            'markdown_extensions': ['toc']
-        })
+        cfg = load_config(markdown_extensions=['toc'])
         md_input = "foo"
-        html_ext, _, _ = build.convert_markdown(md_input, cfg)
+        html_ext, _ = build.convert_markdown(md_input, cfg)
         self.assertEqual(html_ext.strip(), '<p>foo</p>')
 
     def test_copying_media(self):
@@ -313,10 +296,10 @@ class BuildTests(unittest.TestCase):
             os.mkdir(os.path.join(docs_dir, '.git'))
             open(os.path.join(docs_dir, '.git/hidden'), 'w').close()
 
-            cfg = load_config({
-                'docs_dir': docs_dir,
-                'site_dir': site_dir
-            })
+            cfg = load_config(
+                docs_dir=docs_dir,
+                site_dir=site_dir
+            )
             build.build(cfg)
 
             # Verify only the markdown (coverted to html) and the image are copied.
@@ -328,54 +311,16 @@ class BuildTests(unittest.TestCase):
             shutil.rmtree(docs_dir)
             shutil.rmtree(site_dir)
 
-    def test_strict_mode_valid(self):
-        pages = [
-            'index.md',
-            'internal.md',
-            'sub/internal.md',
-        ]
-        site_nav = nav.SiteNavigation(pages)
-
-        valid = "[test](internal.md)"
-        build.convert_markdown(valid, load_config({'strict': False}), site_nav)
-        build.convert_markdown(valid, load_config({'strict': True}), site_nav)
-
-    def test_strict_mode_invalid(self):
-        pages = [
-            'index.md',
-            'internal.md',
-            'sub/internal.md',
-        ]
-        site_nav = nav.SiteNavigation(pages)
-
-        invalid = "[test](bad_link.md)"
-        build.convert_markdown(invalid, load_config({'strict': False}), site_nav)
-
-        self.assertRaises(
-            MarkdownNotFound,
-            build.convert_markdown, invalid, load_config({'strict': True}), site_nav)
-
-    def test_absolute_link(self):
-        pages = [
-            'index.md',
-            'sub/index.md',
-        ]
-        site_nav = nav.SiteNavigation(pages)
-
-        markdown = "[test 1](/index.md) [test 2](/sub/index.md)"
-        cfg = load_config({'strict': True})
-        build.convert_markdown(markdown, cfg, site_nav)
-
     def test_extension_config(self):
         """
         Test that a dictionary of 'markdown_extensions' is recognized as
         both a list of extensions and a dictionary of extnesion configs.
         """
-        cfg = load_config({
-            'markdown_extensions': [{'toc': {'permalink': True}}]
-        })
+        cfg = load_config(
+            markdown_extensions=[{'toc': {'permalink': True}}]
+        )
 
-        html, toc, meta = build.convert_markdown(dedent("""
+        html, toc = build.convert_markdown(dedent("""
         # A Header
         """), cfg)
 
@@ -388,13 +333,56 @@ class BuildTests(unittest.TestCase):
     def test_extra_context(self):
 
         # Same as the default schema, but don't verify the docs_dir exists.
-        cfg = load_config({
-            'site_name': "Site",
-            'extra': {
+        cfg = load_config(
+            site_name="Site",
+            extra={
                 'a': 1
             }
-        })
+        )
 
         context = build.get_global_context(mock.Mock(), cfg)
 
         self.assertEqual(context['config']['extra']['a'], 1)
+
+
+class TestLegacyPagesConfig(MockedMarkdownLoadingTestCase):
+
+    def test_strict_mode_valid(self):
+        config = load_config(pages=[
+            'index.md',
+            'internal.md',
+            'sub/internal.md',
+        ], strict=False)
+
+        site_nav = nav.SiteNavigation(config['pages'])
+        valid = "[test](internal.md)"
+        build.convert_markdown(valid, config, site_nav)
+
+        config['strict'] = True
+        build.convert_markdown(valid, config, site_nav)
+
+    def test_strict_mode_invalid(self):
+        config = load_config(pages=[
+            'index.md',
+            'internal.md',
+            'sub/internal.md',
+        ])
+        site_nav = nav.SiteNavigation(config['pages'])
+
+        invalid = "[test](bad_link.md)"
+        build.convert_markdown(invalid, config, site_nav)
+
+        config['strict'] = True
+        self.assertRaises(
+            MarkdownNotFound,
+            build.convert_markdown, invalid, config, site_nav)
+
+    def test_absolute_link(self):
+        config = load_config(pages=[
+            'index.md',
+            'sub/index.md',
+        ], strict=True)
+        site_nav = nav.SiteNavigation(config['pages'])
+
+        markdown = "[test 1](/index.md) [test 2](/sub/index.md)"
+        build.convert_markdown(markdown, config, site_nav)

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
 
 import os
@@ -274,13 +277,21 @@ class ExtrasTest(unittest.TestCase):
 
 class PagesTest(unittest.TestCase):
 
+    def setUp(self):
+
+        self.config = {
+            'extra_stuff': [],
+            'use_directory_urls': False,
+            'docs_dir': 'docs',
+        }
+
     def test_provided(self):
 
         option = config_options.Pages()
         value = option.validate([['index.md', ], ])
         self.assertEqual(['index.md', ], value)
 
-        option.post_validation({'extra_stuff': []}, 'extra_stuff')
+        option.post_validation(self.config, 'extra_stuff')
 
     def test_provided_dict(self):
 
@@ -291,7 +302,7 @@ class PagesTest(unittest.TestCase):
         ])
         self.assertEqual(['index.md', {'Page': 'page.md'}], value)
 
-        option.post_validation({'extra_stuff': []}, 'extra_stuff')
+        option.post_validation(self.config, 'extra_stuff')
 
     def test_provided_empty(self):
 
@@ -299,7 +310,7 @@ class PagesTest(unittest.TestCase):
         value = option.validate([])
         self.assertEqual(None, value)
 
-        option.post_validation({'extra_stuff': []}, 'extra_stuff')
+        option.post_validation(self.config, 'extra_stuff')
 
     def test_invalid_type(self):
 

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: utf-8
+
 from __future__ import unicode_literals
 
 import unittest

--- a/mkdocs/tests/new_tests.py
+++ b/mkdocs/tests/new_tests.py
@@ -2,27 +2,36 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
+import os
+import shutil
 import tempfile
 import unittest
-import os
 
 from mkdocs.commands import new
 
 
 class NewTests(unittest.TestCase):
 
-    def test_new(self):
+    def setUp(self):
 
-        tempdir = tempfile.mkdtemp()
-        os.chdir(tempdir)
+        self.old_cwd = os.getcwd()
+        self.tempdir = tempfile.mkdtemp()
+        os.chdir(self.tempdir)
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.tempdir)
+
+    def test_new(self):
 
         new.new("myproject")
 
         expected_paths = [
-            os.path.join(tempdir, "myproject"),
-            os.path.join(tempdir, "myproject", "mkdocs.yml"),
-            os.path.join(tempdir, "myproject", "docs"),
-            os.path.join(tempdir, "myproject", "docs", "index.md"),
+            os.path.join(self.tempdir, "myproject"),
+            os.path.join(self.tempdir, "myproject", "mkdocs.yml"),
+            os.path.join(self.tempdir, "myproject", "docs"),
+            os.path.join(self.tempdir, "myproject", "docs", "index.md"),
         ]
 
         for expected_path in expected_paths:

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -2,11 +2,12 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 import unittest
 
 from mkdocs import nav
 from mkdocs import search
-from mkdocs.tests.base import dedent, markdown_to_toc
+from mkdocs.tests.base import dedent, markdown_to_toc, load_config
 
 
 def strip_whitespace(string):
@@ -106,9 +107,11 @@ class SearchTests(unittest.TestCase):
 
         pages = [
             {'Home': 'index.md'},
-            {'About': 'about.md'},
+            {'About': 'about/license.md'},
         ]
-        site_navigation = nav.SiteNavigation(pages)
+        site_navigation = nav.SiteNavigation(pages, load_config(
+            pages=pages
+        ))
 
         md = dedent("""
         # Heading 1

--- a/mkdocs/tests/utils/ghp_import_tests.py
+++ b/mkdocs/tests/utils/ghp_import_tests.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# coding: utf-8
-
 from __future__ import unicode_literals
 
 import mock

--- a/mkdocs/tests/utils/mdutils_tests.py
+++ b/mkdocs/tests/utils/mdutils_tests.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from mkdocs.utils import mdutils
+
+
+class MDUtilsTests(TestCase):
+
+    def test_simple(self):
+
+        markdown = """
+        # The title
+        """
+
+        title = mdutils.get_markdown_title(markdown)
+
+        self.assertEqual(title, "The title")
+
+    def test_no_title(self):
+
+        markdown = """
+        Some markdown content
+        """
+
+        title = mdutils.get_markdown_title(markdown)
+
+        self.assertEqual(title, None)
+
+    def test_title_not_at_the_start(self):
+
+        markdown = """
+        Some markdown content
+
+        # Title
+        """
+
+        title = mdutils.get_markdown_title(markdown)
+
+        self.assertEqual(title, None)
+
+    def test_h2_not_h1(self):
+
+        markdown = """
+        ## Title
+        """
+
+        title = mdutils.get_markdown_title(markdown)
+
+        self.assertEqual(title, None)
+
+    def test_whitespace_before_title(self):
+
+        markdown = """
+            \n# Title
+        """
+
+        title = mdutils.get_markdown_title(markdown)
+
+        self.assertEqual(title, "Title")

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -15,6 +15,7 @@ import os
 import pkg_resources
 import shutil
 import sys
+
 import yaml
 
 from mkdocs import toc, exceptions
@@ -338,15 +339,14 @@ def convert_markdown(markdown_source, extensions=None, extension_configs=None):
     )
     html_content = md.convert(markdown_source)
 
-    # On completely blank markdown files, no Meta or tox properties are added
+    # On completely blank markdown files, no toc property is added
     # to the generated document.
-    meta = getattr(md, 'Meta', {})
     toc_html = getattr(md, 'toc', '')
 
     # Post process the generated table of contents into a data structure
     table_of_contents = toc.TableOfContents(toc_html)
 
-    return (html_content, table_of_contents, meta)
+    return (html_content, table_of_contents)
 
 
 def get_themes():
@@ -413,20 +413,20 @@ def find_or_create_node(branch, key):
     return new_branch
 
 
-def nest_paths(paths):
+def nest_pages(pages):
     """
-    Given a list of paths, convert them into a nested structure that will match
+    Given a list of pages, convert them into a nested structure that will match
     the pages config.
     """
     nested = []
 
-    for path in paths:
+    for page in pages:
 
-        if os.path.sep not in path:
-            nested.append(path)
+        if os.path.sep not in page.input_path:
+            nested.append(page)
             continue
 
-        directory, _ = os.path.split(path)
+        directory, _ = os.path.split(page.input_path)
         parts = directory.split(os.path.sep)
 
         branch = nested
@@ -434,6 +434,6 @@ def nest_paths(paths):
             part = filename_to_title(part)
             branch = find_or_create_node(branch, part)
 
-        branch.append(path)
+        branch.append(page)
 
     return nested

--- a/mkdocs/utils/mdutils.py
+++ b/mkdocs/utils/mdutils.py
@@ -1,0 +1,23 @@
+def get_markdown_title(markdown):
+    """
+    Get the title of a Markdown document. The title in this case is considered
+    to be a H1 that occurs before any other content in the document.
+
+    The procedure is then to iterate through the lines, stopping at the first
+    non-whitespace content. If it is a title, return that, otherwise return
+    None.
+    """
+
+    lines = markdown.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+
+    while lines:
+
+        line = lines.pop(0).strip()
+
+        if not line.strip():
+            continue
+
+        if not line.startswith('# '):
+            return
+
+        return line.lstrip('# ')

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -1,0 +1,176 @@
+"""
+Copyright (c) 2015, Waylan Limberg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or other
+materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+MultiMarkdown Meta-Data
+
+Extracts, parses and transforms MultiMarkdown style data from documents.
+
+"""
+
+
+import re
+
+
+#####################################################################
+# Transformer Collection                                            #
+#####################################################################
+
+class TransformerCollection(object):
+    """
+    A collecton of transformers.
+
+    A transformer is a callable that accepts a single argument (the value to be transformed)
+    and returns a transformed value.
+    """
+
+    def __init__(self, items=None, default=None):
+        """
+        Create a transformer collection.
+
+        `items`: A dictionary which points to a transformer for each key (optional).
+
+        `default`: The default transformer (optional). If no default is provided,
+        then the values of unknown keys are returned unaltered.
+        """
+
+        self._registery = items or {}
+        self.default = default or (lambda v: v)
+
+    def register(self, key=None):
+        """
+        Decorator which registers a transformer for the given key.
+
+        If no key is provided, a "default" transformer is registered.
+        """
+
+        def wrap(fn):
+            if key:
+                self._registery[key] = fn
+            else:
+                self.default = fn
+            return fn
+        return wrap
+
+    def transform(self, key, value):
+        """
+        Calls the transformer for the given key and returns the transformed value.
+        """
+
+        if key in self._registery:
+            return self._registery[key](value)
+        return self.default(value)
+
+    def transform_dict(self, data):
+        """
+        Calls the transformer for each item in a dictionary and returns a new dictionary.
+        """
+
+        newdata = {}
+        for k, v in data.items():
+            newdata[k] = self.transform(k, v)
+        return newdata
+
+
+# The global default transformer collection.
+tc = TransformerCollection()
+
+
+def transformer(key=None):
+    """
+    Decorator which registers a transformer for the given key.
+
+    If no key is provided, a "default" transformer is registered.
+    """
+
+    def wrap(fn):
+        tc.register(key)(fn)
+        return fn
+    return wrap
+
+
+#####################################################################
+# Data Parser                                                       #
+#####################################################################
+
+
+BEGIN_RE = re.compile(r'^-{3}(\s.*)?')
+META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
+META_MORE_RE = re.compile(r'^([ ]{4}|\t)(\s*)(?P<value>.*)')
+END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
+
+
+def get_raw_data(doc):
+    """
+    Extract raw meta-data from a text document.
+
+    Returns a tuple of document and a data dict.
+    """
+
+    lines = doc.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+
+    if lines and BEGIN_RE.match(lines[0]):
+        lines.pop(0)
+
+    data = {}
+    key = None
+    while lines:
+        line = lines.pop(0)
+
+        if line.strip() == '' or END_RE.match(line):
+            break  # blank line or end deliminator - done
+        m1 = META_RE.match(line)
+        if m1:
+            key = m1.group('key').lower().strip()
+            value = m1.group('value').strip()
+            try:
+                data[key].append(value)
+            except KeyError:
+                data[key] = [value]
+        else:
+            m2 = META_MORE_RE.match(line)
+            if m2 and key:
+                # Add another line to existing key
+                data[key].append(m2.group('value').strip())
+            else:
+                lines.insert(0, line)
+                break  # no meta data - done
+    return '\n'.join(lines).lstrip('\n'), data
+
+
+def get_data(doc, transformers=tc):
+    """
+    Extract meta-data from a text document.
+
+    `transformers`: A TransformerCollection used to transform data values.
+
+    Returns a tuple of document and a (transformed) data dict.
+    """
+
+    doc, rawdata = get_raw_data(doc)
+    return doc, transformers.transform_dict(rawdata)


### PR DESCRIPTION
Looking again at this work I started in #627 to try and push forward some much needed internal re-factoring.

---

If you want to review this, the second commit had all the internal updates and is the interesting one. The first just includes a dependency and the last updates all the tests so they match the internal changes.

The general goal here is to load the Markdown files much earlier in the process and split the markdown from the metadata. This then means the metadata is more widely available as an attribute of the Page object, and thus the metadata for a page is available to other pages during the build.

---
##### TODO:
- [x] A number of comments inline on the code need to be addressed, see below for those
- [ ] Fix failing tests on Windows - I can't figure out what I've done to break these tests. It is somewhat strange, I am sure it is obvious but I am missing it.
