### PR TITLE
fixed link for community docs and theme options

### DIFF
--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -6,12 +6,15 @@ A guide to creating and distributing custom themes.
 
 !!! Note
 
-    If you are looking for third party themes, they are listed in the MkDocs
-    [community wiki](https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes). If
-    you want to share a theme you create, you should list it on the Wiki.
+If you are looking for third party themes, they are listed in the
+[MkDocs community wiki](https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes). If 
+you want to share a theme you create, you should list it on the Wiki.
 
-When creating a new theme, you can either follow the steps in this guide to
-create one from scratch or you can download the `mkdocs-basic-theme` as a
+When creating a new theme, you have a few options:
+- You can follow the steps in this guide to
+below to create one from scratch
+
+- You can download the `mkdocs-basic-theme` as a
 basic, yet complete, theme with all the boilerplate required. **You can find
 this base theme on [GitHub](https://github.com/mkdocs/mkdocs-basic-theme)**.
 It contains detailed comments in the code to describe the different features


### PR DESCRIPTION
Removed indent on initial note about where to find MkDocs community themes and added bullet points to lay out theme building choices.