### PR TITLE
Use absolute URLs in nav & media links from error templates.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -170,6 +170,7 @@ better conform with the documented [layout].
 * `http://user.github.io/repo` => `https://user.github.io/repo/` (#1029).
 * Improve installation instructions (#1028).
 * Account for wide tables and consistently wrap inline code spans (#834).
+* Bugfix: Use absolute URLs in nav & media links from error templates (#77).
 
 ## Version 0.15.3 (2016-02-18)
 

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -297,7 +297,16 @@ def build_pages(config, dump_json=False, dirty=False):
     env.filters['tojson'] = filters.tojson
     search_index = search.SearchIndex()
 
+    # Force absolute URLs in the nav of error pages and account for the
+    # possability that the docs root might be different than the server root.
+    # See https://github.com/mkdocs/mkdocs/issues/77
+    site_navigation.url_context.force_abs_urls = True
+    default_base = site_navigation.url_context.base_path
+    site_navigation.url_context.base_path = utils.urlparse(config['site_url']).path
     build_template('404.html', env, config, site_navigation)
+    # Reset nav behavior to the default
+    site_navigation.url_context.force_abs_urls = False
+    site_navigation.url_context.base_path = default_base
 
     if not build_template('search.html', env, config, site_navigation):
         log.debug("Search is enabled but the theme doesn't contain a "

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -82,6 +82,7 @@ class URLContext(object):
 
     def __init__(self):
         self.base_path = '/'
+        self.force_abs_urls = False
 
     def set_current_url(self, current_url):
         self.base_path = os.path.dirname(current_url)
@@ -91,6 +92,10 @@ class URLContext(object):
         Given a URL path return it as a relative URL,
         given the context of the current page.
         """
+        if self.force_abs_urls:
+            abs_url = '%s/%s' % (self.base_path.rstrip('/'), utils.path_to_url(url.lstrip('/')))
+            return abs_url.rstrip('/')
+
         suffix = '/' if (url.endswith('/') and len(url) > 1) else ''
         # Workaround for bug on `os.path.relpath()` in Python 2.6
         if self.base_path == '/':

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -271,6 +271,12 @@ class SiteNavigationTests(unittest.TestCase):
 
         self.assertEqual([n.title for n in nav_items],
                          ['Home', 'Running', 'Notes', 'License'])
+        self.assertEqual([n.url for n in nav_items], [
+            '.',
+            'api-guide/running/',
+            'about/notes/',
+            'about/sub/license/'
+        ])
         self.assertEqual([p.title for p in pages],
                          ['Home', 'Running', 'Notes', 'License'])
 
@@ -291,8 +297,65 @@ class SiteNavigationTests(unittest.TestCase):
 
         self.assertEqual([n.title for n in nav_items],
                          ['Home', 'Running', 'Notes', 'License'])
+        self.assertEqual([n.url for n in nav_items], [
+            '.',
+            'api-guide/running/',
+            'about/notes/',
+            'about/sub/license/'
+        ])
         self.assertEqual([p.title for p in pages],
                          ['Home', 'Running', 'Notes', 'License'])
+
+    def test_force_abs_urls(self):
+        """
+        Verify force absolute URLs
+        """
+
+        pages = [
+            'index.md',
+            'api-guide/running.md',
+            'about/notes.md',
+            'about/sub/license.md',
+        ]
+
+        url_context = nav.URLContext()
+        url_context.force_abs_urls = True
+        nav_items, pages = nav._generate_site_navigation(pages, url_context)
+
+        self.assertEqual([n.title for n in nav_items],
+                         ['Home', 'Running', 'Notes', 'License'])
+        self.assertEqual([n.url for n in nav_items], [
+            '',
+            '/api-guide/running',
+            '/about/notes',
+            '/about/sub/license'
+        ])
+
+    def test_force_abs_urls_with_base(self):
+        """
+        Verify force absolute URLs
+        """
+
+        pages = [
+            'index.md',
+            'api-guide/running.md',
+            'about/notes.md',
+            'about/sub/license.md',
+        ]
+
+        url_context = nav.URLContext()
+        url_context.force_abs_urls = True
+        url_context.base_path = '/foo/'
+        nav_items, pages = nav._generate_site_navigation(pages, url_context)
+
+        self.assertEqual([n.title for n in nav_items],
+                         ['Home', 'Running', 'Notes', 'License'])
+        self.assertEqual([n.url for n in nav_items], [
+            '/foo',
+            '/foo/api-guide/running',
+            '/foo/about/notes',
+            '/foo/about/sub/license'
+        ])
 
     def test_invalid_pages_config(self):
 


### PR DESCRIPTION
An error page can be served from any location and therefore it is
impossable to pre-build an error page with correct relative URLs.
With absolute URLs, the error pages will properly link to other
pages in the nav as well as media files (css, js, images, etc) from
the template regardless of the actual URL the file is served from.

However, to continue to support environments where the docs root is a subdir
of the server root, all other pages must continue to use relative URLs.
The `site_url` is used to determine the server root when building
absolute URLs for the error page to ensure those URLs continue to work
in that type of environment.

Relative URLs are also nessecary for those who browse the site on the
local file system (via `file://`). In that case, the error page will be
broken. However, as error pages are not served by a local file system,
this is no more than a minor inconvience. Error pages should always be
tested from a server environment.

Fixes #77.