### PR TITLE
Remove font-size in readthedocs/theme_extra.css

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -1,16 +1,4 @@
 /*
- * Tweak the overal size to better match RTD.
- */
-html {
-    font-size: 90%;
-}
-
-h3, h4, h5, h6 {
-    color: #2980b9;
-    font-weight: 300
-}
-
-/*
  * Sphinx doesn't have support for section dividers like we do in
  * MkDocs, this styles the section titles in the nav
  *


### PR DESCRIPTION
If you do a side-by-side comparison of [docs.readthedocs.org](https://docs.readthedocs.org/en/latest/builds.html#mkdocs) you can see that mkdocs font is smaller and the colors are different for headers (mkdocs uses blue and readthedocs uses black).

This removes those two discrepancies.