### PR TITLE
Document the `--help` flag.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,23 @@ with the `--clean` switch.
 mkdocs build --clean
 ```
 
+## Other Commands and Options
+
+There are various other commands and options available. For a complete list of
+commands, use the `--help` flag:
+
+```bash
+mkdocs --help
+```
+
+To view a list of options available on a given command, use the `--help` flag
+with that command. For example, to get a list of all options available for the
+`build` command run the following:
+
+```bash
+mkdocs build --help
+```
+
 ## Deploying
 
 The documentation site that we've just built only uses static files so you'll be


### PR DESCRIPTION
As of 40dc17e17e5, any mention of the `--help` flag had been removed from
the documentation. A breif summary has been added here. However, the output
of `--help` has not been included as that can change in the future and
updating the docs every time a option is updated become unnesecarily
duplicative (as the command line is self-documenting). This fixes #767.