### PR TITLE
Allow headers to point to index pages in Nav.

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -1,0 +1,35 @@
+# About MkDocs
+
+An open-source static site generator
+
+---
+
+MkDocs is a fast, simple and downright gorgeous static site generator that's
+geared towards building project documentation. Documentation source files are
+written in Markdown, and configured with a single YAML configuration file.
+
+* Browse the [sourecode](https://github.com/mkdocs/mkdocs) on GitHub.
+* Download the latest release from [PyPI](https://pypi.python.org/pypi/mkdocs).
+* Visit the [MkDocs wiki](https://github.com/mkdocs/mkdocs/wiki) for community
+  resources, including third party themes, user submitted tips and tricks, and
+  a list of MkDocs users.
+* Chat at IRC channel `#mkdocs` on freenode.
+* Get support and discuss future enhancements on [Google
+  Groups](https://groups.google.com/forum/#!forum/mkdocs)
+* [Report bugs](https://github.com/mkdocs/mkdocs/issues) on GitHub.
+
+## Maintenance Team
+
+The current and past members of the MkDocs team.
+
+* [@tomchristie](https://github.com/tomchristie/)
+* [@d0ugal](https://github.com/d0ugal/)
+* [@waylan](https://github.com/waylan/)
+
+## Additional Information
+
+For additional information, see the following pages:
+
+* [Release Notes](release-notes.md)
+* [Contributing](contributing.md)
+* [License](license.md)

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -217,6 +217,7 @@ better conform with the documented [layout].
 * Improve installation instructions (#1028).
 * Account for wide tables and consistently wrap inline code spans (#834).
 * Bugfix: Use absolute URLs in nav & media links from error templates (#77).
+* Add support for sections headers to point to index pages in Nav (#73).
 
 ## Version 0.15.3 (2016-02-18)
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -13,14 +13,6 @@ You can determine your currently installed version using `mkdocs --version`:
     $ mkdocs --version
     mkdocs, version 0.15.2
 
-## Maintenance team
-
-The current and past members of the MkDocs team.
-
-* [@tomchristie](https://github.com/tomchristie/)
-* [@d0ugal](https://github.com/d0ugal/)
-* [@waylan](https://github.com/waylan/)
-
 ## Version 0.16 (2016-02-??)
 
 ### Major Additions to Version 0.16.0

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -56,6 +56,26 @@ and About. Then under User Guide we have two pages, Writing your docs and
 Styling your docs. Under the About section we also have two pages, License and
 Release Notes.
 
+Note that in the above example, the "User Guide" and "About" section headers do
+not actually link to any pages. They are simply a container for a list of child
+pages. If you would like the section headers to also link to pages, include an
+`index` page as the first child of that section with no title defined.
+
+```no-highlight
+pages:
+- Home: 'index.md'
+- About:
+    - 'about/index.md'
+    - 'License': 'about/license.md'
+    - 'Release Notes': 'about/release-notes.md'
+```
+
+In the above example, the "About" section heading will point to the
+`about/index.md` page and no seperate entry for that page will be listed as a
+child. Only the "License" and "Release Notes" pages would be children. This will
+only work if the `index` page is the first item in the sublist and no title is
+defined for that page.
+
 ## File layout
 
 Your documentation source should be written as regular Markdown files, and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ pages:
     - Deploying Your Docs: user-guide/deploying-your-docs.md
     - Custom Themes: user-guide/custom-themes.md
 - About:
+    - about/index.md
     - Release Notes: about/release-notes.md
     - Contributing: about/contributing.md
     - License: about/license.md

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -49,6 +49,7 @@ class SiteNavigationTests(unittest.TestCase):
                 {'Debugging': 'api-guide/debugging.md'},
             ]},
             {'About': [
+                'about/index.md',
                 {'Release notes': 'about/release-notes.md'},
                 {'License': 'about/license.md'}
             ]}
@@ -59,14 +60,14 @@ class SiteNavigationTests(unittest.TestCase):
             Running - /api-guide/running/
             Testing - /api-guide/testing/
             Debugging - /api-guide/debugging/
-        About
+        About - /about/
             Release notes - /about/release-notes/
             License - /about/license/
         """)
         site_navigation = nav.SiteNavigation(pages)
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.nav_items), 3)
-        self.assertEqual(len(site_navigation.pages), 6)
+        self.assertEqual(len(site_navigation.pages), 7)
 
     def test_nested_ungrouped(self):
         pages = [

--- a/mkdocs/themes/mkdocs/nav-sub.html
+++ b/mkdocs/themes/mkdocs/nav-sub.html
@@ -3,8 +3,13 @@
     <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
 </li>
 {%- else %}
-  <li class="dropdown-submenu">
-    <a href="#">{{ nav_item.title }}</a>
+  <li class="dropdown-submenu  btn-group">
+    {%- if nav_item.url %}
+        <a href="{{ nav_item.url }}" class="btn">{{ nav_item.title }}</a>
+        <a href="#" class="btn dropdown-toggle" data-toggle="dropdown" role="button"><b class="caret"></b></a>
+    {%- else %}
+        <a href="#" class="btn dropdown-toggle" data-toggle="dropdown" role="button">{{ nav_item.title }} <b class="caret"></b></a>
+    {%- endif %}
     <ul class="dropdown-menu">
         {%- for nav_item in nav_item.children %}
             {% include "nav-sub.html" %}

--- a/mkdocs/themes/mkdocs/nav.html
+++ b/mkdocs/themes/mkdocs/nav.html
@@ -26,8 +26,13 @@
                 <ul class="nav navbar-nav">
                 {%- for nav_item in nav %}
                 {%- if nav_item.children %}
-                    <li class="dropdown{% if nav_item.active %} active{% endif %}">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
+                    <li class="dropdown btn-group{% if nav_item.active %} active{% endif %}">
+                        {%- if nav_item.url %}
+                            <a href="{{ nav_item.url }}" class="btn">{{ nav_item.title }}</a>
+                            <a href="#" class="btn dropdown-toggle" data-toggle="dropdown" role="button"><b class="caret"></b></a>
+                        {%- else %}
+                            <a href="#" class="btn dropdown-toggle" data-toggle="dropdown" role="button">{{ nav_item.title }} <b class="caret"></b></a>
+                        {%- endif %}
                         <ul class="dropdown-menu">
                         {%- for nav_item in nav_item.children %}
                             {% include "nav-sub.html" %}

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -76,8 +76,11 @@
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
         {%- block site_nav %}
 	<ul class="current">
+	  {% set navlevel = 1 %}
           {% for nav_item in nav %}
-            <li>{% include "toc.html" %}<li>
+            <li class="toctree-l{{ navlevel }}{% if nav_item.active%} current{%endif%}">
+		{% include 'nav.html' %}
+	    </li>
           {% endfor %}
         </ul>
 	{%- endblock %}

--- a/mkdocs/themes/readthedocs/nav.html
+++ b/mkdocs/themes/readthedocs/nav.html
@@ -1,0 +1,22 @@
+{%- if nav_item.url %}
+    <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+{%- else %}
+    <span class="caption-text">{{ nav_item.title }}</span>
+{%- endif %}
+
+{%- if nav_item == page or nav_item.children %}
+    <ul class="subnav">
+        {%- if nav_item == page %}
+            {% include 'toc.html' %}
+        {%- endif %}
+        {%- if nav_item.children %}
+            {%- set navlevel = navlevel + 1%}
+            {%- for nav_item in nav_item.children %}
+                <li class="toctree-l{{ navlevel }}{% if nav_item.active%} current{%endif%}">
+                    {% include 'nav.html' %}
+                </li>
+            {%- endfor %}
+            {%- set navlevel = navlevel - 1%}
+        {%- endif %}
+    </ul>
+{%- endif %}

--- a/mkdocs/themes/readthedocs/toc.html
+++ b/mkdocs/themes/readthedocs/toc.html
@@ -1,23 +1,10 @@
-{% if nav_item.children %}
-    <ul class="subnav">
-    <li><span>{{ nav_item.title }}</span></li>
-
-        {% for nav_item in nav_item.children %}
-            {% include 'toc.html' %}
+{% for toc_item in page.toc %}
+    <li class="toctree-l{{ navlevel + 1 }}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+    {% if toc_item.children %}
+        <ul>
+        {% for toc_item in toc_item.children %}
+            <li><a class="toctree-l{{ navlevel + 2 }}" href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
         {% endfor %}
-    </ul>
-{% else %}
-    <li class="toctree-l1 {% if nav_item.active%}current{%endif%}">
-        <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-        {% if nav_item == page %}
-            <ul>
-            {% for toc_item in page.toc %}
-                <li class="toctree-l3"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
-                {% for toc_item in toc_item.children %}
-                    <li><a class="toctree-l4" href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
-                {% endfor %}
-            {% endfor %}
-            </ul>
-        {% endif %}
-    </li>
-{% endif %}
+        </ul>
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
If the first child is a Nav Header is a `index.md` page, then that page
is assigned as the URL of the Header. The problem is that you can't
actually access it from the Nav as the click is interrupted to display/hide
the dropdown list of children.

Almost fixes #73.

Also need to update the readthedocs theme.
