### PR TITLE
Pass loader option up call chain

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import logging
 import shutil
 import tempfile
+import yaml
 
 from mkdocs.commands.build import build
 from mkdocs.config import load_config
@@ -51,7 +52,7 @@ def _static_server(host, port, site_dir):
 
 
 def serve(config_file=None, dev_addr=None, strict=None, theme=None,
-          theme_dir=None, livereload=True):
+          theme_dir=None, livereload=True, loader=yaml.Loader):
     """
     Start the MkDocs development server
 
@@ -70,6 +71,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             strict=strict,
             theme=theme,
             theme_dir=theme_dir,
+            loader=loader
         )
         config['site_dir'] = tempdir
         build(config, live_server=True, clean_site_dir=True)

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import logging
 import os
+import yaml
 
 from mkdocs import exceptions
 from mkdocs import utils
@@ -96,8 +97,8 @@ class Config(utils.UserDict):
         self.user_configs.append(patch)
         self.data.update(patch)
 
-    def load_file(self, config_file):
-        return self.load_dict(utils.yaml_load(config_file))
+    def load_file(self, config_file, loader):
+        return self.load_dict(utils.yaml_load(config_file, loader))
 
 
 def _open_config_file(config_file):
@@ -126,7 +127,7 @@ def _open_config_file(config_file):
     return config_file
 
 
-def load_config(config_file=None, **kwargs):
+def load_config(config_file=None, loader=yaml.Loader, **kwargs):
     """
     Load the configuration for a given file object or name
 
@@ -151,7 +152,7 @@ def load_config(config_file=None, **kwargs):
     from mkdocs import config
     cfg = Config(schema=config.DEFAULT_SCHEMA)
     # First load the config file
-    cfg.load_file(config_file)
+    cfg.load_file(config_file, loader)
     # Then load the options to overwrite anything in the config.
     cfg.load_dict(options)
 


### PR DESCRIPTION
The yaml_load function has the ability to pass a custom loader. However, this option was lacking from the items calling this function.

This seems like a reasonable fix that allows for users to do whatever they want with their yaml files. Fo example, the ability to include yaml files within each other, as discussed here #942.