### PR TITLE
ReadtheDocs theme TOC scroll bug

### DIFF
--- a/mkdocs/themes/readthedocs/js/theme.js
+++ b/mkdocs/themes/readthedocs/js/theme.js
@@ -71,7 +71,7 @@ $(function() {
         (bounds.bottom >= viewport.bottom)
       ) );
   };
-  if( !$('li.toctree-l1.current').isFullyWithinViewport() ) {
+  if( $('li.toctree-l1.current').length && !$('li.toctree-l1.current').isFullyWithinViewport() ) {
     $('.wy-nav-side')
       .scrollTop(
         $('li.toctree-l1.current').offset().top -


### PR DESCRIPTION
Fixes a JavaScript error when looking for a current page in the TOC when there is not a current page selected, in the case of Search, 404 or any page that isn’t listed in the TOC. This checks if a TOC item with the class of ‘current’ is in the document, and if not, does not call the viewport check or scroll the TOC area.