### PR TITLE
Fixes a bug when 'edit_url' is not defined in the config

### DIFF
--- a/mkdocs/config/__init__.py
+++ b/mkdocs/config/__init__.py
@@ -1,5 +1,6 @@
-from mkdocs.config.base import load_config
-from mkdocs.config.config_options import Config
+from mkdocs.config.base import load_config, Config
 from mkdocs.config.defaults import DEFAULT_SCHEMA
 
-__all__ = ["load_config", 'Config', 'DEFAULT_SCHEMA']
+__all__ = [load_config.__name__,
+           Config.__name__,
+           'DEFAULT_SCHEMA']

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -204,17 +204,11 @@ class Page(object):
         self.canonical_url = utils.urljoin(base, self.abs_url.lstrip('/'))
 
     def set_edit_url(self, repo_url, edit_uri):
-        if not repo_url.endswith('/'):
-            # Skip when using query or fragment in edit_uri
-            if not edit_uri.startswith('?') and not edit_uri.startswith('#'):
-                repo_url += '/'
         if not edit_uri:
             self.edit_url = repo_url
         else:
             # Normalize URL from Windows path '\\' -> '/'
             input_path_url = self.input_path.replace('\\', '/')
-            if not edit_uri.endswith('/'):
-                edit_uri += '/'
             self.edit_url = utils.urljoin(
                 repo_url,
                 edit_uri + input_path_url)

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -197,7 +197,7 @@ class RepoURLTest(unittest.TestCase):
         option = config_options.RepoURL()
         config = {'repo_url': "https://github.com/mkdocs/mkdocs"}
         option.post_validation(config, 'repo_url')
-        self.assertEqual(config['edit_uri'], 'edit/master/docs/')
+        self.assertEqual(config['edit_uri'], '/edit/master/docs/')
 
     def test_edit_uri_bitbucket(self):
 
@@ -211,7 +211,15 @@ class RepoURLTest(unittest.TestCase):
         option = config_options.RepoURL()
         config = {'repo_url': "https://launchpad.net/python-tuskarclient"}
         option.post_validation(config, 'repo_url')
-        self.assertEqual(config.get('edit_uri'), None)
+        self.assertEqual(config.get('edit_uri'), '')
+
+    def test_repo_name_custom_and_empty_edit_uri(self):
+
+        option = config_options.RepoURL()
+        config = {'repo_url': "https://github.com/mkdocs/mkdocs",
+                  'repo_name': 'mkdocs'}
+        option.post_validation(config, 'repo_url')
+        self.assertEqual(config.get('edit_uri'), '/edit/master/docs/')
 
 
 class DirTest(unittest.TestCase):

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -642,7 +642,7 @@ class TestLegacyPagesConfig(unittest.TestCase):
 
         # Ensure the '/' is added to the repo_url and edit_uri
         repo_url = 'http://example.com'
-        edit_uri = 'edit/master/docs'
+        edit_uri = 'edit/master/docs/'
 
         site_navigation = nav.SiteNavigation(pages)
 
@@ -715,7 +715,7 @@ class TestLegacyPagesConfig(unittest.TestCase):
 
         # Ensure the '/' is added to the repo_url and edit_uri
         repo_url = 'http://example.com'
-        edit_uri = 'edit/master/docs'
+        edit_uri = 'edit/master/docs/'
 
         site_navigation = nav.SiteNavigation(pages)
 


### PR DESCRIPTION
i encountered this tailed traceback:

```
  File "/home/user/mkdocs/mkdocs/nav.py", line 180, in __init__
    self._set_edit_url(config['repo_url'], config['edit_uri'])
  File "/home/user/mkdocs/mkdocs/nav.py", line 263, in _set_edit_url
    if not edit_uri.startswith('?') and not edit_uri.startswith('#'):
AttributeError: 'NoneType' object has no attribute 'startswith'
```