### PR TITLE
Support gh-deloy in Python 3 on Windows.

### DIFF
--- a/mkdocs/tests/utils/ghp_import_tests.py
+++ b/mkdocs/tests/utils/ghp_import_tests.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import unittest
 import shutil
+import sys
 
 from mkdocs.utils import ghp_import
 
@@ -27,10 +28,16 @@ class UtilsTests(unittest.TestCase):
 
         ghp_import.try_rebase('origin', 'gh-pages')
 
-        mock_popen.assert_called_once_with(
-            ['git', 'rev-list', '--max-count=1', 'origin/gh-pages'],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        if sys.version_info >= (3, 2, 0):
+            mock_popen.assert_called_once_with(
+                ['git', 'rev-list', '--max-count=1', 'origin/gh-pages'],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, universal_newlines=True)
+        else:
+            mock_popen.assert_called_once_with(
+                ['git', 'rev-list', '--max-count=1', 'origin/gh-pages'],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
         mock_call.assert_called_once_with(
             ['git', 'update-ref', 'refs/heads/gh-pages',
              '4c82346e4b1b816be89dd709d35a6b169aa3df61'])
@@ -47,10 +54,16 @@ class UtilsTests(unittest.TestCase):
         result = ghp_import.get_prev_commit('test-branch')
 
         self.assertEqual(result, u'4c82346e4b1b816be89dd709d35a6b169aa3df61')
-        mock_popen.assert_called_once_with(
-            ['git', 'rev-list', '--max-count=1', 'test-branch', '--'],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        if sys.version_info >= (3, 2, 0):
+            mock_popen.assert_called_once_with(
+                ['git', 'rev-list', '--max-count=1', 'test-branch', '--'],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, universal_newlines=True)
+        else:
+            mock_popen.assert_called_once_with(
+                ['git', 'rev-list', '--max-count=1', 'test-branch', '--'],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
 
     @mock.patch('subprocess.Popen', auto_spec=True)
     def test_get_config(self, mock_popen):
@@ -63,9 +76,14 @@ class UtilsTests(unittest.TestCase):
         result = ghp_import.get_config('user.name')
 
         self.assertEqual(result, u'Dougal Matthews')
-        mock_popen.assert_called_once_with(
-            ['git', 'config', 'user.name'],
-            stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        if sys.version_info >= (3, 2, 0):
+            mock_popen.assert_called_once_with(
+                ['git', 'config', 'user.name'],
+                stdout=subprocess.PIPE, stdin=subprocess.PIPE, universal_newlines=True)
+        else:
+            mock_popen.assert_called_once_with(
+                ['git', 'config', 'user.name'],
+                stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 
     @mock.patch('mkdocs.utils.ghp_import.get_prev_commit')
     @mock.patch('mkdocs.utils.ghp_import.get_config')

--- a/mkdocs/utils/ghp_import.py
+++ b/mkdocs/utils/ghp_import.py
@@ -70,7 +70,10 @@ def normalize_path(path):
 
 def try_rebase(remote, branch):
     cmd = ['git', 'rev-list', '--max-count=1', '%s/%s' % (remote, branch)]
-    p = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
+    kwargs = {'stdin': sp.PIPE, 'stdout': sp.PIPE, 'stderr': sp.PIPE}
+    if sys.version_info >= (3, 2, 0):
+        kwargs['universal_newlines'] = True
+    p = sp.Popen(cmd, **kwargs)
     (rev, _) = p.communicate()
     if p.wait() != 0:
         return True
@@ -81,14 +84,20 @@ def try_rebase(remote, branch):
 
 
 def get_config(key):
-    p = sp.Popen(['git', 'config', key], stdin=sp.PIPE, stdout=sp.PIPE)
+    kwargs = {'stdin': sp.PIPE, 'stdout': sp.PIPE}
+    if sys.version_info >= (3, 2, 0):
+        kwargs['universal_newlines'] = True
+    p = sp.Popen(['git', 'config', key], **kwargs)
     (value, _) = p.communicate()
     return value.decode('utf-8').strip()
 
 
 def get_prev_commit(branch):
     cmd = ['git', 'rev-list', '--max-count=1', branch, '--']
-    p = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
+    kwargs = {'stdin': sp.PIPE, 'stdout': sp.PIPE, 'stderr': sp.PIPE}
+    if sys.version_info >= (3, 2, 0):
+        kwargs['universal_newlines'] = True
+    p = sp.Popen(cmd, **kwargs)
     (rev, _) = p.communicate()
     if p.wait() != 0:
         return None
@@ -141,7 +150,7 @@ def run_import(srcdir, branch, message, nojekyll):
     cmd = ['git', 'fast-import', '--date-format=raw', '--quiet']
     kwargs = {"stdin": sp.PIPE}
     if sys.version_info >= (3, 2, 0):
-        kwargs["universal_newlines"] = False
+        kwargs["universal_newlines"] = True
     pipe = sp.Popen(cmd, **kwargs)
     start_commit(pipe, branch, message)
     for path, _, fnames in os.walk(srcdir):
@@ -167,7 +176,9 @@ def ghp_import(directory, message, remote='origin', branch='gh-pages'):
 
     run_import(directory, branch, message, nojekyll)
 
-    proc = sp.Popen(['git', 'push', remote, branch],
-                    stdout=sp.PIPE, stderr=sp.PIPE)
+    kwargs = {'stdout': sp.PIPE, 'stderr': sp.PIPE}
+    if sys.version_info >= (3, 2, 0):
+        kwargs['universal_newlines'] = True
+    proc = sp.Popen(['git', 'push', remote, branch], **kwargs)
     proc.communicate()
     return proc.wait() == 0


### PR DESCRIPTION
In PY3 calls to `subprocess.Popen` must have `universal_newlines=True` so that Unicode strings are returned.

Note: I have not tested this as I have no way to. And the tests don't cover this either (they are only mock tests). We need to hear from a real person who had the problem before this fix is applied who no longer has the problem afterward.