### PR TITLE
readthedocs theme: Keep same font-size everywhere

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -1,7 +1,7 @@
 /*
  * Tweak the overal size to better match RTD.
  */
-body {
+html {
     font-size: 90%;
 }
 


### PR DESCRIPTION
The RTD CSS uses both the `html` and `p` selectors to define font size.
MkDocs used to use `body` to reduce size, which only applied to anything
else than `p`. This patch restores compatibility with RTD by using html,
not body. Fixes #801.