### PR TITLE
Respect order of config extensions

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -525,6 +525,8 @@ class MarkdownExtensions(OptionallyRequired):
                 if len(item) > 1:
                     raise ValidationError('Invalid Markdown Extensions configuration')
                 ext, cfg = item.popitem()
+                if ext in self.builtins:
+                    self.builtins.remove(ext)
                 extensions.append(ext)
                 if cfg is None:
                     continue
@@ -533,6 +535,8 @@ class MarkdownExtensions(OptionallyRequired):
                                           "Extension '{0}'.".format(ext))
                 self.configdata[ext] = cfg
             elif isinstance(item, utils.string_types):
+                if item in self.builtins:
+                    self.builtins.remove(item)
                 extensions.append(item)
             else:
                 raise ValidationError('Invalid Markdown Extensions configuration')


### PR DESCRIPTION
In some particular case we need to reorder of builtin extensions,
and all the markdown extensions are putted at the `_end`. And the
builtin extension are execute before our extensions.

With this change if a builtin extension is defined in the config
then is removed from builtin and added in the configuration order

In particular we need the `toc` extension after our [i18n extension](https://github.com/gisce/markdown-i18n)
to get the menu translated.

Then I don't know if have sense to execute `utils.reduce_list(self.builtins + extensions)` if they are removed from `self.builtins` if come from config.

If there is another way to accomplish that let me know.