### PR TITLE
Update github.io URL

### DIFF
--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -92,5 +92,5 @@ def gh_deploy(config, message=None, force=False):
             username, repo = path.split('/', 1)
             if repo.endswith('.git'):
                 repo = repo[:-len('.git')]
-            url = 'http://%s.github.io/%s' % (username, repo)
+            url = 'https://%s.github.io/%s/' % (username, repo)
             log.info('Your documentation should shortly be available at: ' + url)


### PR DESCRIPTION
- Add missing trailing / when printing out GitHub URL. Without the trailing `/` a GitHub error message is shown
- Switched from `http` to `https`, since it's now enabled by default by GitHub