### PR TITLE
Consistently use "dirty" to indicate dirtyreload server.

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -106,7 +106,7 @@ def cli():
 @click.option('-e', '--theme-dir', type=click.Path(), help=theme_dir_help)
 @click.option('--livereload', 'livereload', flag_value='livereload', help=reload_help, default=True)
 @click.option('--no-livereload', 'livereload', flag_value='no-livereload', help=no_reload_help)
-@click.option('-d', '--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
+@click.option('--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
 @common_options
 def serve_command(dev_addr, config_file, strict, theme, theme_dir, livereload):
     """Run the builtin development server"""

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -74,7 +74,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
         )
         config['site_dir'] = tempdir
         live_server = livereload in ['dirty', 'livereload']
-        dirty = livereload == 'dirtyreload'
+        dirty = livereload == 'dirty'
         build(config, live_server=live_server, dirty=dirty)
         return config
 
@@ -84,7 +84,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
     host, port = config['dev_addr'].split(':', 1)
 
     try:
-        if livereload in ['livereload', 'dirtyreload']:
+        if livereload in ['livereload', 'dirty']:
             _livereload(host, port, config, builder, tempdir)
         else:
             _static_server(host, port, tempdir)


### PR DESCRIPTION
Also removed the short option `-d` from the `--dirtyreload` flag to match
the other options. Fixes #1074