### PR TITLE
A simple method for providing a quick/dirty reload option (refs #990)

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -92,6 +92,26 @@ to support such customization.
 
 [blocks]: ../user-guide/styling-your-docs/#overriding-template-blocks
 
+#### Support for dirty builds. (#990)
+
+For large sites the build time required to create the pages can become problematic,
+thus a "dirty" build mode was created. This mode simply compares the modified time
+of the generated html and source markdown. If the markdown has changed since the
+html then the page is re-constructed. Otherwise, the page remains as is. This mode
+may be invoked in both the `mkdocs serve` and `mkdocs build` commands:
+
+```text
+mkdocs serve --dirtyreload
+```
+
+```text
+mkdocs build --dirty
+```
+
+It is important to note that this method for building the pages is for development
+of content only, since the navigation and other links do not get updated on other
+pages.
+
 ### Other Changes and Additions to Version 0.16.0
 
 * Bugfix: Support `gh-deploy` command on Windows with Python 3 (#722)

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -12,7 +12,7 @@ the primary working branch (usually `master`) of the git repository where you
 maintain the source documentation for your project, run the following command:
 
 ```sh
-mkdocs gh-deploy --clean
+mkdocs gh-deploy
 ```
 
 That's it! Behind the scenes, MkDocs will build your docs and use the [ghp-import]
@@ -66,7 +66,7 @@ host documentation for your project. Run the following commands from your
 project's root directory to upload your documentation:
 
 ```sh
-mkdocs build --clean
+mkdocs build
 python setup.py upload_docs --upload-dir=site
 ```
 
@@ -113,7 +113,7 @@ For example, a typical set of commands from the command line might look
 something like this:
 
 ```sh
-mkdocs build --clean
+mkdocs build
 scp -r ./site user@host:/path/to/server/root
 ```
 

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -51,7 +51,7 @@ def _static_server(host, port, site_dir):
 
 
 def serve(config_file=None, dev_addr=None, strict=None, theme=None,
-          theme_dir=None, livereload=True):
+          theme_dir=None, livereload='livereload'):
     """
     Start the MkDocs development server
 
@@ -59,6 +59,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
     it will rebuild the documentation and refresh the page automatically
     whenever a file is edited.
     """
+
     # Create a temporary build directory, and set some options to serve it
     tempdir = tempfile.mkdtemp()
 
@@ -69,10 +70,12 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             dev_addr=dev_addr,
             strict=strict,
             theme=theme,
-            theme_dir=theme_dir,
+            theme_dir=theme_dir
         )
         config['site_dir'] = tempdir
-        build(config, live_server=True, clean_site_dir=True)
+        live_server = livereload in ['dirty', 'livereload']
+        dirty = livereload == 'dirtyreload'
+        build(config, live_server=live_server, dirty=dirty)
         return config
 
     # Perform the initial build
@@ -81,7 +84,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
     host, port = config['dev_addr'].split(':', 1)
 
     try:
-        if livereload:
+        if livereload in ['livereload', 'dirtyreload']:
             _livereload(host, port, config, builder, tempdir)
         else:
             _static_server(host, port, tempdir)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -81,6 +81,17 @@ def yaml_load(source, loader=yaml.Loader):
             source.close()
 
 
+def modified_time(file_path):
+    """
+    Return the modified time of the supplied file. If the file does not exists zero is returned.
+    see build_pages for use.
+    """
+    if os.path.exists(file_path):
+        return os.path.getmtime(file_path)
+    else:
+        return 0.0
+
+
 def reduce_list(data_set):
     """ Reduce duplicate items in a list and preserve order """
     seen = set()
@@ -92,6 +103,7 @@ def copy_file(source_path, output_path):
     """
     Copy source_path to output_path, making sure any parent directories exist.
     """
+
     output_dir = os.path.dirname(output_path)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -129,7 +141,7 @@ def clean_directory(directory):
             os.unlink(path)
 
 
-def copy_media_files(from_dir, to_dir, exclude=None):
+def copy_media_files(from_dir, to_dir, exclude=None, dirty=False):
     """
     Recursively copy all files except markdown and exclude[ed] files into another directory.
 
@@ -155,6 +167,11 @@ def copy_media_files(from_dir, to_dir, exclude=None):
             if not is_markdown_file(filename):
                 source_path = os.path.join(source_dir, filename)
                 output_path = os.path.join(output_dir, filename)
+
+                # Do not copy when using --dirty if the file has not been modified
+                if dirty and (modified_time(source_path) < modified_time(output_path)):
+                    continue
+
                 copy_file(source_path, output_path)
 
 


### PR DESCRIPTION
This provides a --dirty-reload option to the serve command. It simply operates by comparing the modified time of the markdown and html. This is a much simpler solution to what was proposed in 
#971 and is meeting my needs well.

Note, that there was some discussion of --clean/--no-clean with the serve command. However, passing a --clean/--no-clean option to the serve command doesn't do anything since each time it runs is creates a different tmp directory (at least for me). So, effectively it is always clean. 

(closes #990)