### PR TITLE
Add a config file for CodeCov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch: false
+    project:
+      default: {}


### PR DESCRIPTION
CodeCov now requires that we customise it with a config file (ala Travis and
AppVeyor.). This is just the default config.