### PR TITLE
Link to the repo from the MkDocs theme

### DIFF
--- a/mkdocs/themes/mkdocs/nav.html
+++ b/mkdocs/themes/mkdocs/nav.html
@@ -69,9 +69,9 @@
               {%- endblock %}
 
               {%- block repo %}
-                {%- if page and page.edit_url %}
+                {%- if repo_url %}
                     <li>
-                        <a href="{{ page.edit_url }}">
+                        <a href="{{ repo_url }}">
                             {%- if repo_name == 'GitHub' %}
                                 <i class="fa fa-github"></i>
                             {%- elif repo_name == 'Bitbucket' -%}


### PR DESCRIPTION
Unlike the readthedocs theme, the wording isn't "edit on .." or
similar. Taking users to the edit page is therefore confusing.

Fixes #269