### PR TITLE
Support `yaml` as extension for the default configuration file

### DIFF
--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -99,9 +99,17 @@ class Config(utils.UserDict):
 
 def _open_config_file(config_file):
 
-    # Default to the standard config filename.
+    filenames = [
+        'mkdocs.yml',
+        'mkdocs.yaml'
+    ]
+
+    # Default to the standard config filenames.
     if config_file is None:
-        config_file = os.path.abspath('mkdocs.yml')
+        for name in filenames:
+            config_file = os.path.abspath(name)
+            if os.path.exists(config_file):
+                break
 
     log.debug("Loading configuration file: %s", config_file)
 


### PR DESCRIPTION
Since the _official file extension_ for YAML files (as stated by the maintainers of the spec) is `.yaml`, it should be supported (also see [here](http://stackoverflow.com/questions/21059124/is-it-yaml-or-yml)).

The last of the supported file names is "the default" and will be reported if missing and no other name is given.

See: https://github.com/mkdocs/mkdocs/issues/711