### PR TITLE
Fix display of code blocks with `nohighlight`; resolves #855

### DIFF
--- a/mkdocs/themes/mkdocs/css/highlight.css
+++ b/mkdocs/themes/mkdocs/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs/themes/readthedocs/css/highlight.css
+++ b/mkdocs/themes/readthedocs/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -69,6 +69,18 @@ p code {
     word-wrap: break-word;
 }
 
+/**
+ * Make code blocks display as blocks and give them the appropriate
+ * font size and padding.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/855
+ */
+pre code {
+  display: block;
+  padding: 12px;
+  font-size: 12px;
+}
+
 /*
  * Fix link colors when the link text is inline code.
  *


### PR DESCRIPTION
Here are "after" screenshots (you can see the "before" in #855):

MkDocs
![MkDocs theme](https://cloud.githubusercontent.com/assets/826865/13473855/e0821e5e-e080-11e5-87c4-e2aadc138f5e.png)

ReadTheDocs
![ReadTheDocs theme](https://cloud.githubusercontent.com/assets/826865/13473847/d5735078-e080-11e5-8766-e5ba87d2f1c0.png)

One important note: this effectively reduces the padding in the MkDocs theme for code blocks, since I eliminated the double-padding. If you prefer the level of padding that it has now (I don't), I can add some more padding to *all* the code blocks so that it looks like it does currently, but is the same whether it's highlighted or not.