### PR TITLE
Ensure various template files are not copied with media files.

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -278,11 +278,13 @@ def build(config, live_server=False, dump_json=False, clean_site_dir=False):
         return
 
     # Reversed as we want to take the media files from the builtin theme
-    # and then from the custom theme_dir so the custom versions take take
+    # and then from the custom theme_dir so that the custom versions take
     # precedence.
     for theme_dir in reversed(config['theme_dir']):
         log.debug("Copying static assets from theme: %s", theme_dir)
-        utils.copy_media_files(theme_dir, config['site_dir'])
+        utils.copy_media_files(
+            theme_dir, config['site_dir'], exclude=['*.py', '*.pyc', '*.html']
+        )
 
     log.debug("Copying static assets from the docs dir.")
     utils.copy_media_files(config['docs_dir'], config['site_dir'])

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -294,7 +294,7 @@ class BuildTests(unittest.TestCase):
         docs_dir = tempfile.mkdtemp()
         site_dir = tempfile.mkdtemp()
         try:
-            # Create a non-empty markdown file, image, dot file and dot directory.
+            # Create a non-empty markdown file, image, html file, dot file and dot directory.
             f = open(os.path.join(docs_dir, 'index.md'), 'w')
             f.write(dedent("""
                 page_title: custom title
@@ -309,6 +309,7 @@ class BuildTests(unittest.TestCase):
             """))
             f.close()
             open(os.path.join(docs_dir, 'img.jpg'), 'w').close()
+            open(os.path.join(docs_dir, 'example.html'), 'w').close()
             open(os.path.join(docs_dir, '.hidden'), 'w').close()
             os.mkdir(os.path.join(docs_dir, '.git'))
             open(os.path.join(docs_dir, '.git/hidden'), 'w').close()
@@ -322,8 +323,44 @@ class BuildTests(unittest.TestCase):
             # Verify only the markdown (coverted to html) and the image are copied.
             self.assertTrue(os.path.isfile(os.path.join(site_dir, 'index.html')))
             self.assertTrue(os.path.isfile(os.path.join(site_dir, 'img.jpg')))
+            self.assertTrue(os.path.isfile(os.path.join(site_dir, 'example.html')))
             self.assertFalse(os.path.isfile(os.path.join(site_dir, '.hidden')))
             self.assertFalse(os.path.isfile(os.path.join(site_dir, '.git/hidden')))
+        finally:
+            shutil.rmtree(docs_dir)
+            shutil.rmtree(site_dir)
+
+    def test_copy_theme_files(self):
+        docs_dir = tempfile.mkdtemp()
+        site_dir = tempfile.mkdtemp()
+        try:
+            # Create a non-empty markdown file.
+            f = open(os.path.join(docs_dir, 'index.md'), 'w')
+            f.write(dedent("""
+                page_title: custom title
+
+                # Heading 1
+
+                This is some text.
+            """))
+            f.close()
+
+            cfg = load_config({
+                'docs_dir': docs_dir,
+                'site_dir': site_dir
+            })
+            build.build(cfg)
+
+            # Verify only theme media are copied, not templates or Python files.
+            self.assertTrue(os.path.isfile(os.path.join(site_dir, 'index.html')))
+            self.assertTrue(os.path.isdir(os.path.join(site_dir, 'js')))
+            self.assertTrue(os.path.isdir(os.path.join(site_dir, 'css')))
+            self.assertTrue(os.path.isdir(os.path.join(site_dir, 'img')))
+            self.assertFalse(os.path.isfile(os.path.join(site_dir, '__init__.py')))
+            self.assertFalse(os.path.isfile(os.path.join(site_dir, '__init__.pyc')))
+            self.assertFalse(os.path.isfile(os.path.join(site_dir, 'base.html')))
+            self.assertFalse(os.path.isfile(os.path.join(site_dir, 'content.html')))
+            self.assertFalse(os.path.isfile(os.path.join(site_dir, 'nav.html')))
         finally:
             shutil.rmtree(docs_dir)
             shutil.rmtree(site_dir)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -16,6 +16,7 @@ import pkg_resources
 import shutil
 import sys
 import yaml
+import fnmatch
 
 from mkdocs import toc, exceptions
 
@@ -128,16 +129,23 @@ def clean_directory(directory):
             os.unlink(path)
 
 
-def copy_media_files(from_dir, to_dir):
+def copy_media_files(from_dir, to_dir, exclude=None):
     """
-    Recursively copy all files except markdown and HTML into another directory.
+    Recursively copy all files except markdown and exclude[ed] files into another directory.
+
+    `exclude` accepts a list of Unix shell-style wildcards (`['*.py', '*.pyc']`).
+    Note that `exclude` only operates on file names, not directories.
     """
     for (source_dir, dirnames, filenames) in os.walk(from_dir):
         relative_path = os.path.relpath(source_dir, from_dir)
         output_dir = os.path.normpath(os.path.join(to_dir, relative_path))
 
-        # Filter filenames starting with a '.'
-        filenames = [f for f in filenames if not f.startswith('.')]
+        # Filter file names using Unix pattern matching
+        # Always filter file names starting with a '.'
+        exclude_patterns = ['.*']
+        exclude_patterns.extend(exclude or [])
+        for pattern in exclude_patterns:
+            filenames = [f for f in filenames if not fnmatch.fnmatch(f, pattern)]
 
         # Filter the dirnames that start with a '.' and update the list in
         # place to prevent us walking these.


### PR DESCRIPTION
Fixes #807. Used the fnmatch lib which supports Unix shell-style wildcard patterns (not regex). This allows patterns like `'*.py'`, `'.*'`, etc. A list of excluded patterns are passed to `mkdocs.utils.copy_media_files`. The pattern `'.*'` is included by default and not overridable.