### PR TITLE
Make 'Edit on GitHub' link point at individual pages. Addresses issue #269.

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -50,6 +50,43 @@ When set, provides a link to your GitHub or Bitbucket repository on each page.
 **default**: `'GitHub'` or `'Bitbucket'` if the `repo_url` matches those
 domains, otherwise `null`
 
+### repo_branch
+
+When set, points "Edit on GitHub" or "Edit on BitBucket" links to the specified branch
+in the repository. Common defaults are 'master' for GitHub and 'default' for BitBucket.
+
+```yaml
+repo_branch: release
+```
+
+**default**: 'master'
+
+### repo_docs_dir
+
+If your docs_dir does not reside at the root of your GitHub repository,
+and repo_link is desired, set repo_docs_dir to be the path from the repository root
+to docs_dir (inclusive). This option is not used for Bitbucket as providing
+direct view/edit links to individual files on Bitbucket is not supported here.
+
+For example, if your repository is `https://github.com/example/repository` with
+project structure of
+
+```
+stuff
+ \_ src
+ \_ docs
+    \_ concepts
+    \_ examples
+```
+
+For properly formed 'Edit on GitHub' links, set repo_docs_dir to
+
+```yaml
+repo_docs_dir: stuff/docs
+```
+
+**default**: `null` (assumes docs_dir to be at the top of the repository)
+
 ### site_description
 
 Set the site description. This will add a meta tag to the generated HTML header.

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -68,6 +68,9 @@ def get_global_context(nav, config):
         # gets passed to themes.
         'repo_url': config['repo_url'],
         'repo_name': config['repo_name'],
+        'repo_branch': config['repo_branch'],
+        'repo_docs_dir': config['repo_docs_dir'],
+        'docs_dir': config['docs_dir'],
         'nav': nav,
         'base_url': nav.url_context.make_relative('/'),
         'homepage_url': nav.homepage.url,

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -75,6 +75,14 @@ DEFAULT_SCHEMA = (
     # "GitHub" or "Bitbucket" for known url or Hostname for unknown urls.
     ('repo_name', config_options.Type(utils.string_types)),
 
+    # Path from the repo root to the docs dir (inclusive), for use with repo_url;
+    # defaults to expecting docs_dir to reside at the top of repo.
+    ('repo_docs_dir', config_options.Type(utils.string_types, default='docs')),
+
+    # Repo branch to use in the "Edit on GitHub" links,
+    # for use with repo_url; defaults to master branch.
+    ('repo_branch', config_options.Type(utils.string_types, default='master')),
+
     # Specify which css or javascript files from the docs directory should be
     # additionally included in the site. Default, List of all .css and .js
     # files in the docs dir.

--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -14,9 +14,17 @@
     <li class="wy-breadcrumbs-aside">
       {% if repo_url %}
         {% if repo_name == 'GitHub' %}
-          <a href="{{ repo_url }}" class="icon icon-github"> Edit on GitHub</a>
+          {% if current_page %}
+            <a href="{{ repo_url }}/blob/{{ repo_branch }}/{{ repo_docs_dir }}/{{ current_page.input_path }}" class="icon icon-github"> Edit on GitHub</a>
+          {% else %}
+            <a href="{{ repo_url }}" class="icon icon-github"> Edit on GitHub</a>
+          {% endif %}
         {% elif repo_name == 'Bitbucket' %}
-          <a href="{{ repo_url }}" class="icon icon-bitbucket"> Edit on BitBucket</a>
+          {% if current_page %}
+            <a href="{{ repo_url }}/src/{{ repo_branch }}/{{ repo_docs_dir }}/{{ current_page.input_path }}" class="icon icon-bitbucket"> Edit on BitBucket</a>
+          {% else %}
+            <a href="{{ repo_url }}" class="icon icon-bitbucket"> Edit on BitBucket</a>
+          {% endif %}
         {% endif %}
       {% endif %}
     </li>


### PR DESCRIPTION
This implements the last suggestion at https://github.com/mkdocs/mkdocs/issues/269#issuecomment-157217372: the 'Edit on GitHub' link takes the user to the specific page they were on (but in view, not edit mode; the user may click on the edit pen to edit). 

No change for 'Edit on Bitbucket' as their model of accessing individual files is not clear to me.

No new tests added, I couldn't think of a useful test here; docs updated. Let me know if this works for upstream, meanwhile I'm using this approach for my docs site.