### PR TITLE
Do not copy permissions with files.

### DIFF
--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -103,12 +103,15 @@ def reduce_list(data_set):
 def copy_file(source_path, output_path):
     """
     Copy source_path to output_path, making sure any parent directories exist.
-    """
 
+    The output_path may be a directory.
+    """
     output_dir = os.path.dirname(output_path)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    shutil.copy(source_path, output_path)
+    if os.path.isdir(output_path):
+        output_path = os.path.join(output_path, os.path.basename(source_path))
+    shutil.copyfile(source_path, output_path)
 
 
 def write_file(content, output_path):


### PR DESCRIPTION
In various stages of a build, a new file may overwrite a previously written
file (for example to override a theme). If a source file is read-only, the
copied file cannot remain read-only. Therefore, permissions must not be
copied with a file. `shutil.copyfile` only copies a file's contents and is
now being used to copy all files.

Fixes #1292.