### PR TITLE
Compress search_index.json

### DIFF
--- a/mkdocs/search.py
+++ b/mkdocs/search.py
@@ -35,6 +35,16 @@ class SearchIndex(object):
         A simple wrapper to add an entry and ensure the contents
         is UTF8 encoded.
         """
+        # Sanity check to compress JSON
+        text=text.replace(u'\u00a0', ' ')
+        text=text.replace('  ', ' ')
+        text=text.replace('\n\n', ' ')
+        text=text.replace('  ', ' ')
+        text=text.replace('\n ', ' ')
+        text=text.replace('  ', ' ')
+        text=text.replace(' \n', ' ')
+        text=text.replace('  ', ' ')
+        text=text.replace('  ', ' ')
         self._entries.append({
             'title': title,
             'text': utils.text_type(text.strip().encode('utf-8'), encoding='utf-8'),
@@ -90,7 +100,7 @@ class SearchIndex(object):
         page_dicts = {
             'docs': self._entries,
         }
-        return json.dumps(page_dicts, sort_keys=True, indent=4)
+        return json.dumps(page_dicts, sort_keys=True)
 
     def strip_tags(self, html):
         """strip html tags from data"""

--- a/mkdocs/search.py
+++ b/mkdocs/search.py
@@ -36,15 +36,15 @@ class SearchIndex(object):
         is UTF8 encoded.
         """
         # Sanity check to compress JSON
-        text=text.replace(u'\u00a0', ' ')
-        text=text.replace('  ', ' ')
-        text=text.replace('\n\n', ' ')
-        text=text.replace('  ', ' ')
-        text=text.replace('\n ', ' ')
-        text=text.replace('  ', ' ')
-        text=text.replace(' \n', ' ')
-        text=text.replace('  ', ' ')
-        text=text.replace('  ', ' ')
+        text = text.replace(u'\u00a0', ' ')
+        text = text.replace('  ', ' ')
+        text = text.replace('\n\n', ' ')
+        text = text.replace('  ', ' ')
+        text = text.replace('\n ', ' ')
+        text = text.replace('  ', ' ')
+        text = text.replace(' \n', ' ')
+        text = text.replace('  ', ' ')
+        text = text.replace('  ', ' ')
         self._entries.append({
             'title': title,
             'text': utils.text_type(text.strip().encode('utf-8'), encoding='utf-8'),


### PR DESCRIPTION
This is a quick solution to compress search_index.json. It replaces duplicated characters. u00a0 is Unicode nowrap space. Also indentation is disable. I could shrink file from 2248293 Bytes to 1752850 Bytes. Might help with search download and start-up. Links to #1127.