### PR TITLE
Start release notes for 0.16.3

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,11 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Version 0.16.3 (2017-??-??)
+
+* Fix a few documentation typos (#1181 & #1185)
+* Fix a regression to livereload server introduced in 0.16.2 (#1174)
+
 ## Version 0.16.2 (2017-03-13)
 
 * System root (`/`) is not a valid path for site_dir or docs_dir (#1161)


### PR DESCRIPTION
Once we fix #1177, then we'll release 0.16.3. Between that and the fix in #1174 we have 2 regressions which are breaking things for users and need to be fixed ASAP.