### PR TITLE
Add a bit more padding to inline `code`

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -45,6 +45,7 @@
  */
 code {
     white-space: pre;
+    padding: 2px 5px;
 }
 
 /*


### PR DESCRIPTION
This matches readthedocs.org much better since there was previously 0 padding top/bottom for <code>variable</code>.
See this page for a comparison: https://docs.readthedocs.org/en/latest/i18n.html