### PR TITLE
Better alignment for current selected menu item in readthedocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -141,7 +141,7 @@ code.cs, code.c {
     padding-left: 1em;
 }
 
-.wy-menu-vertical li.current {
+.wy-menu-vertical .subnav li.current {
     margin-left: 11px;
 }
 

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -141,6 +141,9 @@ code.cs, code.c {
     padding-left: 1em;
 }
 
+.wy-menu-vertical li.current {
+    margin-left: 11px;
+}
 
 /*
  * Improve inline code blocks within admonitions.

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -141,8 +141,11 @@ code.cs, code.c {
     padding-left: 1em;
 }
 
-.wy-menu-vertical .subnav li.current {
-    margin-left: 11px;
+.wy-menu-vertical .subnav li.current > a {
+    padding-left: 2.42em;
+}
+.wy-menu-vertical .subnav li.current > ul li a {
+    padding-left: 3.23em;
 }
 
 /*


### PR DESCRIPTION
It's hard to explain why the alignment looks bad so I will show you a before and after screenshots.

### Nothing selected
This looks fine and will remain the same :+1: 

![first](https://cloud.githubusercontent.com/assets/229881/14391645/45f6298e-fd8b-11e5-83b9-9ea74a6b2dd7.png)

### Select a menu item
This looks wrong because the sub-menu item moved to the left after being clicked :open_mouth: 

![second](https://cloud.githubusercontent.com/assets/229881/14391671/6354623e-fd8b-11e5-8b60-389ea52bebda.png)

### My Fix
Here we can see that the menu item is properly aligned when it is selected :tada: 

![third](https://cloud.githubusercontent.com/assets/229881/14391679/77f5ed84-fd8b-11e5-81ca-61d224ba8aa3.png)
