### PR TITLE
Ensure tests use actual package location. Fixes #923.

### DIFF
--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 
+import mkdocs
 from mkdocs import utils
 from mkdocs.config import config_options
 
@@ -172,6 +173,8 @@ class SiteDirTest(unittest.TestCase):
         j = os.path.join
         option = config_options.SiteDir()
         docs_dir = config_options.Dir()
+        # Not all systems use the same package directory name, so use the actual dir name
+        mkdocs_pkgdir = os.path.basename(os.path.dirname(mkdocs.__file__))
 
         test_configs = (
             {'docs_dir': j('site', 'docs'), 'site_dir': 'site'},
@@ -179,7 +182,7 @@ class SiteDirTest(unittest.TestCase):
             {'docs_dir': '.', 'site_dir': '.'},
             {'docs_dir': 'docs', 'site_dir': ''},
             {'docs_dir': '', 'site_dir': ''},
-            {'docs_dir': j('..', 'mkdocs', 'docs'), 'site_dir': 'docs'},
+            {'docs_dir': j('..', mkdocs_pkgdir, 'docs'), 'site_dir': 'docs'},
         )
 
         for test_config in test_configs:


### PR DESCRIPTION
I think this will resolve the issue. Not able to test conclusively locally as I refuse to use deb packages for Python libs. @brianmay, can you confirm this solves the problem raised in #923?