### PR TITLE
Remove pypy3 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ env:
 - TOXENV=pypy-integration
 - TOXENV=pypy-min-req
 - TOXENV=pypy-unittests
-- TOXENV=pypy3-integration
-- TOXENV=pypy3-min-req
-- TOXENV=pypy3-unittests
 install:
 - pip install tox
 - gem install mdl


### PR DESCRIPTION
This just seems to be causing problems, it seems it is a very old version of pypy/Python 3 and pip refuses to work with it.