### PR TITLE
Added base_url to config so that improper relative path to static files can be fixed in sub directories of mkdocs theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ htmlcov/
 mkdocs.egg-info/
 *.pyc
 .coverage
+.idea/

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -77,7 +77,7 @@ def get_global_context(nav, config):
     return {
         'nav': nav,
         # base_url should never end with a slash.
-        'base_url': nav.url_context.make_relative('/').rstrip('/'),
+        'base_url': config['base_url'] or nav.url_context.make_relative('/').rstrip('/'),
 
         'extra_css': extra_css,
         'extra_javascript': extra_javascript,

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -182,6 +182,15 @@ class URL(OptionallyRequired):
             "The URL isn't valid, it should include the http:// (scheme)")
 
 
+class BaseURL(URL):
+    """
+    Base URL Config Option
+
+    Extension of URL config that sets the base_url
+    """
+    pass
+
+
 class RepoURL(URL):
     """
     Repo URL Config Option

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -26,6 +26,9 @@ DEFAULT_SCHEMA = (
     # The full URL to where the documentation will be hosted
     ('site_url', config_options.URL()),
 
+    # The base URL
+    ('base_url', config_options.BaseURL()),
+
     # A description for the documentation project that will be added to the
     # HTML meta tags.
     ('site_description', config_options.Type(utils.string_types)),

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -99,6 +99,10 @@ class URLTest(unittest.TestCase):
                           option.validate, 1)
 
 
+class BaseURLTest(URLTest):
+    pass
+
+
 class RepoURLTest(unittest.TestCase):
 
     def test_repo_name_github(self):


### PR DESCRIPTION
I was trying to fix https://github.com/tomchristie/django-rest-framework/issues/4758 which occurs due to relative path of static files.