### PR TITLE
Account for wide tables and wrap inline code spans.

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -318,3 +318,20 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     -moz-border-radius: 6px 0 6px 6px;
     border-radius: 6px 0 6px 6px;
 }
+
+/*
+ * Account for wide tables which go off the side.
+ * Also account for long inline code in tables
+ * 
+ * https://github.com/mkdocs/mkdocs/issues/834
+ */
+table {
+  width: 100%;
+  overflow: auto;
+  display: block;
+}
+
+table code {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -153,3 +153,20 @@ code.cs, code.c {
   border: 1px solid rgba(0, 0, 0, 0.2);
   background: rgba(255, 255, 255, 0.7);
 }
+
+/*
+ * Account for wide tables which go off the side.
+ * Also account for long inline code in tables
+ * 
+ * https://github.com/mkdocs/mkdocs/issues/834
+ */
+.rst-content table.docutils {
+  width: 100%;
+  overflow: auto;
+  display: block;
+}
+
+table code {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
The code span wrapping  eliminates the need to account for the long table as
reported, but other things might cause a table to be wider than the page,
so we still address it.

Fixes #834.

Note that I applied this to both the `readthedocs` and `mkdocs` themes. The same problem existed in both. The only difference with `mkdocs` is the entire page can scroll allowing the table to be viewed. This is better, I think.