### PR TITLE
Account for wide tables and wrap inline code spans.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -166,6 +166,10 @@ better conform with the documented [layout].
   (#738).
 * Add a `--force` flag to the `gh-deploy` command to force the push to the
   repository (#973).
+* Improve alignment for current selected menu item in readthedocs theme (#888).
+* `http://user.github.io/repo` => `https://user.github.io/repo/` (#1029).
+* Improve installation instructions (#1028).
+* Account for wide tables and consistently wrap inline code spans (#834).
 
 ## Version 0.15.3 (2016-02-18)
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -218,7 +218,6 @@ directory path.
     If you're using another source code control tool, you'll want to check its
     documentation on how to ignore specific directories.
 
-
 ### extra_css
 
 Set a list of CSS files in your `docs_dir` to be included by the theme. For

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -10,7 +10,6 @@ A guide to creating and distributing custom themes.
     [community wiki](https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes). If
     you want to share a theme you create, you should list it on the Wiki.
 
-
 When creating a new theme, you can either follow the steps in this guide to
 create one from scratch or you can download the `mkdocs-basic-theme` as a
 basic, yet complete, theme with all the boilerplate required. **You can find

--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -108,11 +108,15 @@ code {
     background: #fff;
     border: solid 1px #e1e4e5;
     color: #333;
+    white-space: pre-wrap;
+    word-wrap: break-word;
 }
 
 pre code {
     background: transparent;
     border: none;
+    white-space: pre;
+    word-wrap: normal;
 }
 
 a code {

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -156,3 +156,22 @@ code.cs, code.c {
   border: 1px solid rgba(0, 0, 0, 0.2);
   background: rgba(255, 255, 255, 0.7);
 }
+
+/*
+ * Account for wide tables which go off the side.
+ * Override borders to avoid wierdness on narrow tables.
+ * 
+ * https://github.com/mkdocs/mkdocs/issues/834
+ * https://github.com/mkdocs/mkdocs/pull/1034
+ */
+.rst-content table.docutils {
+    width: 100%;
+    overflow: auto;
+    display: block;
+    border: none;
+}
+
+td, th {
+   border: 1px solid #e1e4e5 !important;
+   border-collapse: collapse;
+}

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -39,24 +39,17 @@
 }
 
 /*
- * Fix wrapping in the code highlighting
- *
- * https://github.com/mkdocs/mkdocs/issues/233
- */
-code {
-    white-space: pre;
-    padding: 2px 5px;
-}
-
-/*
  * Wrap inline code samples otherwise they shoot of the side and
  * can't be read at all.
  *
  * https://github.com/mkdocs/mkdocs/issues/313
+ * https://github.com/mkdocs/mkdocs/issues/233
+ * https://github.com/mkdocs/mkdocs/issues/834
  */
-p code {
-    word-wrap: break-word;
+code {
     white-space: pre-wrap;
+    word-wrap: break-word;
+    padding: 2px 5px;
 }
 
 /**
@@ -64,8 +57,12 @@ p code {
  * font size and padding.
  *
  * https://github.com/mkdocs/mkdocs/issues/855
+ * https://github.com/mkdocs/mkdocs/issues/834
+ * https://github.com/mkdocs/mkdocs/issues/233
  */
 pre code {
+  white-space: pre;
+  word-wrap: normal;
   display: block;
   padding: 12px;
   font-size: 12px;


### PR DESCRIPTION
A better fix for #834. Also see discussions on PRs #1027 and #1034, of which this is a replacement.

This was tested with [this gist][1] as a sample test page.

[1]: https://gist.github.com/waylan/f5503feb9177ffc3aa790561d8220598

That page renders like this in the `readthedocs` theme:

![rtd](https://cloud.githubusercontent.com/assets/78846/17984587/e0880370-6adf-11e6-85cb-c3d32f2b4923.png)

And like this in the `mkdocs` theme:

![mkdocs](https://cloud.githubusercontent.com/assets/78846/17984594/e870e8b8-6adf-11e6-9bd9-1dc5466023e7.png)
