### PR TITLE
Open files with `utf-8-sig` to account for BOM.

### DIFF
--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -248,7 +248,7 @@ class Page(object):
             'page_read_source', None, config=config, page=self)
         if source is None:
             try:
-                with io.open(self.abs_input_path, 'r', encoding='utf-8') as f:
+                with io.open(self.abs_input_path, 'r', encoding='utf-8-sig') as f:
                     source = f.read()
             except IOError:
                 log.error('File not found: %s', self.abs_input_path)


### PR DESCRIPTION
Python simply discards the BOM with `utf-8-sig`. This way, users of
Microsoft text editors can have their files properly parsered. In all other
ways behaves as reading files using `utf-8` encoding. For more info see:
https://docs.python.org/2/library/codecs.html#encodings-and-unicode

Fixes #1186 and replaces #1236.