### PR TITLE
System root ("/") is not a valid path for site_dir or docs_dir.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,14 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Version 0.16.2 (2017-03-??)
+
+* System root (`/`) is not a valid path for site_dir or docs_dir (#1161)
+* Refactor readthedocs theme navigation (#1155 & #1156)
+* Add support to dev server to serve custom error pages (#1040)
+* Ensure nav.homepage.url is not blank on error pages (#1131)
+* Increase livereload dependency to 2.5.1 (#1106)
+
 ## Version 0.16.1 (2016-12-22)
 
 * Ensure scrollspy behavior does not affect nav bar (#1094)

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -181,8 +181,8 @@ up.
 
 Lets you set the directory containing the documentation source markdown files.
 This can either be a relative directory, in which case it is resolved relative
-to the directory containing you configuration file, or it can be an absolute
-directory path.
+to the directory containing your configuration file, or it can be an absolute
+directory path from the root of your local file system.
 
 **default**: `'docs'`
 
@@ -190,8 +190,8 @@ directory path.
 
 Lets you set the directory where the output HTML and other files are created.
 This can either be a relative directory, in which case it is resolved relative
-to the directory containing you configuration file, or it can be an absolute
-directory path.
+to the directory containing your configuration file, or it can be an absolute
+directory path from the root of your local file system.
 
 **default**: `'site'`
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -253,14 +253,14 @@ class SiteDir(Dir):
         # Validate that the docs_dir and site_dir don't contain the
         # other as this will lead to copying back and forth on each
         # and eventually make a deep nested mess.
-        if (config['docs_dir'] + os.sep).startswith(config['site_dir'] + os.sep):
+        if (config['docs_dir'] + os.sep).startswith(config['site_dir'].rstrip(os.sep) + os.sep):
             raise ValidationError(
                 ("The 'docs_dir' should not be within the 'site_dir' as this "
                  "can mean the source files are overwritten by the output or "
                  "it will be deleted if --clean is passed to mkdocs build."
                  "(site_dir: '{0}', docs_dir: '{1}')"
                  ).format(config['site_dir'], config['docs_dir']))
-        elif (config['site_dir'] + os.sep).startswith(config['docs_dir'] + os.sep):
+        elif (config['site_dir'] + os.sep).startswith(config['docs_dir'].rstrip(os.sep) + os.sep):
             raise ValidationError(
                 ("The 'site_dir' should not be within the 'docs_dir' as this "
                  "leads to the build directory being copied into itself and "

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -228,6 +228,7 @@ class SiteDirTest(unittest.TestCase):
             {'docs_dir': 'docs', 'site_dir': ''},
             {'docs_dir': '', 'site_dir': ''},
             {'docs_dir': j('..', parent_dir, 'docs'), 'site_dir': 'docs'},
+            {'docs_dir': 'docs', 'site_dir': '/'}
         )
 
         for test_config in test_configs:
@@ -242,6 +243,7 @@ class SiteDirTest(unittest.TestCase):
             {'docs_dir': 'docs', 'site_dir': j('docs', 'site')},
             {'docs_dir': '.', 'site_dir': 'site'},
             {'docs_dir': '', 'site_dir': 'site'},
+            {'docs_dir': '/', 'site_dir': 'site'},
         )
 
         for test_config in test_configs:


### PR DESCRIPTION
As neither setting can point at a child dir of the other, `/` would be an
invalid value for either setting. However, given its unique nature,
`os.path.abspath` does not follow normal behavior of returning a string without
an ending slash when passed `/`. Therefore, we need to special case it.

Fixes #1161.