### PR TITLE
fix the link to Tom Christie in the copyright notice

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,5 +26,5 @@ markdown_extensions:
         permalink: 
     - admonition:
 
-copyright: Copyright &copy; 2014 <a href="/release-notes/">Tom Christie</a>, Maintained by the <a href="/about/release-notes/#maintenance-team">MkDocs Team</a>.
+copyright: Copyright &copy; 2014 <a href="https://twitter.com/_tomchristie">Tom Christie</a>, Maintained by the <a href="/about/release-notes/#maintenance-team">MkDocs Team</a>.
 google_analytics: ['UA-27795084-5', 'mkdocs.org']


### PR DESCRIPTION
The current link is broken. I've reverted it to its previous state.