### PR TITLE
Add an easy way to order autogenerated pages

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -12,8 +12,10 @@ documentation navigation. If not provided, the pages configuration will be
 automatically created by discovering all the Markdown files in the
 [documentation directory](/user-guide/configuration.md#docs_dir). An
 automatically created pages configuration will always be sorted
-alphanumerically by file name. You will need to manually define your pages
-configuration if you would like your pages sorted differently.
+alphanumerically by file name. If you want pages to be sorted differently,
+you will need to manually define your pages configuration or prepend the
+filename with numbers followed by `__` (`01__first.md`, `02__second`). The
+prefix will then be removed in the navigation.
 
 A simple pages configuration looks like this:
 

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -18,6 +18,10 @@ class UtilsTests(unittest.TestCase):
             'api-guide.md': 'api-guide/index.html',
             'api-guide/index.md': 'api-guide/index.html',
             'api-guide/testing.md': 'api-guide/testing/index.html',
+            '01__cli-guide/testing.md': 'cli-guide/testing/index.html',
+            '01__soap-guide/9__testing.md': 'soap-guide/testing/index.html',
+            'rest-guide/9__testing.md': 'rest-guide/testing/index.html',
+            'grpc-guide/strange_1__page.md': 'grpc-guide/strange_1__page/index.html',
         }
         for file_path, expected_html_path in expected_results.items():
             html_path = utils.get_html_path(file_path)
@@ -155,6 +159,10 @@ class UtilsTests(unittest.TestCase):
     def test_get_theme_dir_keyerror(self):
 
         self.assertRaises(KeyError, utils.get_theme_dir, 'nonexistanttheme')
+
+    def test_filename_to_title(self):
+        self.assertEqual('Ansible', utils.filename_to_title('ansible.md'))
+        self.assertEqual('Ansible', utils.filename_to_title('01__ansible.md'))
 
     @mock.patch('pkg_resources.iter_entry_points', autospec=True)
     def test_get_theme_dir_importerror(self, mock_iter):

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -184,8 +184,11 @@ def get_html_path(path):
     Paths like 'index.md' will be converted to 'index.html'
     Paths like 'about.md' will be converted to 'about/index.html'
     Paths like 'api-guide/core.md' will be converted to 'api-guide/core/index.html'
+    Paths like '02__api-guide/03__core.md' will be converted to 'api-guide/core/index.html'
     """
     path = os.path.splitext(path)[0]
+    # Remove 00__ from filenames.
+    path = re.sub(r'(/|\A)\d+__', '\\1', path)
     if os.path.basename(path) == 'index':
         return path + '.html'
     return "/".join((path, 'index.html'))
@@ -419,6 +422,8 @@ def get_theme_names():
 def filename_to_title(filename):
 
     title = os.path.splitext(filename)[0]
+    # Remove 00__ from filenames.
+    title = re.sub(r'^\d+__', '', title)
     title = title.replace('-', ' ').replace('_', ' ')
     # Capitalize if the filename was all lowercase, otherwise leave it as-is.
     if title.lower() == title:


### PR DESCRIPTION
This allows you to prepend filenames with 00__ and have it removed from
the autogenerated title in the navbar.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>