### PR TITLE
Up livereload version to >=2.5.1.

### DIFF
--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -1,6 +1,6 @@
 click==3.3
 Jinja2==2.7.1
-livereload==2.3.2
+livereload==2.5.1
 Markdown==2.5
 PyYAML==3.10
 tornado==4.1

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,6 +1,6 @@
 click>=3.3
 Jinja2>=2.7.1
-livereload>=2.3.2
+livereload>=2.5.1
 Markdown>=2.5
 PyYAML>=3.10
 tornado>=4.1

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=[
         'click>=3.3',
         'Jinja2>=2.7.1',
-        'livereload>=2.3.2',
+        'livereload>=2.5.1',
         'Markdown>=2.3.1,<2.5' if PY26 else 'Markdown>=2.3.1',
         'PyYAML>=3.10',
         'tornado>=4.1',


### PR DESCRIPTION
This ensures older pyinotify versions don't break the livereload server.
Fixes #1106.