### PR TITLE
Refactor page specific template variables.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -15,6 +15,46 @@ You can determine your currently installed version using `mkdocs --version`:
 
 ## Version 0.16 (2016-02-??)
 
+### Major Additions to Version 0.16.0
+
+#### Template variables refactored. (#874)
+
+Page specific variable names in the template context have been refactored as
+defined in [Custom Themes](../user-guide/custom-themes/#page). The
+old variable names will issue a warning but continue to work for version 0.16,
+but may be removed in a future version.
+
+No global variables were altered except `page_description`. Previously
+its value was altered programicaly based on whether the current
+page was the homepage. Now it simply maps to `config['site_description']`.
+Use `page.is_homepage` in the template to conditionally change the
+description.
+
+Any of the following old variables should be updated to the new ones in user
+created and third-party templates:
+
+| Old Variable Name | New Variable Name   |
+| ----------------- | ------------------- |
+| current_page      | [page]              |
+| page_title        | [page.title]        |
+| content           | [page.content]      |
+| toc               | [page.toc]          |
+| meta              | [page.meta]         |
+| canonical_url     | [page.canonical_url]|
+| previous_page     | [page.previous_page]|
+| next_page         | [page.next_page]    |
+
+[page]: ../user-guide/custom-themes/#page
+[page.title]: ../user-guide/custom-themes/#pagetitle
+[page.content]: ../user-guide/custom-themes/#pagecontent
+[page.toc]: ../user-guide/custom-themes/#pagetoc
+[page.meta]: ../user-guide/custom-themes/#pagemeta
+[page.canonical_url]: ../user-guide/custom-themes/#pagecanonical_url
+[page.previous_page]: ../user-guide/custom-themes/#pageprevious_page
+[page.next_page]: ../user-guide/custom-themes/#pagenext_page
+
+### Other Changes and Additions to Version 0.16.0
+
 * Bugfix: Support `gh-deploy` command on Windows with Python 3 (#722)
 * Bugfix: Include .woff2 font files in Pyhton package build (#894)
 * Various updates and improvements to Documentation Home Page/Tutorial (#870)

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -178,32 +178,28 @@ A Python datetime object that represents the date and time the documentation
 was built in UTC. This is useful for showing how recently the documentation
 was updated.
 
-### Page Context
+#### page
 
-The page context includes all of the above Global context and the following
-additional variables.
+In templates which are not rendered from a Markdown source file, the `page`
+variable is `None`. In templates which are rendered from a Markdown source file,
+the `page` variable contains a page object with the following attributes:
 
-#### page_title
+##### page.title
 
 Contains the Title for the current page.
 
-#### page_description
-
-Contains the description for the current page on the homepage, it is blank on
-other pages.
-
-#### content
+##### page.content
 
 The rendered Markdown as HTML, this is the contents of the documentation.
 
-#### toc
+##### page.toc
 
 An object representing the Table of contents for a page. Displaying the table
 of contents as a simple list can be achieved like this.
 
 ```django
 <ul>
-{% for toc_item in toc %}
+{% for toc_item in page.toc %}
     <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
     {% for toc_item in toc_item.children %}
         <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
@@ -212,7 +208,7 @@ of contents as a simple list can be achieved like this.
 </ul>
 ```
 
-#### meta
+##### page.meta
 
 A mapping of the metadata included at the top of the markdown page. In this
 example we define a `source` property above the page title.
@@ -231,36 +227,41 @@ variable. This could then be used to link to source files related to the
 documentation page.
 
 ```django
-{% for filename in meta.source %}
+{% for filename in page.meta.source %}
   <a class="github" href="https://github.com/.../{{ filename }}">
     <span class="label label-info">{{ filename }}</span>
   </a>
 {% endfor %}
 ```
 
-#### canonical_url
+##### page.canonical_url
 
-The full, canonical URL to the current page. This includes the site_url from
+The full, canonical URL to the current page. This includes the `site_url` from
 the configuration.
 
-#### current_page
+##### page.url
 
-The page object for the current page. The page path and url properties can be
-displayed like this.
+The URL to the current page not including the `site_url` from the configuration.
+
+##### page.is_homepage
+
+Evaluates to `True` for the homepage of the site and `False` for all other
+pages. This can be used in conjuction with other attributes of the `page`
+object to alter the behavior. For example, to display a differant title
+on the homepage:
 
 ```django
-<h1>{{ current_page.title }}</h1>
-<p> This page is at {{ current_page.url }}</p>
+{% if not page.is_homepage %}{{ page.title }} - {% endif %}{{ site_name }}
 ```
 
-#### previous_page
+##### page.previous_page
 
 The page object for the previous  page. The usage is the same as for
-`current_page`.
+`page`.
 
-#### next_page
+##### page.next_page
 
-The page object for the next page.The usage is the same as for `current_page`.
+The page object for the next page.The usage is the same as for `page`.
 
 ### Extra Context
 

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -148,6 +148,13 @@ class Page(object):
         self.next_page = None
         self.ancestors = []
 
+        # Placeholders to be filled in later in the build
+        # process when we have access to the config.
+        self.canonical_url = None
+        self.content = None
+        self.meta = None
+        self.toc = None
+
     @property
     def url(self):
         return self.url_context.make_relative(self.abs_url)
@@ -173,6 +180,11 @@ class Page(object):
         self.active = active
         for ancestor in self.ancestors:
             ancestor.set_active(active)
+
+    def set_canonical_url(self, base):
+        if not base.endswith('/'):
+            base += '/'
+        self.canonical_url = utils.urljoin(base, self.abs_url.lstrip('/'))
 
 
 class Header(object):

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -4,13 +4,13 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        {% if page_description %}<meta name="description" content="{{ page_description }}">{% endif %}
+        {% if page and page.is_homepage %}<meta name="description" content="{{ config['site_description'] }}">{% endif %}
         {% if site_author %}<meta name="author" content="{{ site_author }}">{% endif %}
-        {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}">{% endif %}
+        {% if page and page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
         {% if favicon %}<link rel="shortcut icon" href="{{ base_url }}/{{ favicon }}">
         {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
 
-	<title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}</title>
+	<title>{% if page and page.title and not page.is_homepage %}{{ page.title }} - {% endif %}{{ site_name }}</title>
 
         <link href="{{ base_url }}/css/bootstrap-custom.min.css" rel="stylesheet">
         <link href="{{ base_url }}/css/font-awesome-4.5.0.css" rel="stylesheet">
@@ -39,7 +39,7 @@
         {% endif %}
     </head>
 
-    <body{% if current_page and current_page.is_homepage %} class="homepage"{% endif %}>
+    <body{% if page and page.is_homepage %} class="homepage"{% endif %}>
 
         {% include "nav.html" %}
 
@@ -95,7 +95,7 @@
 
     </body>
 </html>
-{% if current_page and current_page.is_homepage %}
+{% if page and page.is_homepage %}
 <!--
 MkDocs version : {{ mkdocs_version }}
 Build Date UTC : {{ build_date_utc }}

--- a/mkdocs/themes/mkdocs/content.html
+++ b/mkdocs/themes/mkdocs/content.html
@@ -1,9 +1,9 @@
-{% if meta.source %}
+{% if page.meta.source %}
 <div class="source-links">
-{% for filename in meta.source %}
+{% for filename in page.meta.source %}
     <span class="label label-primary">{{ filename }}</span>
 {% endfor %}
 </div>
 {% endif %}
 
-{{ content }}
+{{ page.content }}

--- a/mkdocs/themes/mkdocs/nav.html
+++ b/mkdocs/themes/mkdocs/nav.html
@@ -47,14 +47,14 @@
                         <i class="fa fa-search"></i> Search
                     </a>
                 </li>
-                {% if include_next_prev %}
-                    <li {% if not previous_page %}class="disabled"{% endif %}>
-                        <a rel="next" {% if previous_page %}href="{{ previous_page.url }}"{% endif %}>
+                {% if include_next_prev and page %}
+                    <li {% if not page.previous_page %}class="disabled"{% endif %}>
+                        <a rel="next" {% if page.previous_page %}href="{{ page.previous_page.url }}"{% endif %}>
                             <i class="fa fa-arrow-left"></i> Previous
                         </a>
                     </li>
-                    <li {% if not next_page %}class="disabled"{% endif %}>
-                        <a rel="prev" {% if next_page %}href="{{ next_page.url }}"{% endif %}>
+                    <li {% if not page.next_page %}class="disabled"{% endif %}>
+                        <a rel="prev" {% if page.next_page %}href="{{ page.next_page.url }}"{% endif %}>
                             Next <i class="fa fa-arrow-right"></i>
                         </a>
                     </li>

--- a/mkdocs/themes/mkdocs/toc.html
+++ b/mkdocs/themes/mkdocs/toc.html
@@ -1,6 +1,6 @@
 <div class="bs-sidebar hidden-print affix well" role="complementary">
     <ul class="nav bs-sidenav">
-    {% for toc_item in toc %}
+    {% for toc_item in page.toc %}
         <li class="main {% if toc_item.active %}active{% endif %}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
         {% for toc_item in toc_item.children %}
             <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  {% if page_description %}<meta name="description" content="{{ page_description }}">{% endif %}
+  {% if page and page.is_homepage %}<meta name="description" content="{{ page_description }}">{% endif %}
   {% if site_author %}<meta name="author" content="{{ site_author }}">{% endif %}
   {% block htmltitle %}
-  <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}</title>
+  <title>{% if page and page.title and not page.is_hompage %}{{ page.title }} - {% endif %}{{ site_name }}</title>
   {% endblock %}
 
   {% if favicon %}<link rel="shortcut icon" href="{{ favicon }}">
@@ -24,12 +24,12 @@
   <link href="{{ path }}" rel="stylesheet">
   {%- endfor %}
 
-  {% if current_page %}
+  {% if page %}
   <script>
     // Current page data
-    var mkdocs_page_name = {{ page_title|tojson|safe }};
-    var mkdocs_page_input_path = {{ current_page.input_path|tojson|safe }};
-    var mkdocs_page_url = {{ current_page.abs_url|tojson|safe }};
+    var mkdocs_page_name = {{ page.title|tojson|safe }};
+    var mkdocs_page_input_path = {{ page.input_path|tojson|safe }};
+    var mkdocs_page_url = {{ page.abs_url|tojson|safe }};
   </script>
   {% endif %}
   <script src="{{ base_url }}/js/jquery-2.1.1.min.js"></script>
@@ -92,7 +92,7 @@
           <div role="main">
             <div class="section">
               {% block content %}
-                {{ content }}
+                {{ page.content }}
               {% endblock %}
             </div>
           </div>
@@ -110,7 +110,7 @@
 
 </body>
 </html>
-{% if current_page and current_page.is_homepage %}
+{% if page and page.is_homepage %}
 <!--
 MkDocs version : {{ mkdocs_version }}
 Build Date UTC : {{ build_date_utc }}

--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -1,8 +1,8 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">
     <li><a href="{{ homepage_url }}">Docs</a> &raquo;</li>
-    {% if current_page %}
-      {% for doc in current_page.ancestors %}
+    {% if page %}
+      {% for doc in page.ancestors %}
         {% if doc.link %}
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
         {% else %}
@@ -10,7 +10,7 @@
         {% endif %}
       {% endfor %}
     {% endif %}
-    {% if current_page %}<li>{{ current_page.title }}</li>{% endif %}
+    {% if page %}<li>{{ page.title }}</li>{% endif %}
     <li class="wy-breadcrumbs-aside">
       {% if repo_url %}
         {% if repo_name == 'GitHub' %}

--- a/mkdocs/themes/readthedocs/footer.html
+++ b/mkdocs/themes/readthedocs/footer.html
@@ -1,11 +1,11 @@
 <footer>
-  {% if next_page or previous_page %}
+  {% if page and page.next_page or page.previous_page %}
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      {% if next_page %}
-        <a href="{{ next_page.url }}" class="btn btn-neutral float-right" title="{{ next_page.title }}">Next <span class="icon icon-circle-arrow-right"></span></a>
+      {% if page.next_page %}
+        <a href="{{ page.next_page.url }}" class="btn btn-neutral float-right" title="{{ page.next_page.title }}">Next <span class="icon icon-circle-arrow-right"></span></a>
       {% endif %}
-      {% if previous_page %}
-        <a href="{{ previous_page.url }}" class="btn btn-neutral" title="{{ previous_page.title }}"><span class="icon icon-circle-arrow-left"></span> Previous</a>
+      {% if page.previous_page %}
+        <a href="{{ page.previous_page.url }}" class="btn btn-neutral" title="{{ page.previous_page.title }}"><span class="icon icon-circle-arrow-left"></span> Previous</a>
       {% endif %}
     </div>
   {% endif %}

--- a/mkdocs/themes/readthedocs/toc.html
+++ b/mkdocs/themes/readthedocs/toc.html
@@ -9,9 +9,9 @@
 {% else %}
     <li class="toctree-l1 {% if nav_item.active%}current{%endif%}">
         <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-        {% if nav_item == current_page %}
+        {% if nav_item == page %}
             <ul>
-            {% for toc_item in toc %}
+            {% for toc_item in page.toc %}
                 <li class="toctree-l3"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
                 {% for toc_item in toc_item.children %}
                     <li><a class="toctree-l4" href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>

--- a/mkdocs/themes/readthedocs/versions.html
+++ b/mkdocs/themes/readthedocs/versions.html
@@ -5,11 +5,11 @@
       {% elif repo_name == 'Bitbucket' %}
           <a href="{{ repo_url }}" class="icon icon-bitbucket" style="float: left; color: #fcfcfc"> BitBucket</a>
       {% endif %}
-      {% if previous_page %}
-        <span><a href="{{ previous_page.url }}" style="color: #fcfcfc;">&laquo; Previous</a></span>
+      {% if page.previous_page %}
+        <span><a href="{{ page.previous_page.url }}" style="color: #fcfcfc;">&laquo; Previous</a></span>
       {% endif %}
-      {% if next_page %}
-        <span style="margin-left: 15px"><a href="{{ next_page.url }}" style="color: #fcfcfc">Next &raquo;</a></span>
+      {% if page.next_page %}
+        <span style="margin-left: 15px"><a href="{{ page.next_page.url }}" style="color: #fcfcfc">Next &raquo;</a></span>
       {% endif %}
     </span>
 </div>


### PR DESCRIPTION
A deprecation warning is issued for all old variables and all new
page specific variables are attributes of the 'page' object.

Global variables are uneffected, except page_description.

See the changes described in the release notes for details.

Fixes #874.