### PR TITLE
Adds 'load_markdown' event

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -11,9 +11,7 @@ using a plugin which comes with MkDocs, then it was installed when you installed
 MkDocs. However, to install third party plugins, you need to determine the
 appropriate package name and install it using `pip`:
 
-```python
-pip install mkdocs-foo-plugin
-```
+    pip install mkdocs-foo-plugin
 
 Once a plugin has been successfully installed, it is ready to use. It just needs
 to be [enabled](#using-plugins) in the configuration file.
@@ -156,7 +154,7 @@ entire site.
     be used to alter the site navigation.
 
     Parameters:
-    : __site_navigation__: global navigation object
+    : __site_navigation:__ global navigation object
     : __config:__ global configuration object
 
     Returns:
@@ -170,7 +168,7 @@ entire site.
     Parameters:
     : __env:__ global Jinja environment
     : __config:__ global configuration object
-    : __site_navigation__: global navigation object
+    : __site_navigation:__ global navigation object
 
     Returns:
     : global Jinja Environment
@@ -274,7 +272,7 @@ event.
     : __markdown:__ Markdown source text of page as string
     : __page:__ `mkdocs.nav.Page` instance
     : __config:__ global configuration object
-    : __site_navigation__: global navigation object
+    : __site_navigation:__ global navigation object
 
     Returns:
     : Markdown source text of page as string
@@ -289,7 +287,7 @@ event.
     : __html:__ HTML rendered from Markdown source as string
     : __page:__ `mkdocs.nav.Page` instance
     : __config:__ global configuration object
-    : __site_navigation__: global navigation object
+    : __site_navigation:__ global navigation object
 
     Returns:
     : HTML rendered from Markdown source as string
@@ -303,7 +301,7 @@ event.
     : __context__: dict of template context variables
     : __page:__ `mkdocs.nav.Page` instance
     : __config:__ global configuration object
-    : __site_navigation__: global navigation object
+    : __site_navigation:__ global navigation object
 
     Returns:
     : dict of template context variables
@@ -319,7 +317,7 @@ event.
     : __output_content:__ output of rendered template as string
     : __page:__ `mkdocs.nav.Page` instance
     : __config:__ global configuration object
-    : __site_navigation__: global navigation object
+    : __site_navigation:__ global navigation object
 
     Returns:
     : output of rendered template as string
@@ -358,14 +356,14 @@ Note that registering a plugin does not activate it. The user still needs to
 tell MkDocs to use if via the config.
 
 [BasePlugin]:#baseplugin
-[entry point]: #entry-point
 [config]: configuration.md#plugins
+[entry point]: #entry-point
+[env]: #on_env
 [events]: #events
+[extra_templates]: configuration.md#extra_templates
 [Global Events]: #global-events
 [Page Events]: #page-events
-[Template Events]: #template-events
-[static_templates]: configuration.md#static_templates
-[extra_templates]: configuration.md#extra_templates
-[env]: #on_env
-[post_template]: #on_post_template
 [post_build]: #on_post_build
+[post_template]: #on_post_template
+[static_templates]: configuration.md#static_templates
+[Template Events]: #template-events

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -246,15 +246,29 @@ event.
     Parameters:
     : __page:__ `mkdocs.nav.Page` instance
     : __config:__ global configuration object
-    : __site_navigation__: global navigation object
+    : __site_navigation:__ global navigation object
 
     Returns:
     : `mkdocs.nav.Page` instance
 
+##### on_page_read_source
+
+:   The `on_page_read_source` event can replace the default mechanism to read
+    the contents of a page's source from the filesystem.
+
+    Parameters:
+    : __page:__ `mkdocs.nav.Page` instance
+    : __config:__ global configuration object
+
+    Returns:
+    : The raw source for a page as unicode string. If `None` is returned, the
+      default loading from a file will be performed.
+
 ##### on_page_markdown
 
-:   The `page_markdown` event is called after the page is loaded from file and
-    can be used to alter the Markdown source text.
+:   The `page_markdown` event is called after the page's markdown is loaded
+    from file and can be used to alter the Markdown source text. The meta-
+    data has been stripped off and is available as `page.meta` at this point.
 
     Parameters:
     : __markdown:__ Markdown source text of page as string

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -124,7 +124,7 @@ def _build_page(page, config, site_navigation, env, dirty=False):
 
     # Run the `pre_page` plugin event
     page = config['plugins'].run_event(
-        'page_markdown', page, config=config, site_navigation=site_navigation
+        'pre_page', page, config=config, site_navigation=site_navigation
     )
 
     page.read_source(config=config)

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -127,7 +127,7 @@ def _build_page(page, config, site_navigation, env, dirty=False):
         'page_markdown', page, config=config, site_navigation=site_navigation
     )
 
-    page.load_markdown()
+    page.read_source(config=config)
 
     # Run `page_markdown` plugin events.
     page.markdown = config['plugins'].run_event(

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -243,14 +243,18 @@ class Page(object):
     def is_top_level(self):
         return len(self.ancestors) == 0
 
-    def load_markdown(self):
-        try:
-            input_content = io.open(self.abs_input_path, 'r', encoding='utf-8').read()
-        except IOError:
-            log.error('file not found: %s', self.abs_input_path)
-            raise
+    def read_source(self, config):
+        source = config['plugins'].run_event(
+            'page_read_source', None, config=config, page=self)
+        if source is None:
+            try:
+                with io.open(self.abs_input_path, 'r', encoding='utf-8') as f:
+                    source = f.read()
+            except IOError:
+                log.error('File not found: %s', self.abs_input_path)
+                raise
 
-        self.markdown, self.meta = meta.get_data(input_content)
+        self.markdown, self.meta = meta.get_data(source)
 
     def _set_canonical_url(self, base):
         if not base.endswith('/'):

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -19,8 +19,8 @@ log = logging.getLogger('mkdocs.plugins')
 
 EVENTS = (
     'config', 'pre_build', 'nav', 'env', 'pre_template', 'template_context',
-    'post_template', 'pre_page', 'page_markdown', 'page_content', 'page_context',
-    'post_page', 'post_build', 'serve'
+    'post_template', 'pre_page', 'page_read_source', 'page_markdown',
+    'page_content', 'page_context', 'post_page', 'post_build', 'serve'
 )
 
 

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -28,7 +28,7 @@ def build_page(title, path, config, md_src=None):
     sitenav = nav.SiteNavigation(config)
     page = nav.Page(title, path, sitenav.url_context, config)
     if md_src:
-        # Fake page.load_markdown()
+        # Fake page.read_source()
         page.markdown, page.meta = meta.get_data(md_src)
     return page, sitenav
 

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -124,7 +124,7 @@ class SearchTests(unittest.TestCase):
         full_content = ''.join("""Heading{0}Content{0}""".format(i) for i in range(1, 4))
 
         for page in site_navigation:
-            # Fake page.load_markdown() and page.render()
+            # Fake page.read_source() and page.render()
             page.markdown = md
             page.toc = toc
             page.content = html_content


### PR DESCRIPTION
This allows to override the loading of source files, e.g. to fetch it from a remote location or for generated contents.