### PR TITLE
Remove external themes from MkDocs

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -6,13 +6,9 @@ The legal stuff.
 
 ## Included projects
 
-Themes used under license from the Bootstrap, ReadTheDocs, GhostWriter and
-Bootswatch projects.
+Themes used under license from the ReadTheDocs projects.
 
-* Bootstrap theme - [View license](//github.com/twbs/bootstrap/blob/master/LICENSE).
 * ReadTheDocs theme - [View license](//github.com/snide/sphinx_rtd_theme/blob/master/LICENSE).
-* Bootswatch theme - [View license](//github.com/thomaspark/bootswatch/blob/gh-pages/LICENSE).
-* Highlight.js GitHub theme - [View license](//github.com/isagalaev/highlight.js/blob/master/LICENSE).
 
 Many thanks to the authors and contributors of those wonderful projects.
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -52,7 +52,7 @@ details about these specific themes.
 [MkDocs Bootstrap]: http://mkdocs.github.io/mkdocs-bootstrap/
 [MkDocs Bootswatch]: http://mkdocs.github.io/mkdocs-bootswatch/
 
-They will be included with MkDocs by default until the 1.0 release. After that
+They will be included with MkDocs by default until a future release. After that
 they will be installable with pip: `pip install mkdocs-bootstrap` and `pip
 install mkdocs-bootswatch`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,11 @@ S3, or anywhere else you choose.
 
 ### Great themes available
 
-There's a stack of good looking themes included by default. Choose from
-bootstrap, readthedocs, or any of the 12 bootswatch themes.
-You can also check out a list of 3rd party themes in the
-[MkDocs wiki](https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes),
-or better yet, add your own.
+There's a stack of good looking themes available for MkDocs. Choose between
+the built in themes [mkdocs](/user-guide/styling-your-docs/#mkdocs) and
+[readthedocs](/user-guide/styling-your-docs/#readthedocs) or check out a list
+of 3rd party themes in the [MkDocs wiki](https://github.com/mkdocs/mkdocs/wiki
+/MkDocs-Themes) (or better yet, add your own).
 
 ### Preview your site as you work
 

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -4,6 +4,13 @@ A guide to creating and distributing custom themes.
 
 ---
 
+!!! Note
+
+    If you are looking for third party themes, they are listed in the MkDocs
+    [community wiki](https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes). If
+    you want to share a theme you create, you should list it on the Wiki.
+
+
 When creating a new theme, you can either follow the steps in this guide to
 create one from scratch or you can download the `mkdocs-basic-theme` as a
 basic, yet complete, theme with all the boilerplate required. **You can find

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -30,74 +30,10 @@ the [custom themes](#custom-themes) section below.
 
 ![ReadTheDocs](https://docs.readthedocs.org/en/latest/_images/screen_mobile.png)
 
-## Bootstrap and Bootswatch themes
+### Third Party Themes
 
-MkDocs version 0.x also includes themes provided by two packages, [MkDocs Bootstrap] and
-[MkDocs Bootswatch]. The Bootstrap package provides a theme based on [Bootstrap]
-and the Bootswatch package provides 12 themes based on the [Bootswatch] project.
-
-!!! note
-
-    The Bootstrap and Bootswatch themes will not be included by default from
-    MkDocs version 1.0. They will need to be installed manually with `pip
-    install mkdocs-bootstrap` or `pip install mkdocs-bootswatch`.
-
-[Bootstrap]: http://getbootstrap.com/
-[Bootswatch]: http://bootswatch.com/
-[MkDocs Bootstrap]: http://mkdocs.github.io/mkdocs-bootstrap/
-[MkDocs Bootswatch]: http://mkdocs.github.io/mkdocs-bootswatch/
-
-### Bootstrap
-
-![Bootstrap](http://bootstrapdocs.com/v2.3.1/docs/assets/img/examples/bootstrap-example-fluid.png)
-
-### Amelia
-
-![Amelia](http://bootswatch.com/2/amelia/thumbnail.png)
-
-### Cerulean
-
-![Cerulean](http://bootswatch.com/cerulean/thumbnail.png)
-
-### Cosmo
-
-![Cosmo](http://bootswatch.com/cosmo/thumbnail.png)
-
-### Cyborg
-
-![Cyborg](http://bootswatch.com/cyborg/thumbnail.png)
-
-### Flatly
-
-![Flatly](http://bootswatch.com/flatly/thumbnail.png)
-
-### Journal
-
-![Journal](http://bootswatch.com/journal/thumbnail.png)
-
-### Readable
-
-![Readable](http://bootswatch.com/readable/thumbnail.png)
-
-### Simplex
-
-![Simplex](http://bootswatch.com/simplex/thumbnail.png)
-
-### Slate
-
-![Slate](http://bootswatch.com/slate/thumbnail.png)
-
-### Spacelab
-
-![Spacelab](http://bootswatch.com/spacelab/thumbnail.png)
-
-### United
-
-![United](http://bootswatch.com/united/thumbnail.png)
-
-### Yeti
-
-![Yeti](http://bootswatch.com/yeti/thumbnail.png)
+Third party themes can be found in the MkDocs [community wiki](
+https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes).
 
 ## Customising a Theme
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -297,30 +297,29 @@ class Theme(OptionallyRequired):
     def run_validation(self, value):
         themes = utils.get_theme_names()
 
+        # These themes have been moved to the mkdocs-bootstrap and
+        # mkdocs-bootswatch packages. At some point we wont depend on
+        # these by default.
+        moved_themes = [
+            'bootstrap', 'amelia', 'cerulean', 'cosmo', 'cyborg',
+            'flatly', 'journal', 'readable', 'simplex', 'slate',
+            'spacelab', 'united', 'yeti'
+        ]
+
         if value in themes:
-
-            # These themes have been moved to the mkdocs-bootstrap and
-            # mkdocs-bootswatch packages. At some point we wont depend on
-            # these by default.
-            moved_themes = [
-                'bootstrap', 'amelia', 'cerulean', 'cosmo', 'cyborg',
-                'flatly', 'journal', 'readable', 'simplex', 'slate',
-                'spacelab', 'united', 'yeti'
-            ]
-
-            if value not in moved_themes:
-                return value
-
-            self.warnings.append(
-                ("The theme '{0}' will be removed in an upcoming MkDocs "
-                 "release. See http://www.mkdocs.org/about/release-notes/ "
-                 "for more details").format(value)
-            )
             return value
 
+        elif value in moved_themes:
+            raise ValidationError(
+                ("The theme '{0}' is no longer included in MkDocs by default "
+                 "and must be installed with pip. See http://www.mkdocs.org"
+                 "/about/release-notes/#add-support-for-installable-themes"
+                 "for more details").format(value)
+            )
+
         raise ValidationError(
-            "Unrecognised theme '{0}'. The available installed themes"
-            "are: ".format(value, ', '.join(themes))
+            "Unrecognised theme '{0}'. The available installed themes "
+            "are: {1}".format(value, ', '.join(themes))
         )
 
 

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -112,9 +112,7 @@ class UtilsTests(unittest.TestCase):
 
         self.assertEqual(
             sorted(utils.get_theme_names()),
-            sorted(['flatly', 'cerulean', 'slate', 'bootstrap', 'yeti',
-                    'spacelab', 'united', 'readable', 'simplex', 'mkdocs',
-                    'cosmo', 'journal', 'cyborg', 'readthedocs', 'amelia']))
+            ['mkdocs', 'readthedocs'])
 
     @mock.patch('pkg_resources.iter_entry_points', autospec=True)
     def test_get_themes_warning(self, mock_iter):

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -2,7 +2,5 @@ click==3.3
 Jinja2==2.7.1
 livereload==2.3.2
 Markdown==2.5
-mkdocs-bootstrap==0.1.1
-mkdocs-bootswatch==0.1.0
 PyYAML==3.10
 tornado==4.1

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -2,7 +2,5 @@ click>=3.3
 Jinja2>=2.7.1
 livereload>=2.3.2
 Markdown>=2.5
-mkdocs-bootstrap>=0.1.1
-mkdocs-bootswatch>=0.1.0
 PyYAML>=3.10
 tornado>=4.1

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,6 @@ setup(
         'Jinja2>=2.7.1',
         'livereload>=2.3.2',
         'Markdown>=2.3.1,<2.5' if PY26 else 'Markdown>=2.3.1',
-        'mkdocs-bootstrap>=0.1.1',
-        'mkdocs-bootswatch>=0.1.0',
         'PyYAML>=3.10',
         'tornado>=4.1',
     ],


### PR DESCRIPTION
This change removes the dependency on mkdocs-bootstrap and mkdocs-bootswatch.
It also updates all references in the code. The only remaining connection is
when a user specifies one of these themes but they are not installed they get
slightly helpful error.