### PR TITLE
Add option to hide Sphinx footer

### DIFF
--- a/mkdocs/themes/readthedocs/footer.html
+++ b/mkdocs/themes/readthedocs/footer.html
@@ -19,5 +19,7 @@
     {% endif %}
   </div>
 
+  {% if hide_sphinx %}
   Built with <a href="http://www.mkdocs.org">MkDocs</a> using a <a href="https://github.com/snide/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+  {% endif %}
 </footer>


### PR DESCRIPTION
Add an option to hide the Sphinx footer. The official theme also has such an option so I thought to port it

https://github.com/snide/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/footer.html#L45
