### PR TITLE
Follow symlinks in subfolders of docs_dir

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -391,7 +391,7 @@ class Extras(OptionallyRequired):
         if self.file_match is None:
             raise StopIteration
 
-        for (dirpath, dirs, filenames) in os.walk(docs_dir):
+        for (dirpath, dirs, filenames) in os.walk(docs_dir, followlinks=True):
             dirs.sort()
             for filename in sorted(filenames):
                 fullpath = os.path.join(dirpath, filename)


### PR DESCRIPTION
My usecase is that I have a `docs/` dir with general files, and subdirs with project-specific documentation. These subdirs should ideally be symlinks, eg. to easen local development.

This patch makes the automatic page discovery follow symlinks, which currently is not the case.