### PR TITLE
Update default text when search is running.

### DIFF
--- a/mkdocs/themes/readthedocs/search.html
+++ b/mkdocs/themes/readthedocs/search.html
@@ -15,7 +15,7 @@
   </form>
 
   <div id="mkdocs-search-results">
-    Sorry, page not found.
+    Searching...
   </div>
 
 {% endblock %}


### PR DESCRIPTION
The search tool will replace the text with "No results found" if that is the case.
No reason to display is here. Also, the default text displays when the search 
is running (especially if the search takes a long time), so it might as well be 
accurate and indicate that the search is running. Addresses #859.