### PR TITLE
Don't override config value for strict mode if not specified on CLI.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -138,6 +138,8 @@ pages.
 * Change "Edit on..." links to point directly to the file in the source
   repository, rather than to the root of the repository (#975), configurable
   via the new [`edit_uri`](../user-guide/configuration.md#edit_uri) setting.
+* Bugfix: Don't override config value for strict mode if not specified on CLI
+  (#738).
 
 ## Version 0.15.3 (2016-02-18)
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -9,7 +9,7 @@ import socket
 from mkdocs import __version__
 from mkdocs import utils
 from mkdocs import exceptions
-from mkdocs.config import load_config
+from mkdocs import config
 from mkdocs.commands import build, gh_deploy, new, serve
 
 log = logging.getLogger(__name__)
@@ -112,6 +112,10 @@ def serve_command(dev_addr, config_file, strict, theme, theme_dir, livereload):
 
     logging.getLogger('tornado').setLevel(logging.WARNING)
 
+    # Don't override config value if user did not specify --strict flag
+    # Conveniently, load_config drops None values
+    strict = strict or None
+
     try:
         serve.serve(
             config_file=config_file,
@@ -136,8 +140,13 @@ def serve_command(dev_addr, config_file, strict, theme, theme_dir, livereload):
 @common_options
 def build_command(clean, config_file, strict, theme, theme_dir, site_dir):
     """Build the MkDocs documentation"""
+
+    # Don't override config value if user did not specify --strict flag
+    # Conveniently, load_config drops None values
+    strict = strict or None
+
     try:
-        build.build(load_config(
+        build.build(config.load_config(
             config_file=config_file,
             strict=strict,
             theme=theme,
@@ -168,8 +177,12 @@ def json_command(clean, config_file, strict, site_dir):
                 "future MkDocs release. For details on updating: "
                 "http://www.mkdocs.org/about/release-notes/")
 
+    # Don't override config value if user did not specify --strict flag
+    # Conveniently, load_config drops None values
+    strict = strict or None
+
     try:
-        build.build(load_config(
+        build.build(config.load_config(
             config_file=config_file,
             strict=strict,
             site_dir=site_dir
@@ -189,13 +202,13 @@ def json_command(clean, config_file, strict, site_dir):
 def gh_deploy_command(config_file, clean, message, remote_branch, remote_name):
     """Deploy your documentation to GitHub Pages"""
     try:
-        config = load_config(
+        cfg = config.load_config(
             config_file=config_file,
             remote_branch=remote_branch,
             remote_name=remote_name
         )
-        build.build(config, dirty=not clean)
-        gh_deploy.gh_deploy(config, message=message)
+        build.build(cfg, dirty=not clean)
+        gh_deploy.gh_deploy(cfg, message=message)
     except exceptions.ConfigurationError as e:
         # Avoid ugly, unhelpful traceback
         raise SystemExit('\n' + str(e))

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -22,16 +22,31 @@ class CLITests(unittest.TestCase):
             cli.cli, ["serve", ], catch_exceptions=False)
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(mock_serve.call_count, 1)
+        mock_serve.assert_called_once_with(
+            config_file=None,
+            dev_addr=None,
+            strict=None,
+            theme=None,
+            theme_dir=None,
+            livereload=None
+        )
 
+    @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
-    def test_build(self, mock_build):
+    def test_build(self, mock_build, mock_load_config):
 
         result = self.runner.invoke(
             cli.cli, ["build", ], catch_exceptions=False)
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_build.call_count, 1)
+        mock_load_config.assert_called_once_with(
+            config_file=None,
+            strict=None,
+            theme=None,
+            theme_dir=None,
+            site_dir=None
+        )
 
     @mock.patch('mkdocs.commands.build.build', autospec=True)
     def test_build_verbose(self, mock_build):


### PR DESCRIPTION
Fixes #738 

This probably still needs a test or two. I just ran out of time. I'll get to it later.