### PR TITLE
Provide the source file name to the JS in readthedocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -27,6 +27,7 @@
   <script>
     // Current page data
     var mkdocs_page_name = "{{ page_title }}";
+    var mkdocs_page_input_path = "{{ current_page.input_path }}";
     var mkdocs_page_url = "{{ current_page.abs_url }}";
   </script>
   {% endif %}


### PR DESCRIPTION
readthedocs.org needs the file name in order to identify the correct source file to link to the same file in other versions of the same documentation or to the source on GitHub.

See rtfd/readthedocs.org#1480 for more information.