### PR TITLE
added support for removing ToC from specific file

### DIFF
--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -44,9 +44,13 @@
         {% include "nav.html" %}
 
         <div class="container">
-            {% block content %}
-                <div class="col-md-3">{% include "toc.html" %}</div>
-                <div class="col-md-9" role="main">{% include "content.html" %}</div>
+	{% block content %}
+		{% if meta.no_toc %}
+			<div class="col-md-12" role="main">{% include "content.html" %}</div>
+ 		{% else %}
+			<div class="col-md-3">{% include "toc.html" %}</div>
+			<div class="col-md-9" role="main">{% include "content.html" %}</div>
+		{% endif %}
             {% endblock %}
         </div>
 


### PR DESCRIPTION
This theme update will allow user to define a variable ```no_toc``` to disable ToC from that specific page.

This should be useful for scenario's like https://github.com/mkdocs/mkdocs/issues/700 or https://github.com/mkdocs/mkdocs/issues/900