### PR TITLE
Add 404 page for RTD Theme

### DIFF
--- a/mkdocs/themes/readthedocs/404.html
+++ b/mkdocs/themes/readthedocs/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+  <h1 id="404-page-not-found">404</h1>
+
+  <p><strong>Page not found</strong></p>
+
+{% endblock %}


### PR DESCRIPTION
The ReadtheDocs theme does not include a 404 page in the build output. I checked and the Sphinx theme doesn't have one either, but if wanted, here's a simple 404 page. It may have been excluded for a reason, but I couldn't locate any previous issue.