### PR TITLE
Support SOURCE_DATE_EPOCH environment variable for "reproducible" builds.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -73,6 +73,8 @@ created and third-party templates:
   pages config. (#728)
 * Update searching to Lunr 0.7, which comes with some performance enhancements
   for larger documents (#859)
+* Bugfix: Support SOURCE_DATE_EPOCH environment variable for "reproducible"
+  builds (#938)
 
 ## Version 0.15.3 (2016-02-18)
 

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 from datetime import datetime
+from calendar import timegm
 import io
 import logging
 import os
@@ -56,6 +57,10 @@ def get_global_context(nav, config):
 
     extra_css = utils.create_media_urls(nav, config['extra_css'])
 
+    # Support SOURCE_DATE_EPOCH environment variable for "reproducible" builds.
+    # See https://reproducible-builds.org/specs/source-date-epoch/
+    timestamp = int(os.environ.get('SOURCE_DATE_EPOCH', timegm(datetime.utcnow().utctimetuple())))
+
     return {
         'site_name': site_name,
         'site_author': config['site_author'],
@@ -84,7 +89,7 @@ def get_global_context(nav, config):
         'google_analytics': config['google_analytics'],
 
         'mkdocs_version': mkdocs.__version__,
-        'build_date_utc': datetime.utcnow(),
+        'build_date_utc': datetime.utcfromtimestamp(timestamp),
 
         'config': config
     }


### PR DESCRIPTION
Fixes #938.