### PR TITLE
Start the deprecation of auto-populating extra_css and extra_javascript

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -382,6 +382,16 @@ class Extras(OptionallyRequired):
 
         config[key_name] = extras
 
+        if not extras:
+            return
+
+        self.warnings.append((
+            'The following files have been automatically included in the '
+            'documentation build and will be added to the HTML: {}. In '
+            'MkDocs they will need to be explicitly included with the '
+            'extra_javascript and extra_css config settings.'
+        ).format(','.join(extras)))
+
 
 class Pages(Extras):
     """


### PR DESCRIPTION
See #986 

This is perhaps a bit rough, and could probably do with a test addition. I had to make an addition to the validation workflow so that warnings can be added in the post validation stage. At the same time I added support for this in the pre-validation stage too, since the logic is the same.

Outstanding bits:

- [ ] Add test
- [ ] Update the documentation to note this pending change
- [ ] Possibly change the wording of the warning