### PR TITLE
Removed hack that broke images on Windows

### DIFF
--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -124,7 +124,7 @@ class UtilsTests(unittest.TestCase):
 
         assertPathGenerated("img.png", "./img.png")
         assertPathGenerated("./img.png", "./img.png")
-        assertPathGenerated("/img.png", "../img.png")        
+        assertPathGenerated("/img.png", "../img.png")
 
     def test_reduce_list(self):
         self.assertEqual(

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -7,7 +7,6 @@ import mock
 import os
 import unittest
 
-from sys import platform
 from mkdocs import nav, utils, exceptions
 from mkdocs.tests.base import dedent
 
@@ -93,10 +92,7 @@ class UtilsTests(unittest.TestCase):
             ]}
         ])
         site_navigation.url_context.set_current_url('/subpage/')
-        if platform == "win32":
-            site_navigation.file_context.current_file = "subpage\\index.md"
-        else: 
-            site_navigation.file_context.current_file = "subpage/index.md"
+        site_navigation.file_context.current_file = "subpage/index.md"
 
         def assertPathGenerated(declared, expected):
             url = utils.create_relative_media_url(site_navigation, declared)

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -102,6 +102,30 @@ class UtilsTests(unittest.TestCase):
         assertPathGenerated("./img.png", "./img.png")
         assertPathGenerated("/img.png", "../img.png")
 
+    def test_create_relative_media_url_sub_index_windows(self):
+        '''
+        test special case where there's a sub/index.md page and we are on Windows.
+        current_file paths uses backslash in Windows
+        '''
+
+        site_navigation = nav.SiteNavigation([
+            {'Home': 'index.md'},
+            {'Sub': [
+                {'Sub Home': '/level1/level2/index.md'},
+
+            ]}
+        ])
+        site_navigation.url_context.set_current_url('/level1/level2')
+        site_navigation.file_context.current_file = "level1\\level2\\index.md"
+
+        def assertPathGenerated(declared, expected):
+            url = utils.create_relative_media_url(site_navigation, declared)
+            self.assertEqual(url, expected)
+
+        assertPathGenerated("img.png", "./img.png")
+        assertPathGenerated("./img.png", "./img.png")
+        assertPathGenerated("/img.png", "../img.png")        
+
     def test_reduce_list(self):
         self.assertEqual(
             utils.reduce_list([1, 2, 3, 4, 5, 5, 2, 4, 6, 7, 8]),

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -7,6 +7,7 @@ import mock
 import os
 import unittest
 
+from sys import platform
 from mkdocs import nav, utils, exceptions
 from mkdocs.tests.base import dedent
 
@@ -92,7 +93,10 @@ class UtilsTests(unittest.TestCase):
             ]}
         ])
         site_navigation.url_context.set_current_url('/subpage/')
-        site_navigation.file_context.current_file = "subpage/index.md"
+        if platform == "win32":
+            site_navigation.file_context.current_file = "subpage\\index.md"
+        else: 
+            site_navigation.file_context.current_file = "subpage/index.md"
 
         def assertPathGenerated(declared, expected):
             url = utils.create_relative_media_url(site_navigation, declared)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -14,6 +14,7 @@ import markdown
 import os
 import pkg_resources
 import shutil
+import re
 import sys
 import yaml
 import fnmatch
@@ -332,11 +333,12 @@ def create_relative_media_url(nav, url):
     # TODO: Fix this, this is a hack. Relative urls are not being calculated
     # correctly for images in the same directory as the markdown. I think this
     # is due to us moving it into a directory with index.html, but I'm not sure
