### PR TITLE
Support theme customization with blocks

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -65,7 +65,7 @@ behavior of the navigation, among other things. See the relevant
 To enable this feature, the primary entry point for page templates has been
 changed from `base.html` to `main.html`. This allows `base.html` to continue to
 exist while allowing users to override `main.html` and extend `base.html`. For
-version 1.16, `base.html` will continue to work if no `main.html` template
+version 0.16, `base.html` will continue to work if no `main.html` template
 exists, but it is deprecated and will raise a warning. In version 1.0, a build
 will fail if no `main.html` template exists. Any custom and third party
 templates should be updated accordingly.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -53,6 +53,37 @@ created and third-party templates:
 [page.previous_page]: ../user-guide/custom-themes/#pageprevious_page
 [page.next_page]: ../user-guide/custom-themes/#pagenext_page
 
+#### Increased Template Customization. (#607)
+
+The built-in themes have been updated by having each of their many parts wrapped
+in template blocks which allow each individual block to be easily overriden
+using the `theme_dir` config setting. Without any new settings, you can use a
+differant analytics service, replace the default search function, or alter the
+behavior of the navigation, among other things. See the relevant
+[documentation][blocks] for more details.
+
+To enable this feature, the primary entry point for page templates has been
+changed from `base.html` to `main.html`. This allows `base.html` to continue to
+exist while allowing users to override `main.html` and extend `base.html`. For
+version 1.16, `base.html` will continue to work if no `main.html` template
+exists, but it is deprecated and will raise a warning. In version 1.0, a build
+will fail if no `main.html` template exists. Any custom and third party
+templates should be updated accordingly.
+
+The easiest way for a third party theme to be updated would be to simply add a
+`main.html` file which only contains the following line:
+
+```django
+{% extends "base.html" %}
+```
+
+That way, the theme contains the `main.html` entry point, and also supports
+overriding blocks in the same manner as the built-in themes. Third party themes
+are encouraged to wrap the various pieces of their templates in blocks in order
+to support such customization.
+
+[blocks]: ../user-guide/styling-your-docs/#overriding-template-blocks
+
 ### Other Changes and Additions to Version 0.16.0
 
 * Bugfix: Support `gh-deploy` command on Windows with Python 3 (#722)

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -20,11 +20,11 @@ and their usage.
 
 ## Creating a custom theme
 
-The bare minimum required for a custom theme is a `base.html` [Jinja2
+The bare minimum required for a custom theme is a `main.html` [Jinja2
 template] file. This should be placed in a directory which will be the
 `theme_dir` and it should be created next to the `mkdocs.yml` configuration
 file. Within `mkdocs.yml`, specify the `theme_dir` option and set it to the
-name of the directory containing `base.html`. For example, given this example
+name of the directory containing `main.html`. For example, given this example
 project layout:
 
     mkdocs.yml
@@ -32,7 +32,7 @@ project layout:
         index.md
         about.md
     custom_theme/
-        base.html
+        main.html
         ...
 
 You would include the following setting to use the custom theme directory:
@@ -41,13 +41,13 @@ You would include the following setting to use the custom theme directory:
 
 !!! Note
 
-    Generally, when building your own theme, the `theme` configurations setting
-    would be left blank. However, if used in combination with the `theme`
+    Generally, when building your own theme, the `theme` configuration setting
+    would be left blank. However, if used in combination with the `theme_dir`
     configuration value a custom theme can be used to replace only specific
     parts of a built-in theme. For example, with the above layout and if you set
-    `theme: mkdocs` then the `base.html` file would replace that in the theme
-    but otherwise it would remain the same. This is useful if you want to make
-    small adjustments to an existing theme.
+    `theme: mkdocs` then the `main.html` file would replace that in the theme
+    but otherwise the theme would remain the same. This is useful if you want to
+    make small adjustments to an existing theme.
 
     For more specific information, see [styling your docs].
 
@@ -55,7 +55,7 @@ You would include the following setting to use the custom theme directory:
 
 ## Basic theme
 
-The simplest `base.html` file is the following:
+The simplest `main.html` file is the following:
 
 ```django
 <!DOCTYPE html>
@@ -365,13 +365,13 @@ Bootswatch theme].
 
 The following layout is recommended for themes. Two files at the top level
 directory called `MANIFEST.in` amd `setup.py`. Then a directory with the name
-of your theme and containing a `base.html` file and a `__init__.py`.
+of your theme and containing a `main.html` file and a `__init__.py`.
 
 ```no-highlight
 .
 |-- MANIFEST.in
 |-- theme_name
-|   |-- base.html
+|   |-- main.html
 |   |-- __init__.py
 `-- setup.py
 ```
@@ -425,9 +425,9 @@ including in the package. The name on the left is the one that users will use
 in their mkdocs.yml and the one on the right is the directory containing your
 theme files.
 
-The directory you created at the start of this section with the base.html file
+The directory you created at the start of this section with the main.html file
 should contain all of the other theme files. The minimum requirement is that
-it includes a `base.html` for the theme. It **must** also include a
+it includes a `main.html` for the theme. It **must** also include a
 `__init__.py` file which should be empty, this file tells Python that the
 directory is a package.
 

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -35,19 +35,22 @@ project layout:
         main.html
         ...
 
-You would include the following setting to use the custom theme directory:
+You would include the following settings in `mkdocs.yml` to use the custom theme
+directory:
 
+    theme: null
     theme_dir: 'custom_theme'
 
 !!! Note
 
-    Generally, when building your own theme, the `theme` configuration setting
-    would be left blank. However, if used in combination with the `theme_dir`
-    configuration value a custom theme can be used to replace only specific
-    parts of a built-in theme. For example, with the above layout and if you set
-    `theme: mkdocs` then the `main.html` file would replace that in the theme
-    but otherwise the theme would remain the same. This is useful if you want to
-    make small adjustments to an existing theme.
+    Generally, when building your own custom theme, the `theme` configuration
+    setting would be set to `null`. However, if used in combination with the
+    `theme_dir` configuration value a custom theme can be used to replace only
+    specific parts of a built-in theme. For example, with the above layout and
+    if you set `theme: "mkdocs"` then the `main.html` file in the `theme_dir`
+    would replace that in the theme but otherwise the `mkdocs` theme would
+    remain the same. This is useful if you want to make small adjustments to an
+    existing theme.
 
     For more specific information, see [styling your docs].
 
@@ -75,6 +78,23 @@ with a normal HTML file. Navbars and tables of contents can also be generated
 and included automatically, through the `nav` and `toc` objects, respectively.
 If you wish to write your own theme, it is recommended to start with one of
 the [built-in themes] and modify it accordingly.
+
+!!! Note
+
+    As MkDocs uses [Jinja] as its template engine, you have access to all the
+    power of Jinja, including [template inheritance]. You may notice that the
+    themes included with MkDocs make extensive use of template inheritance anf
+    blocks, allowing users to easily override small bits and pieces of the
+    templates from the [theme_dir]. Therefore, the builtin themes are
+    implemented in a `base.html` file, which `main.html` extends. Although not
+    required, third party template authors are encouraged to follow a similar
+    pattern and may want to define the same [blocks] as are used in the built-in
+    themes for consistency.
+
+[Jinja]: http://jinja.pocoo.org/
+[template inheritance]: http://jinja.pocoo.org/docs/dev/templates/#template-inheritance
+[theme_dir]: ./styling-your-docs.md#using-the-theme_dir
+[blocks]: ./styling-your-docs.md#overriding-template-blocks
 
 ## Template Variables
 
@@ -357,6 +377,16 @@ To see an example of a package containing one theme, see the [MkDocs Bootstrap
 theme] and to see a package that contains many themes, see the [MkDocs
 Bootswatch theme].
 
+!!! Note
+
+    It is not strictly nessecary to package a theme, as the entire theme
+    can be contained in the `theme_dir`. If you have created a "one-off theme,"
+    that should be sufficent. However, if you intend to distribute your theme
+    for others to use, packaging the theme has some advantages. By packaging
+    your theme, your users can more easily install it and they can them take
+    advantage of the [theme_dir] to make tweaks to your theme to better suit
+    their needs.
+
 [Python packaging]: https://packaging.python.org/en/latest/
 [MkDocs Bootstrap theme]: http://mkdocs.github.io/mkdocs-bootstrap/
 [MkDocs Bootswatch theme]: http://mkdocs.github.io/mkdocs-bootswatch/
@@ -364,15 +394,16 @@ Bootswatch theme].
 ### Package Layout
 
 The following layout is recommended for themes. Two files at the top level
-directory called `MANIFEST.in` amd `setup.py`. Then a directory with the name
-of your theme and containing a `main.html` file and a `__init__.py`.
+directory called `MANIFEST.in` amd `setup.py` beside the theme directory which
+contains an empty `__init__.py` file and your template and media files.
 
 ```no-highlight
 .
 |-- MANIFEST.in
 |-- theme_name
-|   |-- main.html
 |   |-- __init__.py
+|   |-- main.py
+|   |-- styles.css
 `-- setup.py
 ```
 

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -153,6 +153,52 @@ Your directory structure should now look like this:
     `theme`. If you want to remove files, or build a theme from scratch, then
     you should review the documentation for building a [custom theme].
 
+#### Overriding Template Blocks
+
+The built-in themes implement many of their parts inside template blocks which
+can be individually overridden in the `main.html` template. Simply create a
+`main.html` template file in your `theme_dir` and define replacement blocks
+within that file. Just make sure that the `main.html` extends `base.html`. For
+example, to alter the title of the MkDocs theme, your replacement `main.html`
+template would contain the following:
+
+```django
+{% extends "base.html" %}
+
+{% block title %}
+<title>Custom title goes here</title>
+{% endblock %}
+```
+
+In the above example, the title block defined in your custom `main.html` file
+will be used in place of the default title block defined in the parent theme.
+You may re-define as many blocks as you desire, as long as those blocks are
+defined in the parent. For example, you could replace the Google Analytics
+script with one for a different service or replace the search feature with your
+own. You will need to consult the parent theme you are using to determine what
+blocks are available to override. The MkDocs and ReadTheDocs themes provide the
+following blocks:
+
+* `site_meta`: Contains meta tags in the document head.
+* `htmltitle`: Contains the page title in the document head.
+* `styles`: Contains the link tags for stylesheets.
+* `scripts`: Contains the JavaScript libraries included in the page.
+* `analytics`: Contains the analytics script.
+* `extrahead`: An empty block in the `<head>` to insert custom tags/scripts/etc.
+* `search_modal`: Contains the search pop-up modal.
+* `site_name`: Contains the site name in the navigation bar.
+* `site_nav`: Contains the site navigation in the navigation bar.
+* `search_box`: Contains the search button/box in the navigation bar.
+* `next_prev`: Contains the next and previous buttons in the navigation bar.
+* `repo`: Contains the repository link in the navigation bar.
+* `content`: Contains the page content and table of contents for the page.
+* `footer`: Contains the page footer.
+
+You may need to view the source template files to ensure your modifications will
+work with the structure of the site. See [Template Variables] for a list of
+variables you can use within your custom blocks. For a more complete
+explaination of blocks, consult the [Jinja documentation].
+
 [built-in themes]: #built-in-themes
 [third party themes]: #third-party-themes
 [docs_dir]: #using-the-docs_dir
@@ -168,3 +214,5 @@ Your directory structure should now look like this:
 [theme]: ./configuration/#theme
 [mkdocs]: #mkdocs
 [browse source]: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/themes/mkdocs
+[Template Variables]: ./custom-themes.md#template-variables
+[Jinja documentation]: http://jinja.pocoo.org/docs/dev/templates/#template-inheritance

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -91,6 +91,13 @@ should mirror the directory structure of the `theme`. You may include templates,
 JavaScript files, CSS files, images, fonts, or any other media included in a
 theme.
 
+!!! Note
+
+    For this to work, the `theme` setting must be set to a known installed theme.
+    If the `theme` settign is instead set to `null`, then there is no theme to
+    override and the contents of the `theme_dir` must be a complete, standalone
+    theme. See [Custom Themes][custom theme] for more information.
+
 For example, the [mkdocs] theme ([browse source]), contains the following
 directory structure (in part):
 
@@ -185,10 +192,9 @@ following blocks:
 * `scripts`: Contains the JavaScript libraries included in the page.
 * `analytics`: Contains the analytics script.
 * `extrahead`: An empty block in the `<head>` to insert custom tags/scripts/etc.
-* `search_modal`: Contains the search pop-up modal.
 * `site_name`: Contains the site name in the navigation bar.
 * `site_nav`: Contains the site navigation in the navigation bar.
-* `search_box`: Contains the search button/box in the navigation bar.
+* `search_box`: Contains the search box in the navigation bar.
 * `next_prev`: Contains the next and previous buttons in the navigation bar.
 * `repo`: Contains the repository link in the navigation bar.
 * `content`: Contains the page content and table of contents for the page.

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -183,7 +183,16 @@ def _build_page(page, config, site_navigation, env, dump_json):
     if 'template' in meta:
         template = env.get_template(meta['template'][0])
     else:
-        template = env.get_template('base.html')
+        try:
+            template = env.get_template('main.html')
+        except jinja2.TemplateNotFound:
+            # TODO: Remove this in version 1.0
+            template = env.get_template('base.html')
+            log.warn(
+                "Your theme does not appear to contain a 'main.html' template. "
+                "The 'base.html' template was used instead, which is deprecated. "
+                "Update your theme so that the primary entry point is 'main.html'."
+            )
 
     # Render the template.
     output_content = template.render(context)

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -82,32 +82,8 @@
         {%- endfor %}
       {%- endblock %}
 
-      {%- block search_modal %}
-        <div class="modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-labelledby="Search Modal" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                        <h4 class="modal-title" id="exampleModalLabel">Search</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            From here you can search these documents. Enter
-                            your search terms below.
-                        </p>
-                        <form role="form">
-                            <div class="form-group">
-                                <input type="text" class="form-control" placeholder="Search..." id="mkdocs-search-query">
-                            </div>
-                        </form>
-                        <div id="mkdocs-search-results"></div>
-                    </div>
-                    <div class="modal-footer">
-                    </div>
-                </div>
-            </div>
-        </div>
-      {%- endblock %}
+        {%- include "search.html" %}
+
     </body>
 </html>
 {% if page and page.is_homepage %}

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+      {%- block site_meta %}
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,9 +10,13 @@
         {% if page and page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
         {% if favicon %}<link rel="shortcut icon" href="{{ base_url }}/{{ favicon }}">
         {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
+      {%- endblock %}
 
-	<title>{% if page and page.title and not page.is_homepage %}{{ page.title }} - {% endif %}{{ site_name }}</title>
+      {%- block htmltitle %}
+        <title>{% if page and page.title and not page.is_homepage %}{{ page.title }} - {% endif %}{{ site_name }}</title>
+      {%- endblock %}
 
+      {%- block styles %}
         <link href="{{ base_url }}/css/bootstrap-custom.min.css" rel="stylesheet">
         <link href="{{ base_url }}/css/font-awesome-4.5.0.css" rel="stylesheet">
         <link href="{{ base_url }}/css/base.css" rel="stylesheet">
@@ -19,6 +24,7 @@
         {%- for path in extra_css %}
         <link href="{{ path }}" rel="stylesheet">
         {%- endfor %}
+      {%- endblock %}
 
         <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
         <!--[if lt IE 9]>
@@ -26,7 +32,8 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if google_analytics %}
+      {%- block analytics %}
+        {%- if google_analytics %}
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -36,7 +43,10 @@
             ga('create', '{{ google_analytics[0] }}', '{{ google_analytics[1] }}');
             ga('send', 'pageview');
         </script>
-        {% endif %}
+        {%- endif %}
+      {%- endblock %}
+      
+      {%- block extrahead %} {% endblock %}
     </head>
 
     <body{% if page and page.is_homepage %} class="homepage"{% endif %}>
@@ -44,20 +54,23 @@
         {% include "nav.html" %}
 
         <div class="container">
-            {% block content %}
+            {%- block content %}
                 <div class="col-md-3">{% include "toc.html" %}</div>
                 <div class="col-md-9" role="main">{% include "content.html" %}</div>
-            {% endblock %}
+            {%- endblock %}
         </div>
 
         <footer class="col-md-12">
+          {%- block footer %}
             <hr>
-            {% if copyright %}
+            {%- if copyright %}
                 <p>{{ copyright }}</p>
-            {% endif %}
+            {%- endif %}
             <p>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</p>
+          {%- endblock %}
         </footer>
 
+      {%- block scripts %}
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>
@@ -67,7 +80,9 @@
         {%- for path in extra_javascript %}
         <script src="{{ path }}"></script>
         {%- endfor %}
+      {%- endblock %}
 
+      {%- block search_modal %}
         <div class="modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-labelledby="Search Modal" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">
@@ -92,7 +107,7 @@
                 </div>
             </div>
         </div>
-
+      {%- endblock %}
     </body>
 </html>
 {% if page and page.is_homepage %}

--- a/mkdocs/themes/mkdocs/main.html
+++ b/mkdocs/themes/mkdocs/main.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{#
+The entry point for the MkDocs Theme.
+ 
+Any custom themes which inherit from this theme should override this file to redefine
+blocks defined in the various templates. The custom theme should only need to define
+a main.html which `{% extends "base.html" %}` and defines various blocks which will
+replace the blocks defined in base.html and its included child templates.
+#}

--- a/mkdocs/themes/mkdocs/main.html
+++ b/mkdocs/themes/mkdocs/main.html
@@ -3,8 +3,8 @@
 {#
 The entry point for the MkDocs Theme.
  
-Any custom themes which inherit from this theme should override this file to redefine
-blocks defined in the various templates. The custom theme should only need to define
-a main.html which `{% extends "base.html" %}` and defines various blocks which will
-replace the blocks defined in base.html and its included child templates.
+Any theme customisations should override this file to redefine blocks defined in
+the various templates. The custom theme should only need to define a main.html
+which `{% extends "base.html" %}` and defines various blocks which will replace
+the blocks defined in base.html and its included child templates.
 #}

--- a/mkdocs/themes/mkdocs/nav-sub.html
+++ b/mkdocs/themes/mkdocs/nav-sub.html
@@ -1,14 +1,14 @@
-{% if not nav_item.children %}
+{%- if not nav_item.children %}
 <li {% if nav_item.active %}class="active"{% endif %}>
     <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
 </li>
-{% else %}
+{%- else %}
   <li class="dropdown-submenu">
     <a tabindex="-1" href="">{{ nav_item.title }}</a>
     <ul class="dropdown-menu">
-        {% for nav_item in nav_item.children %}
+        {%- for nav_item in nav_item.children %}
             {% include "nav-sub.html" %}
-        {% endfor %}
+        {%- endfor %}
     </ul>
   </li>
-{% endif %}
+{%- endif %}

--- a/mkdocs/themes/mkdocs/nav.html
+++ b/mkdocs/themes/mkdocs/nav.html
@@ -3,7 +3,7 @@
 
         <!-- Collapsed navigation -->
         <div class="navbar-header">
-            {% if include_nav or include_next_prev or repo_url %}
+            {%- if include_nav or include_next_prev or repo_url %}
             <!-- Expander button -->
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                 <span class="sr-only">Toggle navigation</span>
@@ -11,43 +11,50 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            {% endif %}
+            {%- endif %}
 
-            <!-- Main title -->
+          {%- block site_name %}
             <a class="navbar-brand" href="{{ homepage_url }}">{{ site_name }}</a>
+          {%- endblock %}
         </div>
 
         <!-- Expanded navigation -->
         <div class="navbar-collapse collapse">
-            {% if include_nav %}
+          {%- block site_nav %}
+            {%- if include_nav %}
                 <!-- Main navigation -->
                 <ul class="nav navbar-nav">
-                {% for nav_item in nav %}
-                {% if nav_item.children %}
+                {%- for nav_item in nav %}
+                {%- if nav_item.children %}
                     <li class="dropdown{% if nav_item.active %} active{% endif %}">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                         <ul class="dropdown-menu">
-                        {% for nav_item in nav_item.children %}
+                        {%- for nav_item in nav_item.children %}
                             {% include "nav-sub.html" %}
-                        {% endfor %}
+                        {%- endfor %}
                         </ul>
                     </li>
-                {% else %}
+                {%- else %}
                     <li {% if nav_item.active %}class="active"{% endif %}>
                         <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
                     </li>
-                {% endif %}
-                {% endfor %}
+                {%- endif %}
+                {%- endfor %}
                 </ul>
-            {% endif %}
+            {%- endif %}
+          {%- endblock %}
 
             <ul class="nav navbar-nav navbar-right">
+              {%- block search_button %}
                 <li>
                     <a href="#" data-toggle="modal" data-target="#mkdocs_search_modal">
                         <i class="fa fa-search"></i> Search
                     </a>
                 </li>
-                {% if include_next_prev and page %}
+              {%- endblock %}
+
+              {%- block next_prev %}
+                {%- if include_next_prev and page %}
                     <li {% if not page.previous_page %}class="disabled"{% endif %}>
                         <a rel="next" {% if page.previous_page %}href="{{ page.previous_page.url }}"{% endif %}>
                             <i class="fa fa-arrow-left"></i> Previous
@@ -58,19 +65,23 @@
                             Next <i class="fa fa-arrow-right"></i>
                         </a>
                     </li>
-                {% endif %}
-                {% if repo_url %}
+                {%- endif %}
+              {%- endblock %}
+
+              {%- block repo %}
+                {%- if repo_url %}
                     <li>
                         <a href="{{ repo_url }}">
-                            {% if repo_name == 'GitHub' %}
+                            {%- if repo_name == 'GitHub' %}
                                 <i class="fa fa-github"></i>
-                            {% elif repo_name == 'Bitbucket' %}
+                            {%- elif repo_name == 'Bitbucket' -%}
                                 <i class="fa fa-bitbucket"></i>
-                            {% endif %}
+                            {%- endif -%}
                             {{ repo_name }}
                         </a>
                     </li>
-                {% endif %}
+                {%- endif %}
+              {%- endblock %}
             </ul>
         </div>
     </div>

--- a/mkdocs/themes/mkdocs/search.html
+++ b/mkdocs/themes/mkdocs/search.html
@@ -1,0 +1,24 @@
+<div class="modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-labelledby="Search Modal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title" id="exampleModalLabel">Search</h4>
+            </div>
+            <div class="modal-body">
+                <p>
+                    From here you can search these documents. Enter
+                    your search terms below.
+                </p>
+                <form role="form">
+                    <div class="form-group">
+                        <input type="text" class="form-control" placeholder="Search..." id="mkdocs-search-query">
+                    </div>
+                </form>
+                <div id="mkdocs-search-results"></div>
+            </div>
+            <div class="modal-footer">
+            </div>
+        </div>
+    </div>
+</div>

--- a/mkdocs/themes/mkdocs/toc.html
+++ b/mkdocs/themes/mkdocs/toc.html
@@ -1,10 +1,10 @@
 <div class="bs-sidebar hidden-print affix well" role="complementary">
     <ul class="nav bs-sidenav">
-    {% for toc_item in page.toc %}
+    {%- for toc_item in page.toc %}
         <li class="main {% if toc_item.active %}active{% endif %}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
-        {% for toc_item in toc_item.children %}
+        {%- for toc_item in toc_item.children %}
             <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
-        {% endfor %}
-    {% endfor %}
+        {%- endfor %}
+    {%- endfor %}
     </ul>
 </div>

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -116,8 +116,6 @@
       </div>
 
     </section>
-
-    {%- block search_modal %} {% endblock %}
     
   </div>
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -2,19 +2,21 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  {%- block site_meta %}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% if page and page.is_homepage %}<meta name="description" content="{{ page_description }}">{% endif %}
   {% if site_author %}<meta name="author" content="{{ site_author }}">{% endif %}
-  {% block htmltitle %}
-  <title>{% if page and page.title and not page.is_hompage %}{{ page.title }} - {% endif %}{{ site_name }}</title>
-  {% endblock %}
-
   {% if favicon %}<link rel="shortcut icon" href="{{ favicon }}">
   {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
+  {%- endblock %}
 
-  {# CSS #}
+  {%- block htmltitle %}
+  <title>{% if page and page.title and not page.is_hompage %}{{ page.title }} - {% endif %}{{ site_name }}</title>
+  {%- endblock %}
+  
+  {%- block styles %}
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
 
   <link rel="stylesheet" href="{{ base_url }}/css/theme.css" type="text/css" />
@@ -23,7 +25,9 @@
   {%- for path in extra_css %}
   <link href="{{ path }}" rel="stylesheet">
   {%- endfor %}
+  {%- endblock %}
 
+  {%- block scripts %}
   {% if page %}
   <script>
     // Current page data
@@ -36,6 +40,7 @@
   <script src="{{ base_url }}/js/modernizr-2.8.3.min.js"></script>
   <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js"></script>
   <script src="{{ base_url }}/js/theme.js"></script>
+  {%- endblock %}
 
   {%- block extrahead %} {% endblock %}
 
@@ -43,6 +48,7 @@
   <script src="{{ path }}"></script>
   {%- endfor %}
 
+  {%- block analytics %}
   {% if google_analytics %}
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -54,6 +60,7 @@
       ga('send', 'pageview');
   </script>
   {% endif %}
+  {%- endblock %}
 </head>
 
 <body class="wy-body-for-nav" role="document">
@@ -63,16 +70,22 @@
     {# SIDE NAV, TOGGLES ON MOBILE #}
     <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
       <div class="wy-side-nav-search">
+	{%- block site_name %}
         <a href="{{ homepage_url }}" class="icon icon-home"> {{ site_name }}</a>
+	{%- endblock %}
+	{%- block search_button %}
         {% include "searchbox.html" %}
+	{%- endblock %}
       </div>
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
-        <ul class="current">
+        {%- block site_nav %}
+	<ul class="current">
           {% for nav_item in nav %}
             <li>{% include "toc.html" %}<li>
           {% endfor %}
         </ul>
+	{%- endblock %}
       </div>
       &nbsp;
     </nav>
@@ -104,6 +117,8 @@
 
     </section>
 
+    {%- block search_modal %} {% endblock %}
+    
   </div>
 
 {% include "versions.html" %}

--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -12,6 +12,7 @@
     {% endif %}
     {% if page %}<li>{{ page.title }}</li>{% endif %}
     <li class="wy-breadcrumbs-aside">
+      {%- block repo %}
       {% if repo_url %}
         {% if repo_name == 'GitHub' %}
           <a href="{{ repo_url }}" class="icon icon-github"> Edit on GitHub</a>
@@ -19,6 +20,7 @@
           <a href="{{ repo_url }}" class="icon icon-bitbucket"> Edit on BitBucket</a>
         {% endif %}
       {% endif %}
+      {%- endblock %}
     </li>
   </ul>
   <hr/>

--- a/mkdocs/themes/readthedocs/footer.html
+++ b/mkdocs/themes/readthedocs/footer.html
@@ -1,4 +1,5 @@
 <footer>
+  {%- block next_prev %}
   {% if page and page.next_page or page.previous_page %}
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       {% if page.next_page %}
@@ -9,6 +10,7 @@
       {% endif %}
     </div>
   {% endif %}
+  {%- endblock %}
 
   <hr/>
 

--- a/mkdocs/themes/readthedocs/main.html
+++ b/mkdocs/themes/readthedocs/main.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{#
+The entry point for the ReadTheDocs Theme.
+ 
+Any custom themes which inherit from this theme should override this file to redefine
+blocks defined in the various templates. The custom theme should only need to define
+a main.html which `{% extends "base.html" %}` and defines various blocks which will
+replace the blocks defined in base.html and its included child templates.
+#}

--- a/mkdocs/themes/readthedocs/main.html
+++ b/mkdocs/themes/readthedocs/main.html
@@ -3,8 +3,8 @@
 {#
 The entry point for the ReadTheDocs Theme.
  
-Any custom themes which inherit from this theme should override this file to redefine
-blocks defined in the various templates. The custom theme should only need to define
-a main.html which `{% extends "base.html" %}` and defines various blocks which will
-replace the blocks defined in base.html and its included child templates.
+Any theme customisations should override this file to redefine blocks defined in
+the various templates. The custom theme should only need to define a main.html
+which `{% extends "base.html" %}` and defines various blocks which will replace
+the blocks defined in base.html and its included child templates.
 #}


### PR DESCRIPTION
Partially addresses #607.

Note that we have to rename `base.html` to `main.html` and then create a new `base.html` which is an empty file that "extends" `main.html `. We could reverse the roles of those two files, but that would be backward incompatible with existing custom/third party themes as all themes are loaded from `base.html`. Existing custom themes may not have a `main.html` and switching the role of the two files, despite being more sensible,  could break existing custom and third party themes. Of course, if we want to make the backward incompatible change, now is the time to do it. Let me know and I'll update this PR.

Also note that this provides a way for users to override the behavior of next/prev links when `include_next_prev` is deprecated (see #633, #679,  #681, & #946), use a different analytics service, override search, and various other common requests -- all without any new config settings or Plugin API.