### PR TITLE
correct site_url in sitemap

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -163,7 +163,12 @@ class URL(OptionallyRequired):
     Validate a URL by requiring a scheme is present.
     """
 
+    def __init__(self, default='', required=False):
+        super(URL, self).__init__(default, required)
+
     def run_validation(self, value):
+        if value == '':
+            return value
 
         try:
             parsed_url = utils.urlparse(value)


### PR DESCRIPTION
I'm currently getting `<loc>None/</loc>` in my sitemap, see http://help.tutorcruncher.com/sitemap.xml

I believe this should fix it however we should probably add a test, where would be the best place for the test to go?

I can see that the real solution is to set `site_url`, either mkdocs should deal better with no `site_url` or it should be required.