### PR TITLE
Fix readthedocs theme subnav padding

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -25,8 +25,12 @@ h3, h4, h5, h6 {
     color: #838383;
 }
 
-.wy-menu-vertical .subnav a {
+.wy-menu-vertical .subnav a,
+.wy-menu-vertical .subnav li a {
     padding: 0.4045em 2.427em;
+}
+.wy-menu-vertical .subnav li.toctree-l3 a {
+    padding: 0.4045em 3.641em;
 }
 
 /*


### PR DESCRIPTION
Padding is broken when using level-3 navigation, this change fixes it.