### PR TITLE
Ensure nav.homepage.url is not blank on error pages.

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -76,7 +76,8 @@ def get_global_context(nav, config):
 
     return {
         'nav': nav,
-        'base_url': nav.url_context.make_relative('/'),
+        # base_url should never end with a slash.
+        'base_url': nav.url_context.make_relative('/').rstrip('/'),
 
         'extra_css': extra_css,
         'extra_javascript': extra_javascript,

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -97,7 +97,7 @@ class URLContext(object):
         """
         if self.force_abs_urls:
             abs_url = '%s/%s' % (self.base_path.rstrip('/'), utils.path_to_url(url.lstrip('/')))
-            return abs_url.rstrip('/')
+            return abs_url
 
         suffix = '/' if (url.endswith('/') and len(url) > 1) else ''
         # Workaround for bug on `os.path.relpath()` in Python 2.6

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -325,10 +325,10 @@ class SiteNavigationTests(unittest.TestCase):
         self.assertEqual([n.title for n in nav_items],
                          ['Home', 'Running', 'Notes', 'License'])
         self.assertEqual([n.url for n in nav_items], [
-            '',
-            '/api-guide/running',
-            '/about/notes',
-            '/about/sub/license'
+            '/',
+            '/api-guide/running/',
+            '/about/notes/',
+            '/about/sub/license/'
         ])
 
     def test_force_abs_urls_with_base(self):
@@ -351,10 +351,10 @@ class SiteNavigationTests(unittest.TestCase):
         self.assertEqual([n.title for n in nav_items],
                          ['Home', 'Running', 'Notes', 'License'])
         self.assertEqual([n.url for n in nav_items], [
-            '/foo',
-            '/foo/api-guide/running',
-            '/foo/about/notes',
-            '/foo/about/sub/license'
+            '/foo/',
+            '/foo/api-guide/running/',
+            '/foo/about/notes/',
+            '/foo/about/sub/license/'
         ])
 
     def test_invalid_pages_config(self):

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -286,7 +286,7 @@ def create_media_urls(nav, path_list):
             continue
         # We must be looking at a local path.
         url = path_to_url(path)
-        relative_url = '%s/%s' % (nav.url_context.make_relative('/'), url)
+        relative_url = '%s/%s' % (nav.url_context.make_relative('/').rstrip('/'), url)
         final_urls.append(relative_url)
 
     return final_urls


### PR DESCRIPTION
Also maintain pattern of ending urls with a slash in nav (all non-error pages
do so the error page shoudl also). A couple extra checks to ensure base_url
doesn't end in a slash though as it is expected that the string appended
to base_url will always begin with the slash.

Fixes #1131