### PR TITLE
Flake8 Cleanup.

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -223,5 +223,6 @@ def new_command(project_directory):
     """Create a new MkDocs project"""
     new.new(project_directory)
 
+
 if __name__ == '__main__':  # pragma: no cover
     cli()

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -262,7 +262,6 @@ def build_pages(config, dump_json=False, dirty=False):
         'content': 'page.content',
         'toc': 'page.toc',
         'meta': 'page.meta',
-        'current_page': 'page.current_page',
         'canonical_url': 'page.canonical_url',
         'previous_page': 'page.previous_page',
         'next_page': 'page.next_page',

--- a/mkdocs/tests/integration.py
+++ b/mkdocs/tests/integration.py
@@ -66,5 +66,6 @@ def main(output=None):
 
     log.debug("Theme and integration builds are in {0}".format(output))
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Newly released Flake8 version 3.2.0 resulted in a few previously missed
[errors being reported][1] for the first time. First observed in #1091.

[1]: https://travis-ci.org/mkdocs/mkdocs/jobs/175856685#L224