### PR TITLE
Make the repo link an "edit" link, if edit_uri is set.

### DIFF
--- a/mkdocs/themes/mkdocs/nav.html
+++ b/mkdocs/themes/mkdocs/nav.html
@@ -71,7 +71,18 @@
               {%- endblock %}
 
               {%- block repo %}
-                {%- if config.repo_url %}
+                {%- if page and page.edit_url %}
+                    <li>
+                        <a href="{{ config.edit_url }}">
+                            {%- if config.repo_name == 'GitHub' %}
+                                <i class="fa fa-github"></i>
+                            {%- elif config.repo_name == 'Bitbucket' -%}
+                                <i class="fa fa-bitbucket"></i>
+                            {%- endif -%}
+                            Edit on {{ config.repo_name }}
+                        </a>
+                    </li>
+                {%- elif config.repo_url %}
                     <li>
                         <a href="{{ config.repo_url }}">
                             {%- if config.repo_name == 'GitHub' %}


### PR DESCRIPTION
Fixes #1129 .

I'm happy to write a unit test for this, if there are any on the themes. I couldn't spot them, though.