### PR TITLE
Updates to mkdocs ReadTheDocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -29,7 +29,7 @@
 .wy-nav-side {
     height: calc(100% - 45px);
     overflow-y: auto;
-    min-height: 0%;
+    min-height: 0;
 }
 
 .rst-versions{

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -37,6 +37,10 @@
 	 height: 45px;
 }
 
+.wy-nav-side.shift{
+	height: 100%;
+}
+
 /*
  * readthedocs theme hides nav items when the window height is
  * too small to contain them.

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -33,12 +33,12 @@
 }
 
 .rst-versions{
-	 border-top: 0;
-	 height: 45px;
+    border-top: 0;
+    height: 45px;
 }
 
-.wy-nav-side.shift{
-	height: 100%;
+.wy-nav-side .shift{
+    height: 100%;
 }
 
 /*

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -22,10 +22,19 @@
  * area doesn't scroll.
  *
  * https://github.com/mkdocs/mkdocs/pull/202
+ *
+ * Builds upon pull 202 https://github.com/mkdocs/mkdocs/pull/202
+ * to make toc scrollbar end before navigations buttons to not be overlapping.
  */
 .wy-nav-side {
-    height: 100%;
+    height: calc(100% - 45px);
     overflow-y: auto;
+    min-height: 0%;
+}
+
+.rst-versions{
+	 border-top: 0;
+	 height: 45px;
 }
 
 /*

--- a/mkdocs/themes/readthedocs/js/theme.js
+++ b/mkdocs/themes/readthedocs/js/theme.js
@@ -1,5 +1,4 @@
 $( document ).ready(function() {
-
     // Shift nav in mobile when clicking the menu.
     $(document).on('click', "[data-toggle='wy-nav-top']", function() {
       $("[data-toggle='wy-nav-shift']").toggleClass("shift");
@@ -53,3 +52,31 @@ window.SphinxRtdTheme = (function (jquery) {
         StickyNav : stickyNav
     };
 }($));
+
+// The code below is a copy of @seanmadsen code posted Jan 10, 2017 on issue 803.
+// https://github.com/mkdocs/mkdocs/issues/803
+// This just incorporates the auto scroll into the theme itself without
+// the need for additional custom.js file.
+//
+$(function() {
+  $.fn.isFullyWithinViewport = function(){
+      var viewport = {};
+      viewport.top = $(window).scrollTop();
+      viewport.bottom = viewport.top + $(window).height();
+      var bounds = {};
+      bounds.top = this.offset().top;
+      bounds.bottom = bounds.top + this.outerHeight();
+      return ( ! (
+        (bounds.top <= viewport.top) ||
+        (bounds.bottom >= viewport.bottom)
+      ) );
+  };
+  if( !$('li.toctree-l1.current').isFullyWithinViewport() ) {
+    $('.wy-nav-side')
+      .scrollTop(
+        $('li.toctree-l1.current').offset().top -
+        $('.wy-nav-side').offset().top -
+        60
+      );
+  }
+});

--- a/mkdocs/themes/readthedocs/versions.html
+++ b/mkdocs/themes/readthedocs/versions.html
@@ -1,7 +1,7 @@
 <div class="rst-versions" role="note" style="cursor: pointer">
     <span class="rst-current-version" data-toggle="rst-current-version">
       {% if config.repo_name == 'GitHub' %}
-          <a href="{{ config.repo_url }}" class="icon icon-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="{{ config.repo_url }}" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
       {% elif config.repo_name == 'Bitbucket' %}
           <a href="{{ config.repo_url }}" class="icon icon-bitbucket" style="float: left; color: #fcfcfc"> BitBucket</a>
       {% endif %}


### PR DESCRIPTION
This Pull Request addresses three issues:  1) adjusts TOC scrollbar so that the bottom is not covered by the 'Next' navigation button; 2) fixes the 'GitHub' class name in the version.html file; and 3) incorporates @seanmadsen code posted on Jan 10 issue #803 (if accepted and merged can be marked as closed) which may address some concerns with issue #588.  Still needing someone to address the collapsible TOC headings discussed in issue #588.

![mkdocs github update scrollbar](https://cloud.githubusercontent.com/assets/25963099/23813493/c43a8dea-05a4-11e7-8448-cf1f95f3d844.jpg)
