### PR TITLE
Remove extra theme_dir alias

### DIFF
--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -205,19 +205,19 @@ work with the structure of the site. See [Template Variables] for a list of
 variables you can use within your custom blocks. For a more complete
 explaination of blocks, consult the [Jinja documentation].
 
+[browse source]: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/themes/mkdocs
 [built-in themes]: #built-in-themes
-[third party themes]: #third-party-themes
-[docs_dir]: #using-the-docs_dir
-[customize]: #customizing-a-theme
-[custom theme]: ./custom-themes.md
-[ReadTheDocs]: ./deploying-your-docs.md#readthedocs
 [community wiki]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
+[custom theme]: ./custom-themes.md
+[customize]: #customizing-a-theme
+[docs_dir]: #using-the-docs_dir
 [documentation directory]: ./configuration/#docs_dir
 [extra_css]: ./configuration.md#extra_css
 [extra_javascript]: ./configuration.md#extra_javascript
-[theme_dir]: ./configuration/#theme_dir
-[theme]: ./configuration/#theme
-[mkdocs]: #mkdocs
-[browse source]: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/themes/mkdocs
-[Template Variables]: ./custom-themes.md#template-variables
 [Jinja documentation]: http://jinja.pocoo.org/docs/dev/templates/#template-inheritance
+[mkdocs]: #mkdocs
+[ReadTheDocs]: ./deploying-your-docs.md#readthedocs
+[Template Variables]: ./custom-themes.md#template-variables
+[theme]: ./configuration/#theme
+[theme_dir]: ./configuration/#theme_dir
+[third party themes]: #third-party-themes

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -77,7 +77,7 @@ changes were automatically picked up and the documentation will be updated.
 
     Any extra CSS or JavaScript files will be added to the generated HTML
     document after the page content. If you desire to include a JavaScript
-    library, you may have better sucess including the library by using the
+    library, you may have better success including the library by using the
     [theme_dir].
 
 ### Using the theme_dir
@@ -208,7 +208,6 @@ explaination of blocks, consult the [Jinja documentation].
 [built-in themes]: #built-in-themes
 [third party themes]: #third-party-themes
 [docs_dir]: #using-the-docs_dir
-[theme_dir]: #using-the-theme_dir
 [customize]: #customizing-a-theme
 [custom theme]: ./custom-themes.md
 [ReadTheDocs]: ./deploying-your-docs.md#readthedocs


### PR DESCRIPTION
theme_dir is listed twice at the bottom links, this removed the
one that relates to this page. All usages make sense when linking
directly to the config page.