### PR TITLE
Partially Revert "Remove deprecated autofill of extra configs."

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -140,9 +140,9 @@ In previous versions of MkDocs, if the `extra_css` or `extra_javascript` config
 settings were empty, MkDocs would scan the `docs_dir` and auto-populate each
 setting with all of the CSS and JavaScript files found. On version 0.16 this
 behavior was deprecated and a warning was issued. In 1.0 any unlisted CSS and
-JavaScript files will not be included in the HTML templates without warning. In
-other words, they will still be copied to the `site-dir`, but they will not have
-any effect on the theme if they are not explicitly listed.
+JavaScript files will not be included in the HTML templates, however, a warning
+will be issued. In other words, they will still be copied to the `site-dir`, but
+they will not have any effect on the theme if they are not explicitly listed.
 
 All CSS and javaScript files in the `docs_dir` should be explicitly listed in
 the `extra_css` or `extra_javascript` config settings going forward.

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -433,6 +433,63 @@ class Theme(BaseConfigOption):
         config[key_name] = theme.Theme(**theme_config)
 
 
+class Extras(OptionallyRequired):
+    """
+    Extras Config Option
+
+    Validate the extra configs are a list and issue a warning for any files
+    found in the docs_dir which are not listed here.
+
+    TODO: Delete this in a future release and use
+    `config_options.Type(list, default=[])` instead.
+    """
+
+    def __init__(self, file_match=None, **kwargs):
+        super(Extras, self).__init__(**kwargs)
+        self.file_match = file_match
+
+    def run_validation(self, value):
+        if isinstance(value, list):
+            return list(os.path.normcase(path) for path in value)
+        else:
+            raise ValidationError(
+                "Expected a list, got {0}".format(type(value)))
+
+    def walk_docs_dir(self, docs_dir):
+        if self.file_match is None:
+            raise StopIteration
+
+        for (dirpath, dirs, filenames) in os.walk(docs_dir, followlinks=True):
+            dirs.sort()
+            for filename in sorted(filenames):
+                fullpath = os.path.join(dirpath, filename)
+
+                # Some editors (namely Emacs) will create temporary symlinks
+                # for internal magic. We can just ignore these files.
+                if os.path.islink(fullpath):
+                    local_fullpath = os.path.join(dirpath, os.readlink(fullpath))
+                    if not os.path.exists(local_fullpath):
+                        continue
+
+                relpath = os.path.normpath(os.path.relpath(fullpath, docs_dir))
+                if self.file_match(relpath):
+                    yield relpath
+
+    def post_validation(self, config, key_name):
+        missing_extras = []
+        for filename in self.walk_docs_dir(config['docs_dir']):
+            if filename not in config[key_name]:
+                missing_extras.append(filename)
+
+        if missing_extras:
+            self.warnings.append((
+                "Some files in your 'docs_dir' are not listed in the '{0}' "
+                "config setting and will be ignored by the theme. Add the "
+                "following files to the '{0}' config setting if you want "
+                "them to have an effect on the theme: ['{1}']"
+            ).format(key_name, "', '".join(missing_extras)))
+
+
 class Pages(OptionallyRequired):
     """
     Pages Config Option

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -79,8 +79,9 @@ DEFAULT_SCHEMA = (
 
     # Specify which css or javascript files from the docs directory should be
     # additionally included in the site.
-    ('extra_css', config_options.Type(list, default=[])),
-    ('extra_javascript', config_options.Type(list, default=[])),
+    ('extra_css', config_options.Extras(file_match=utils.is_css_file, default=[])),
+    ('extra_javascript', config_options.Extras(
+        file_match=utils.is_javascript_file, default=[])),
 
     # Similar to the above, but each template (HTML or XML) will be build with
     # Jinja2 and the global context.

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -485,7 +485,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True
@@ -509,7 +508,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True
@@ -526,7 +524,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True
@@ -550,7 +547,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True
@@ -586,7 +582,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True
@@ -610,7 +605,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True
@@ -627,7 +621,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True
@@ -651,7 +644,6 @@ class SiteNavigationTests(unittest.TestCase):
             pages=pages,
             repo_url=repo_url,
             edit_uri=edit_uri,
-            docs_dir='docs',
             site_dir='site',
             site_url='',
             use_directory_urls=True


### PR DESCRIPTION
This partially reverts commit f90c44a20d12635db83021ebd11c31bbac4e28d3.

The behavior is still deprecated, but a warning is now issued to inform
the user that the "extra" files not listed have been ignored.