### PR TITLE
Drop support for Python 2.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ env:
 - TOXENV=linkchecker
 - TOXENV=jshint
 - TOXENV=csslint
-- TOXENV=py26-integration
-- TOXENV=py26-min-req
-- TOXENV=py26-unittests
 - TOXENV=py27-integration
 - TOXENV=py27-min-req
 - TOXENV=py27-unittests

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -29,7 +29,7 @@ TODO...
 
 ### Other Changes and Additions to Version 1.0.0
 
-TODO...
+* Support for Python 2.6 has been dropped (#165)
 
 ## Version 0.16.2 (2017-03-13)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ $ pip --version
 pip 1.5.2
 ```
 
-MkDocs supports Python versions 2.6, 2.7, 3.3, 3.4, 3.5 and pypy.
+MkDocs supports Python versions 2.7, 3.3, 3.4, 3.5 and pypy.
 
 #### Installing Python
 

--- a/mkdocs/relative_path_ext.py
+++ b/mkdocs/relative_path_ext.py
@@ -51,12 +51,6 @@ from mkdocs.exceptions import MarkdownNotFound
 log = logging.getLogger(__name__)
 
 
-def _iter(node):
-    # TODO: Remove when dropping Python 2.6. Replace this
-    # function call with note.iter()
-    return [node] + node.findall('.//*')
-
-
 def path_to_url(url, nav, strict):
 
     scheme, netloc, path, params, query, fragment = (
@@ -116,7 +110,7 @@ class RelativePathTreeprocessor(Treeprocessor):
         tags and then makes them relative based on the site navigation
         """
 
-        for element in _iter(root):
+        for element in root.iter():
 
             if element.tag == 'a':
                 key = 'href'

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ import re
 import os
 import sys
 
-PY26 = sys.version_info[:2] == (2, 6)
-
 
 long_description = (
     "MkDocs is a fast, simple and downright gorgeous static site generator "
@@ -61,7 +59,7 @@ setup(
         'click>=3.3',
         'Jinja2>=2.7.1',
         'livereload>=2.5.1',
-        'Markdown>=2.3.1,<2.5' if PY26 else 'Markdown>=2.3.1',
+        'Markdown>=2.3.1',
         'PyYAML>=3.10',
         'tornado>=4.1',
     ],
@@ -83,7 +81,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 envlist =
-    py{26,27,33,34,35}-{unittests,integration,min-req},
+    py{27,33,34,35}-{unittests,integration,min-req},
     flake8, markdown-lint, linkchecker, jshint, csslint
 
 [testenv]
 passenv = LANG
 deps=
-    py{26,27,33,34,35,py,py3}-{unittests,integration}: -rrequirements/project.txt
-    py{26,27,33,34,35,py,py3}-min-req: -rrequirements/project-min.txt
-    py{26,27,33,34,35,py,py3}-{unittests,min-req}: -rrequirements/test.txt
+    py{27,33,34,35,py,py3}-{unittests,integration}: -rrequirements/project.txt
+    py{27,33,34,35,py,py3}-min-req: -rrequirements/project-min.txt
+    py{27,33,34,35,py,py3}-{unittests,min-req}: -rrequirements/test.txt
 commands=
-    py{26,27,33,34,35,py,py3}-{unittests,min-req}: {envbindir}/nosetests --with-coverage --cover-package mkdocs mkdocs
-    py{26,27,33,34,35,py,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds
+    py{27,33,34,35,py,py3}-{unittests,min-req}: {envbindir}/nosetests --with-coverage --cover-package mkdocs mkdocs
+    py{27,33,34,35,py,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds
 
 [testenv:flake8]
 basepython = python2.7


### PR DESCRIPTION
MkDocs most likley will no longer run on Python 2.6. All relevant tests
have been removed. Closes #165.