### PR TITLE
Added deploy-docs script to build and push to gh-pages on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
 - tox
 before_install: pip install codecov
 after_success: codecov
+after_deploy: test $TRAVIS_BRANCH == "master" && bash ./deploy-docs.sh
 deploy:
   provider: pypi
   user: mkdocsdeploy

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+GH_REPO="@github.com/mkdocs/mkdocs.git"
+FULL_REPO="https://${GH_TOKEN}$GH_REPO"
+GH_NAME="mkdocs";
+GH_EMAIL="travis@mkdocs.org"
+
+mkdir -p out
+cd out
+
+git init
+git remote add origin $FULL_REPO
+git fetch
+git config user.name $GH_NAME
+git config user.email $GH_EMAIL
+git checkout gh-pages
+
+cd ../
+
+mkdocs build --clean -d out
+
+cd out
+
+touch .
+git add -A .
+git commit -m "GH-Pages update by travis after $TRAVIS_COMMIT"
+git push -q origin gh-pages


### PR DESCRIPTION
Fixes: #814

Sorry it took so long.

For this to work you need to set an environment variable in Travis: https://travis-ci.org/mkdocs/mkdocs/settings called GH_TOKEN with a personal access token. This is then used within the script from the travis build environment but they hide it from output.

I hope this is what you had in mind, if not, let me know and I'll make the necessary changes.
