### PR TITLE
Optimize search by building index locally.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -190,6 +190,22 @@ better conform with the documented [layout].
 
 [layout]: ../user-guide/writing-your-docs/#file-layout
 
+#### Support for Pre-Built Search Index
+
+Previously, on each page load, the search index would need to be rebuilt from a
+JSON file of all the data by the client. While this was okay for small sites, it
+created a real burden on large sites (with hundreds of pages) and has been known
+to cause the entire browser to hang while the index is being built. MkDocs will
+now attempt to pre-build the index as a seperate JSON file, which is loaded by
+the client. Note that this new behavior only works if [Node.js] is installed on
+the build machine. If the build fails for any reason, MkDocs falls back to the
+old behavior. There are no settings to alter the behavior; MkDocs just uses the
+best option available on a given system. It is expected that most users will not
+need to do anything about this. However, users with large sites are encouraged
+to have Node.js installed on there build machines.
+
+[Node.js]: https://nodejs.org/
+
 ### Other Changes and Additions to Version 0.16.0
 
 * Bugfix: Support `gh-deploy` command on Windows with Python 3 (#722)

--- a/mkdocs/assets/search/mkdocs/js/search.js
+++ b/mkdocs/assets/search/mkdocs/js/search.js
@@ -2,55 +2,72 @@ require([
     base_url + '/mkdocs/js/mustache.min.js',
     base_url + '/mkdocs/js/lunr.min.js',
     'text!search-results-template.mustache',
+    'text!../search_data.json',
     'text!../search_index.json',
-], function (Mustache, lunr, results_template, data) {
-   "use strict";
+], function (Mustache, lunr, results_template, data, indexDump) {
+    "use strict";
 
-    function getSearchTerm()
-    {
+    function getSearchTerm() {
         var sPageURL = window.location.search.substring(1);
         var sURLVariables = sPageURL.split('&');
-        for (var i = 0; i < sURLVariables.length; i++)
-        {
+        for (var i = 0; i < sURLVariables.length; i++) {
             var sParameterName = sURLVariables[i].split('=');
-            if (sParameterName[0] == 'q')
-            {
+            if (sParameterName[0] == 'q') {
                 return decodeURIComponent(sParameterName[1].replace(/\+/g, '%20'));
             }
         }
     }
 
-    var index = lunr(function () {
-        this.field('title', {boost: 10});
-        this.field('text');
-        this.ref('location');
-    });
+    function isEmptyObject(obj) {
+        // See http://stackoverflow.com/a/34491287/866026
+        for (var x in obj) { return false; }
+        return true;
+    }
 
+    indexDump = JSON.parse(indexDump);
     data = JSON.parse(data);
     var documents = {};
 
-    for (var i=0; i < data.docs.length; i++){
-        var doc = data.docs[i];
-        doc.location = base_url + doc.location;
-        index.add(doc);
-        documents[doc.location] = doc;
+    if (! isEmptyObject(indexDump)) {
+        // Load prebuilt index
+        console.debug('Loading pre-built index...');
+        var index = lunr.Index.load(indexDump);
+
+        for (var i=0; i < data.docs.length; i++) {
+            var doc = data.docs[i];
+            documents[doc.location] = doc;
+        }
+    } else {
+        // No prebuilt index. create it
+        console.debug('Building index...');
+        var index = lunr(function () {
+            this.field('title', {boost: 10});
+            this.field('text');
+            this.ref('location');
+        });
+
+        for (var i=0; i < data.docs.length; i++) {
+            var doc = data.docs[i];
+            doc.location = base_url + doc.location;
+            index.add(doc);
+            documents[doc.location] = doc;
+        }
     }
 
-    var search = function(){
-
+    var search = function() {
         var query = document.getElementById('mkdocs-search-query').value;
         var search_results = document.getElementById("mkdocs-search-results");
         while (search_results.firstChild) {
             search_results.removeChild(search_results.firstChild);
         }
 
-        if(query === ''){
+        if(query === '') {
             return;
         }
 
         var results = index.search(query);
 
-        if (results.length > 0){
+        if (results.length > 0) {
             for (var i=0; i < results.length; i++){
                 var result = results[i];
                 doc = documents[result.ref];
@@ -63,26 +80,24 @@ require([
             search_results.insertAdjacentHTML('beforeend', "<p>No results found</p>");
         }
 
-        if(jQuery){
+        if(jQuery) {
             /*
              * We currently only automatically hide bootstrap models. This
              * requires jQuery to work.
              */
-            jQuery('#mkdocs_search_modal a').click(function(){
+            jQuery('#mkdocs_search_modal a').click(function() {
                 jQuery('#mkdocs_search_modal').modal('hide');
             })
         }
-
     };
 
     var search_input = document.getElementById('mkdocs-search-query');
 
     var term = getSearchTerm();
-    if (term){
+    if (term) {
         search_input.value = term;
         search();
     }
 
     search_input.addEventListener("keyup", search);
-
 });

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -338,9 +338,15 @@ def build_pages(config, dump_json=False, dirty=False):
             log.error("Error building page %s", page.input_path)
             raise
 
+    log.debug('Building search_data.json')
+    search_data = search_index.generate_search_data()
+    search_data_path = os.path.join(config['site_dir'], 'mkdocs', 'search_data.json')
+    utils.write_file(search_data.encode('utf-8'), search_data_path)
+
+    log.debug('Building search_index.json')
     search_index = search_index.generate_search_index()
-    json_output_path = os.path.join(config['site_dir'], 'mkdocs', 'search_index.json')
-    utils.write_file(search_index.encode('utf-8'), json_output_path)
+    search_index_path = os.path.join(config['site_dir'], 'mkdocs', 'search_index.json')
+    utils.write_file(search_index.encode('utf-8'), search_index_path)
 
 
 def build(config, live_server=False, dump_json=False, dirty=False):

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -4,3 +4,4 @@ livereload==2.3.2
 Markdown==2.5
 PyYAML==3.10
 tornado==4.1
+PyExecJS>=1.4

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -4,3 +4,4 @@ livereload>=2.3.2
 Markdown>=2.5
 PyYAML>=3.10
 tornado>=4.1
+PyExecJS>=1.4

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Markdown>=2.3.1,<2.5' if PY26 else 'Markdown>=2.3.1',
         'PyYAML>=3.10',
         'tornado>=4.1',
+        'PyExecJS>=1.4',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This builds an actual lunr.js search index via Node.js in addition to a JSON
array of page objects previously used to build the index client side. Note that
both are needed as the array of page objects is used to display search
results.

If Node fails (not installed or errors out), then fallback to old behavior
by creating an empty index. If the client (browser) receives an empty index,
then it builds the index from the array of pages as previously, which is
fine for most (small) sites. Large sites will want to make sure Node is
installed to avoid the browser from hanging during index creation.

Partially addresses #859.
