### PR TITLE
#1134 but against 1.0.dev - Follow_symlinks if they exist

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -363,12 +363,7 @@ class Extras(OptionallyRequired):
         if self.file_match is None:
             raise StopIteration
 
-        if follow_links:
-            dir_tree = os.walk(docs_dir, followlinks=True)
-        else:
-            dir_tree = os.walk(docs_dir)
-
-        for (dirpath, dirs, filenames) in dir_tree:
+        for (dirpath, dirs, filenames) in os.walk(docs_dir, followlinks=follow_links):
             dirs.sort()
             for filename in sorted(filenames):
                 fullpath = os.path.join(dirpath, filename)
@@ -376,8 +371,8 @@ class Extras(OptionallyRequired):
                 # Some editors (namely Emacs) will create temporary symlinks
                 # for internal magic. We can just ignore these files.
                 if os.path.islink(fullpath):
-                    fp = os.path.join(dirpath, os.readlink(fullpath))
-                    if not os.path.exists(fp):
+                    local_fullpath = os.path.join(dirpath, os.readlink(fullpath))
+                    if not os.path.exists(local_fullpath):
                         continue
 
                 relpath = os.path.normpath(os.path.relpath(fullpath, docs_dir))

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -267,6 +267,7 @@ class SiteDir(Dir):
                  "(site_dir: '{0}', docs_dir: '{1}')"
                  ).format(config['site_dir'], config['docs_dir']))
 
+
 class ThemeDir(Dir):
     """
     ThemeDir Config Option

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -258,14 +258,14 @@ class SiteDir(Dir):
                  "can mean the source files are overwritten by the output or "
                  "it will be deleted if --clean is passed to mkdocs build."
                  "(site_dir: '{0}', docs_dir: '{1}')"
-                ).format(config['site_dir'], config['docs_dir']))
+                 ).format(config['site_dir'], config['docs_dir']))
         elif (config['site_dir'] + os.sep).startswith(config['docs_dir'] + os.sep):
             raise ValidationError(
                 ("The 'site_dir' should not be within the 'docs_dir' as this "
                  "leads to the build directory being copied into itself and "
                  "duplicate nested files in the 'site_dir'."
                  "(site_dir: '{0}', docs_dir: '{1}')"
-                ).format(config['site_dir'], config['docs_dir']))
+                 ).format(config['site_dir'], config['docs_dir']))
 
 class ThemeDir(Dir):
     """

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -181,7 +181,6 @@ class URL(OptionallyRequired):
         raise ValidationError(
             "The URL isn't valid, it should include the http:// (scheme)")
 
-
 class RepoURL(URL):
     """
     Repo URL Config Option
@@ -259,15 +258,14 @@ class SiteDir(Dir):
                  "can mean the source files are overwritten by the output or "
                  "it will be deleted if --clean is passed to mkdocs build."
                  "(site_dir: '{0}', docs_dir: '{1}')"
-                 ).format(config['site_dir'], config['docs_dir']))
+                ).format(config['site_dir'], config['docs_dir']))
         elif (config['site_dir'] + os.sep).startswith(config['docs_dir'] + os.sep):
             raise ValidationError(
                 ("The 'site_dir' should not be within the 'docs_dir' as this "
                  "leads to the build directory being copied into itself and "
                  "duplicate nested files in the 'site_dir'."
                  "(site_dir: '{0}', docs_dir: '{1}')"
-                 ).format(config['site_dir'], config['docs_dir']))
-
+                ).format(config['site_dir'], config['docs_dir']))
 
 class ThemeDir(Dir):
     """
@@ -360,12 +358,17 @@ class Extras(OptionallyRequired):
             raise ValidationError(
                 "Expected a list, got {0}".format(type(value)))
 
-    def walk_docs_dir(self, docs_dir):
+    def walk_docs_dir(self, docs_dir, follow_links=False):
 
         if self.file_match is None:
             raise StopIteration
 
