### PR TITLE
Use the edit url for the 'Edit on...' links

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -107,6 +107,9 @@ to support such customization.
 * Bugfix: Support SOURCE_DATE_EPOCH environment variable for "reproducible"
   builds (#938)
 * Follow links when copying media files (#869).
+* Change "Edit on..." links to point directly to the file in the source
+  repository, rather than to the root of the repository (#975), configurable
+  via the new [`edit_uri`](../user-guide/configuration.md#edit_uri) setting.
 
 ## Version 0.15.3 (2016-02-18)
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -62,10 +62,10 @@ makes it easier to find and edit the source for the page. If `repo_url` is not
 set, this option is ignored.
 
 For example, for a GitHub-hosted repository, the `edit_uri` would be as follows.
-(Note the `blob` path and `master` branch...)
+(Note the `edit` path and `master` branch...)
 
 ```yaml
-edit_uri: blob/master/docs/
+edit_uri: edit/master/docs/
 ```
 
 For a Bitbucket-hosted repository, the equivalent `edit_uri` would be as
@@ -78,8 +78,15 @@ edit_uri: src/default/docs/
 For other repository hosts, `edit_uri` works the same way. Simply specify the
 relative path to the docs directory.
 
-**default**: `blob/master/docs/` or `src/default/docs/` for GitHub or Bitbucket
+**default**: `edit/master/docs/` or `src/default/docs/` for GitHub or Bitbucket
 repos, respectively, if `repo_url` matches those domains, otherwise `null`
+
+!!! note "Note:"
+    On GitHub, the `edit` path opens the page in the online GitHub editor. This
+    functionality requires that the user have and be logged in to a GitHub
+    account. Otherwise, the user will be redirected to a login/signup page.
+    Alternatively, use the `blob` path to open a read-only view, which supports
+    anonymous access. E.g. `blob/master/docs/`
 
 ### site_description
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -204,7 +204,7 @@ class RepoURL(URL):
 
         if config['repo_url'] is not None and config.get('edit_uri') is None:
             if config['repo_name'].lower() == 'github':
-                config['edit_uri'] = 'blob/master/docs/'
+                config['edit_uri'] = 'edit/master/docs/'
             elif config['repo_name'].lower() == 'bitbucket':
                 config['edit_uri'] = 'src/default/docs/'
 

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -130,7 +130,7 @@ class RepoURLTest(unittest.TestCase):
         option = config_options.RepoURL()
         config = {'repo_url': "https://github.com/mkdocs/mkdocs"}
         option.post_validation(config, 'repo_url')
-        self.assertEqual(config['edit_uri'], 'blob/master/docs/')
+        self.assertEqual(config['edit_uri'], 'edit/master/docs/')
 
     def test_edit_uri_bitbucket(self):
 


### PR DESCRIPTION
Rather than the view-based `blob` URL, default to the `edit` URL for GitHub-hosted repositories. Also update the release notes.

See #975 for previous work and the discussion leading to this change.