### PR TITLE
Add white-space: pre-wrap to code in the readthedocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -56,6 +56,7 @@ code {
  */
 p code {
     word-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 /**


### PR DESCRIPTION
I think this offers the best compromise. This is based on my
testing of the suggestion @facelessuser made.

Fixes #709