### PR TITLE
Remove previously deprecated `json` command.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -29,6 +29,7 @@ TODO...
 
 ### Other Changes and Additions to Version 1.0.0
 
+* The deprecated `json` command has been removed (#481)
 * Support for Python 2.6 has been dropped (#165)
 
 ## Version 0.16.2 (2017-03-13)

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -159,40 +159,6 @@ def build_command(clean, config_file, strict, theme, theme_dir, site_dir):
         raise SystemExit('\n' + str(e))
 
 
-@cli.command(name="json")
-@click.option('-c', '--clean/--dirty', is_flag=True, default=True, help=clean_help)
-@click.option('-f', '--config-file', type=click.File('rb'), help=config_help)
-@click.option('-s', '--strict', is_flag=True, help=strict_help)
-@click.option('-d', '--site-dir', type=click.Path(), help=site_dir_help)
-@common_options
-def json_command(clean, config_file, strict, site_dir):
-    """Build the MkDocs documentation to JSON files
-
-    Rather than building your documentation to HTML pages, this
-    outputs each page in a simple JSON format. This command is
-    useful if you want to index your documentation in an external
-    search engine.
-    """
-
-    log.warning("The json command is deprecated and will be removed in a "
-                "future MkDocs release. For details on updating: "
-                "http://www.mkdocs.org/about/release-notes/")
-
-    # Don't override config value if user did not specify --strict flag
-    # Conveniently, load_config drops None values
-    strict = strict or None
-
-    try:
-        build.build(config.load_config(
-            config_file=config_file,
-            strict=strict,
-            site_dir=site_dir
-        ), dump_json=True, dirty=not clean)
-    except exceptions.ConfigurationError as e:  # pragma: no cover
-        # Avoid ugly, unhelpful traceback
-        raise SystemExit('\n' + str(e))
-
-
 @cli.command(name="gh-deploy")
 @click.option('-c', '--clean/--dirty', is_flag=True, default=True, help=clean_help)
 @click.option('-f', '--config-file', type=click.File('rb'), help=config_help)

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -318,15 +318,6 @@ class CLITests(unittest.TestCase):
         logger = logging.getLogger('mkdocs')
         self.assertEqual(logger.level, logging.ERROR)
 
-    @mock.patch('mkdocs.commands.build.build', autospec=True)
-    def test_json(self, mock_build):
-
-        result = self.runner.invoke(
-            cli.cli, ["json", ], catch_exceptions=False)
-
-        self.assertEqual(result.exit_code, 0)
-        self.assertEqual(mock_build.call_count, 1)
-
     @mock.patch('mkdocs.commands.new.new', autospec=True)
     def test_new(self, mock_new):
 


### PR DESCRIPTION
Closes #481.