### PR TITLE
Insert whitespace after url

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -330,7 +330,7 @@ class Theme(OptionallyRequired):
             raise ValidationError(
                 ("The theme '{0}' is no longer included in MkDocs by default "
                  "and must be installed with pip. See http://www.mkdocs.org"
-                 "/about/release-notes/#add-support-for-installable-themes"
+                 "/about/release-notes/#add-support-for-installable-themes "
                  "for more details").format(value)
             )
 


### PR DESCRIPTION
Minor typo fix to separate the URL from the rest of the warning message in

> ERROR   -  Config value: 'theme'. Error: The theme 'simplex' is no longer included in MkDocs by default and must be installed with pip. See http://www.mkdocs.org/about/release-notes/#add-support-for-installable-themesfor more details 