-        for (dirpath, dirs, filenames) in os.walk(docs_dir):
+        if follow_links:
+            dir_tree = os.walk(docs_dir, followlinks=True)
+        else:
+            dir_tree = os.walk(docs_dir)
+
+        for (dirpath, dirs, filenames) in dir_tree:
             dirs.sort()
             for filename in sorted(filenames):
                 fullpath = os.path.join(dirpath, filename)
@@ -388,7 +391,7 @@ class Extras(OptionallyRequired):
 
         extras = []
 
-        for filename in self.walk_docs_dir(config['docs_dir']):
+        for filename in self.walk_docs_dir(config['docs_dir'], config['follow_links']):
             extras.append(filename)
 
         config[key_name] = extras
@@ -446,7 +449,7 @@ class Pages(Extras):
 
         pages = []
 
-        for filename in self.walk_docs_dir(config['docs_dir']):
+        for filename in self.walk_docs_dir(config['docs_dir'], config['follow_links']):
 
             if os.path.splitext(filename)[0] == 'index':
                 pages.insert(0, filename)

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -181,6 +181,7 @@ class URL(OptionallyRequired):
         raise ValidationError(
             "The URL isn't valid, it should include the http:// (scheme)")
 
+
 class RepoURL(URL):
     """
     Repo URL Config Option
@@ -359,12 +360,12 @@ class Extras(OptionallyRequired):
             raise ValidationError(
                 "Expected a list, got {0}".format(type(value)))
 
-    def walk_docs_dir(self, docs_dir, follow_links=False):
+    def walk_docs_dir(self, docs_dir):
 
         if self.file_match is None:
             raise StopIteration
 
-        for (dirpath, dirs, filenames) in os.walk(docs_dir, followlinks=follow_links):
+        for (dirpath, dirs, filenames) in os.walk(docs_dir, followlinks=True):
             dirs.sort()
             for filename in sorted(filenames):
                 fullpath = os.path.join(dirpath, filename)
@@ -387,7 +388,7 @@ class Extras(OptionallyRequired):
 
         extras = []
 
-        for filename in self.walk_docs_dir(config['docs_dir'], config['follow_links']):
+        for filename in self.walk_docs_dir(config['docs_dir']):
             extras.append(filename)
 
         config[key_name] = extras
@@ -445,7 +446,7 @@ class Pages(Extras):
 
         pages = []
 
-        for filename in self.walk_docs_dir(config['docs_dir'], config['follow_links']):
+        for filename in self.walk_docs_dir(config['docs_dir']):
 
             if os.path.splitext(filename)[0] == 'index':
                 pages.insert(0, filename)

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -111,9 +111,6 @@ DEFAULT_SCHEMA = (
     # encountered rather than display an error.
     ('strict', config_options.Type(bool, default=False)),
 
-    # Enabling the directory walker to follow links (aka symlinks in Linux OS).
-    ('follow_links', config_options.Type(bool, default=False)),
-
     # the remote branch to commit to when using gh-deploy
     ('remote_branch', config_options.Type(
         utils.string_types, default='gh-pages')),

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -111,6 +111,9 @@ DEFAULT_SCHEMA = (
     # encountered rather than display an error.
     ('strict', config_options.Type(bool, default=False)),
 
+    # Enabling the directory walker to follow links (aka symlinks in Linux OS).
+    ('follow_links', config_options.Type(bool, default=False)),
+
     # the remote branch to commit to when using gh-deploy
     ('remote_branch', config_options.Type(
         utils.string_types, default='gh-pages')),


### PR DESCRIPTION
This is an updated PR pointing at 1.0-dev as suggested by @waylan in https://github.com/mkdocs/mkdocs/pull/1134#issuecomment-315421392

Allows symlinks within docs folder to be followed by python rather than ignored.

This corrects an inconsistency with [existing behaviour](https://github.com/mkdocs/mkdocs/issues/869) where assets in symlinked paths are followed resulting in a sub-dir holding assets but no content.

