### PR TITLE
Allow pypy3 failures for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ install:
 script:
 - git clean -f -d -x
 - tox
+matrix:
+  allow_failures:
+    - env: TOXENV=pypy3-integration
+    - env: TOXENV=pypy3-min-req
+    - env: TOXENV=pypy3-unittests
 before_install: pip install codecov
 after_success: codecov
 deploy:


### PR DESCRIPTION
It seems that the pypy3 version is old and pip no longer supports it. We can maybe remove this entirely, but for now lets keep it but turn the build green again.