### PR TITLE
Refactor readthedocs navigation template.

### DIFF
--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -76,8 +76,11 @@
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
         {%- block site_nav %}
 	<ul class="current">
+	  {% set navlevel = 1 %}
           {% for nav_item in nav %}
-            <li>{% include "toc.html" %}<li>
+            <li class="toctree-l{{ navlevel }}{% if nav_item.active and not nav_item.children %} current{%endif%}">
+		{% include 'nav.html' %}
+	    </li>
           {% endfor %}
         </ul>
 	{%- endblock %}

--- a/mkdocs/themes/readthedocs/nav.html
+++ b/mkdocs/themes/readthedocs/nav.html
@@ -1,0 +1,22 @@
+{%- if nav_item.url %}
+    <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+{%- else %}
+    <span class="caption-text">{{ nav_item.title }}</span>
+{%- endif %}
+
+{%- if nav_item == page or nav_item.children %}
+    <ul class="subnav">
+        {%- if nav_item == page %}
+            {% include 'toc.html' %}
+        {%- endif %}
+        {%- if nav_item.children %}
+            {%- set navlevel = navlevel + 1%}
+            {%- for nav_item in nav_item.children %}
+                <li class="{% if navlevel > 2 %}toctree-l{{ navlevel }}{% endif %}{% if nav_item.active%} current{%endif%}">
+                    {% include 'nav.html' %}
+                </li>
+            {%- endfor %}
+            {%- set navlevel = navlevel - 1%}
+        {%- endif %}
+    </ul>
+{%- endif %}

--- a/mkdocs/themes/readthedocs/toc.html
+++ b/mkdocs/themes/readthedocs/toc.html
@@ -1,23 +1,10 @@
-{% if nav_item.children %}
-    <ul class="subnav">
-    <li><span>{{ nav_item.title }}</span></li>
-
-        {% for nav_item in nav_item.children %}
-            {% include 'toc.html' %}
+{% for toc_item in page.toc %}
+    <li class="toctree-l{{ navlevel + 1 }}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+    {% if toc_item.children %}
+        <ul>
+        {% for toc_item in toc_item.children %}
+            <li><a class="toctree-l{{ navlevel + 2 }}" href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
         {% endfor %}
-    </ul>
-{% else %}
-    <li class="toctree-l1 {% if nav_item.active%}current{%endif%}">
-        <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-        {% if nav_item == page %}
-            <ul>
-            {% for toc_item in page.toc %}
-                <li class="toctree-l3"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
-                {% for toc_item in toc_item.children %}
-                    <li><a class="toctree-l4" href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
-                {% endfor %}
-            {% endfor %}
-            </ul>
-        {% endif %}
-    </li>
-{% endif %}
+        </ul>
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
* Fix a nested `<li>` bug.
* More closely replicate nesting of the Sphinx theme nav (related to #588).
* If sections headers ever get urls, this will support them (related to #73).

I pulled the RTD changes out of #1042 and applied them separately with a few tweaks. These changes need to happen regardless of whether #1042 get rejected (my current leaning) and this gets us closer to resolving #588. The remaining work to complete #588 should be CSS/JS related only.

I should note that this is not an exact clone of the upstream (Sphinx)  theme (although it is closer). In the upstream theme, there is only provision for one level of section headings and one level of pages were we allow pages in the section heading level and multiple levels of pages under a section. If we were to take it that far, then we would introduce backward incompatible changes to existing projects. For complete feature parity, that may be necessary, in which case this needs more work. If, on the other hand, we are willing to forego some feature parity for backward compatibility with our existing users, then this should be ready to go.