### PR TITLE
Add support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python: '2.7'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
 - TOXENV=py34-integration
 - TOXENV=py34-min-req
 - TOXENV=py34-unittests
+- TOXENV=py35-integration
+- TOXENV=py35-min-req
+- TOXENV=py35-unittests
 - TOXENV=pypy-integration
 - TOXENV=pypy-min-req
 - TOXENV=pypy-unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-python: '2.7'
+python: '3.5'
 env:
 - TOXENV=py26-integration
 - TOXENV=py26-min-req

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ environment:
     - TOXENV: py34-integration
     - TOXENV: py34-min-req
     - TOXENV: py34-unittests
+    - TOXENV: py35-integration
+    - TOXENV: py35-min-req
+    - TOXENV: py35-unittests
     - TOXENV: flake8
 init:
   - "ECHO %TOXENV%"

--- a/mkdocs/search.py
+++ b/mkdocs/search.py
@@ -53,6 +53,7 @@ class SearchIndex(object):
         # us to iterate through it.
         parser = ContentParser()
         parser.feed(content)
+        parser.close()
 
         # Get the absolute URL for the page, this is then
         # prepended to the urls of the sections

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -28,6 +28,7 @@ class SearchTests(unittest.TestCase):
         parser = search.ContentParser()
 
         parser.feed('<h1 id="title">Title</h1>TEST')
+        parser.close()
 
         self.assertEquals(parser.data, [search.ContentSection(
             text=["TEST"],
@@ -40,6 +41,7 @@ class SearchTests(unittest.TestCase):
         parser = search.ContentParser()
 
         parser.feed("<h1>Title</h1>TEST")
+        parser.close()
 
         self.assertEquals(parser.data, [search.ContentSection(
             text=["TEST"],
@@ -52,6 +54,7 @@ class SearchTests(unittest.TestCase):
         parser = search.ContentParser()
 
         parser.feed("Content Before H1 <h1>Title</h1>TEST")
+        parser.close()
 
         self.assertEquals(parser.data, [search.ContentSection(
             text=["TEST"],

--- a/mkdocs/toc.py
+++ b/mkdocs/toc.py
@@ -64,6 +64,13 @@ class TOCParser(HTMLParser):
         self.in_anchor = False
         self.attrs = None
         self.title = ''
+        
+        # Prior to Python3.4 no convert_charrefs keyword existed.
+        # However, in Python3.5 the default was changed to True.
+        # We need the False behavior in all versions but can only
+        # set it if it exists.
+        if hasattr(self, 'convert_charrefs'):
+            self.convert_charrefs = False
 
     def handle_starttag(self, tag, attrs):
 

--- a/mkdocs/toc.py
+++ b/mkdocs/toc.py
@@ -64,7 +64,7 @@ class TOCParser(HTMLParser):
         self.in_anchor = False
         self.attrs = None
         self.title = ''
-        
+
         # Prior to Python3.4 no convert_charrefs keyword existed.
         # However, in Python3.5 the default was changed to True.
         # We need the False behavior in all versions but can only

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 envlist =
-    py{26,27,33,34}-{unittests,integration,min-req},
+    py{26,27,33,34,35}-{unittests,integration,min-req},
     flake8
 
 [testenv]
 passenv = LANG
 deps=
-    py{26,27,33,34,py,py3}-{unittests,integration}: -rrequirements/project.txt
-    py{26,27,33,34,py,py3}-min-req: -rrequirements/project-min.txt
-    py{26,27,33,34,py,py3}-{unittests,min-req}: -rrequirements/test.txt
+    py{26,27,33,34,35,py,py3}-{unittests,integration}: -rrequirements/project.txt
+    py{26,27,33,34,35,py,py3}-min-req: -rrequirements/project-min.txt
+    py{26,27,33,34,35,py,py3}-{unittests,min-req}: -rrequirements/test.txt
 commands=
-    py{26,27,33,34,py,py3}-{unittests,min-req}: {envbindir}/nosetests --with-coverage --cover-package mkdocs mkdocs
-    py{26,27,33,34,py,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds
+    py{26,27,33,34,35,py,py3}-{unittests,min-req}: {envbindir}/nosetests --with-coverage --cover-package mkdocs mkdocs
+    py{26,27,33,34,35,py,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds
 
 [testenv:flake8]
 deps=-rrequirements/test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands=
     py{26,27,33,34,35,py,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds
 
 [testenv:flake8]
+basepython = python2.7
 deps=-rrequirements/test.txt
 commands={envbindir}/flake8 mkdocs --max-line-length=119 --exclude=mkdocs/compat.py
 


### PR DESCRIPTION
Also include a fix for one failing test with HTMLParser. Three additional
tests are still failing for a different problem related to search.

If I work out that issue, I'll push up another commit to fix it here.