### PR TITLE
Add "edit link" support to MkDocs theme.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -149,6 +149,7 @@ the `extra_css` or `extra_javascript` config settings going forward.
 
 ### Other Changes and Additions to Version 0.17.0
 
+* Add "edit Link" support to MkDocs theme (#1129)
 * Open files with `utf-8-sig` to account for BOM (#1186)
 * Symbolic links are now followed consistently (#1134)
 * Support for keyboard navigation shortcuts added to included themes (#1095)

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -57,9 +57,11 @@ page, accounting for specifics of the repository host (e.g. GitHub, Bitbucket,
 etc), the branch, and the docs directory itself. Mkdocs concatenates `repo_url`
 and `edit_uri`, and appends the input path of the page.
 
-When set, provides a link directly to the page in your source repository. This
-makes it easier to find and edit the source for the page. If `repo_url` is not
-set, this option is ignored.
+When set, and if your theme supports it, provides a link directly to the page in
+your source repository. This makes it easier to find and edit the source for the
+page. If `repo_url` is not set, this option is ignored. On some themes, setting
+this option may cause an edit link to be used in place of a repository link.
+Other themes may show both links.
 
 For example, for a GitHub-hosted repository, the `edit_uri` would be as follows.
 (Note the `edit` path and `master` branch...)

--- a/mkdocs/themes/mkdocs/nav.html
+++ b/mkdocs/themes/mkdocs/nav.html
@@ -71,7 +71,18 @@
               {%- endblock %}
 
               {%- block repo %}
-                {%- if config.repo_url %}
+                {%- if page and page.edit_url %}
+                    <li>
+                        <a href="{{ config.edit_url }}">
+                            {%- if config.repo_name == 'GitHub' %}
+                                <i class="fa fa-github"></i>
+                            {%- elif config.repo_name == 'Bitbucket' -%}
+                                <i class="fa fa-bitbucket"></i>
+                            {%- endif -%}
+                            Edit on {{ config.repo_name }}
+                        </a>
+                    </li>
+                {%- elif config.repo_url %}
                     <li>
                         <a href="{{ config.repo_url }}">
                             {%- if config.repo_name == 'GitHub' %}


### PR DESCRIPTION
Theme shows either a repo link or an edit link depending on whether
`edit_uri` is set. Also clarified documentation that this behavior is
dependent upon theme support. Fixes #1129.

Updates #1304 with documentation and release notes.