-    if (nav.file_context.current_file.endswith("/index.md") is False and
+    # win32 platform uses backslash "\". eg. "\level1\level2"         
+    if (re.match(r".*(?:\\|/)index.md$", nav.file_context.current_file) is None and
             nav.url_context.base_path != '/' and
             relative_url.startswith("./")):
-        relative_url = ".%s" % relative_url
-
+        relative_url = ".%s" % relative_url 
+        
     return relative_url
 
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -329,14 +329,6 @@ def create_relative_media_url(nav, url):
     else:
         relative_url = '%s/%s' % (relative_base, url)
 
-    # TODO: Fix this, this is a hack. Relative urls are not being calculated
-    # correctly for images in the same directory as the markdown. I think this
-    # is due to us moving it into a directory with index.html, but I'm not sure
-    if (nav.file_context.current_file.endswith("/index.md") is False and
-            nav.url_context.base_path != '/' and
-            relative_url.startswith("./")):
-        relative_url = ".%s" % relative_url
-
     return relative_url
 
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -19,6 +19,7 @@ import yaml
 import fnmatch
 
 from mkdocs import toc, exceptions
+from sys import platform
 
 try:                                                        # pragma: no cover
     from urllib.parse import urlparse, urlunparse, urljoin  # noqa
@@ -328,6 +329,15 @@ def create_relative_media_url(nav, url):
         relative_url = url
     else:
         relative_url = '%s/%s' % (relative_base, url)
+
+    # TODO: Fix this, this is a hack. Relative urls are not being calculated
+    # correctly for images in the same directory as the markdown. I think this
+    # is due to us moving it into a directory with index.html, but I'm not sure
+    # This hack is breaking win32 relative paths to images, so we prevent it from running in Windows
+    if (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False and
+            nav.url_context.base_path != '/' and
+            relative_url.startswith("./")):
+        relative_url = ".%s" % relative_url
 
     return relative_url
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -333,9 +333,8 @@ def create_relative_media_url(nav, url):
     # TODO: Fix this, this is a hack. Relative urls are not being calculated
     # correctly for images in the same directory as the markdown. I think this
     # is due to us moving it into a directory with index.html, but I'm not sure
-    # win32 platform uses backslash "\". eg. "\level1\level2\index.md"    
-    if (((platform == "win32" and nav.file_context.current_file.endswith("\index.md") is False) or
-         (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False)) and
+    # This hack is breaking win32 relative paths to images, so we prevent it from running in Windows
+    if (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False and
             nav.url_context.base_path != '/' and
             relative_url.startswith("./")):
         relative_url = ".%s" % relative_url

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -333,12 +333,12 @@ def create_relative_media_url(nav, url):
     # TODO: Fix this, this is a hack. Relative urls are not being calculated
     # correctly for images in the same directory as the markdown. I think this
     # is due to us moving it into a directory with index.html, but I'm not sure
-    # win32 platform uses backslash "\". eg. "\level1\level2"         
-    if (re.match(r".*(?:\\|/)index.md$", nav.file_context.current_file) is None and
-            nav.url_context.base_path != '/' and
-            relative_url.startswith("./")):
-        relative_url = ".%s" % relative_url 
-        
+    # win32 platform uses backslash "\". eg. "\level1\level2"
+    notindex = re.match(r'.*(?:\\|/)index.md$', nav.file_context.current_file) is None
+
+    if notindex and nav.url_context.base_path != '/' and relative_url.startswith("./"):
+        relative_url = ".%s" % relative_url
+
     return relative_url
 
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -19,7 +19,6 @@ import yaml
 import fnmatch
 
 from mkdocs import toc, exceptions
-from sys import platform
 
 try:                                                        # pragma: no cover
     from urllib.parse import urlparse, urlunparse, urljoin  # noqa
@@ -329,15 +328,6 @@ def create_relative_media_url(nav, url):
         relative_url = url
     else:
         relative_url = '%s/%s' % (relative_base, url)
-
-    # TODO: Fix this, this is a hack. Relative urls are not being calculated
-    # correctly for images in the same directory as the markdown. I think this
-    # is due to us moving it into a directory with index.html, but I'm not sure
-    # This hack is breaking win32 relative paths to images, so we prevent it from running in Windows
-    if (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False and
-            nav.url_context.base_path != '/' and
-            relative_url.startswith("./")):
-        relative_url = ".%s" % relative_url
 
     return relative_url
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -333,10 +333,12 @@ def create_relative_media_url(nav, url):
     # TODO: Fix this, this is a hack. Relative urls are not being calculated
     # correctly for images in the same directory as the markdown. I think this
     # is due to us moving it into a directory with index.html, but I'm not sure
-    # win32 platform uses backslash "\". eg. "\level1\level2\index.md"    
-    if (((platform == "win32" and nav.file_context.current_file.endswith("\index.md") is False) or
-         (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False)) and
-            nav.url_context.base_path != '/' and
+    # win32 platform uses backslash "\". eg. "\level1\level2\index.md"
+
+    winpath = platform == "win32" and nav.file_context.current_file.endswith("\\index.md") is False
+    otherpath = platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False
+
+    if ((winpath or otherpath) and nav.url_context.base_path != '/' and
             relative_url.startswith("./")):
         relative_url = ".%s" % relative_url
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -329,6 +329,14 @@ def create_relative_media_url(nav, url):
     else:
         relative_url = '%s/%s' % (relative_base, url)
 
+    # TODO: Fix this, this is a hack. Relative urls are not being calculated
+    # correctly for images in the same directory as the markdown. I think this
+    # is due to us moving it into a directory with index.html, but I'm not sure
+    if (nav.file_context.current_file.endswith("/index.md") is False and
+            nav.url_context.base_path != '/' and
+            relative_url.startswith("./")):
+        relative_url = ".%s" % relative_url
+
     return relative_url
 
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -333,12 +333,10 @@ def create_relative_media_url(nav, url):
     # TODO: Fix this, this is a hack. Relative urls are not being calculated
     # correctly for images in the same directory as the markdown. I think this
     # is due to us moving it into a directory with index.html, but I'm not sure
-    # win32 platform uses backslash "\". eg. "\level1\level2\index.md"
-
-    winpath = platform == "win32" and nav.file_context.current_file.endswith("\\index.md") is False
-    otherpath = platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False
-
-    if ((winpath or otherpath) and nav.url_context.base_path != '/' and
+    # win32 platform uses backslash "\". eg. "\level1\level2\index.md"    
+    if (((platform == "win32" and nav.file_context.current_file.endswith("\index.md") is False) or
+         (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False)) and
+            nav.url_context.base_path != '/' and
             relative_url.startswith("./")):
         relative_url = ".%s" % relative_url
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -333,8 +333,9 @@ def create_relative_media_url(nav, url):
     # TODO: Fix this, this is a hack. Relative urls are not being calculated
     # correctly for images in the same directory as the markdown. I think this
     # is due to us moving it into a directory with index.html, but I'm not sure
-    # This hack is breaking win32 relative paths to images, so we prevent it from running in Windows
-    if (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False and
+    # win32 platform uses backslash "\". eg. "\level1\level2\index.md"    
+    if (((platform == "win32" and nav.file_context.current_file.endswith("\index.md") is False) or
+         (platform != "win32" and nav.file_context.current_file.endswith("/index.md") is False)) and
             nav.url_context.base_path != '/' and
             relative_url.startswith("./")):
         relative_url = ".%s" % relative_url


### PR DESCRIPTION
We are working in a team with both MacOS and Windows computers. We where facing and estrange issue where media routes where not properly generated in Windows.

If you have the following folder structure:
- mkdocs.yml
- docs
    - level1
        -  level2
            - img
                - sample.png
            - index.md

Where the content of index.md is:

```markdown
This is a route test:
![alt text](img/sample.png)
``` 
The output in MacOS is referencing the current path (right):
```html
<p> 
    This is a test
    <img src="./img/sample.png" alt="alt text" />
</p>
```

However, in Windows we where getting a reference to the upper folder (wrong):
```html
<p> 
    This is a test
    <img src="../img/sample.png" alt="alt text" />
</p>
```

After some debugging in both Windows and MacOS platforms, I found that the following hack where causing this behaviour:

```python
def create_relative_media_url(nav, url):
...

    # TODO: Fix this, this is a hack. Relative urls are not being calculated
    # correctly for images in the same directory as the markdown. I think this
    # is due to us moving it into a directory with index.html, but I'm not sure
    if (nav.file_context.current_file.endswith("/index.md") is False and
            nav.url_context.base_path != '/' and
            relative_url.startswith("./")):
        relative_url = ".%s" % relative_url

    return relative_url
```

As I mentioned before, in the Windows case, the ".%s" is adding an extra "." to the media URL, resulting in a broken image due to incorrect path:

```python
        relative_url = ".%s" % relative_url
```

I have removed the hack and checked that the behaviour of media url is still correct in both Windows and MacOS, for the following scenarios:

1. Building the documentation
2. Executing the following test scenario, with both image at same level as MD (as stated in the hack comment) and in a folder a index.md relative level:
- mkdocs.yml
- docs
    - level1
        -  level2
            - img
                - sample.png
            - index.md
            - sample2.png

This PR removes the hack from create_relative_media_url and 