### PR TITLE
get_pip.py installs setuptools. ez_setup.py is deprecated.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,7 @@ init:
   - "ECHO %TOXENV%"
   - ps: "ls C:\\Python*"
 install:
-  - ps: Invoke-WebRequest "https://bootstrap.pypa.io/ez_setup.py" -OutFile "c:\\ez_setup.py"
   - ps: Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" -OutFile "c:\\get-pip.py"
-  - "c:\\python27\\python c:\\ez_setup.py"
   - "c:\\python27\\python c:\\get-pip.py"
   - "c:\\python27\\Scripts\\pip install tox"
 test_script:


### PR DESCRIPTION
Addresses problem discovered in #1290.