### PR TITLE
Override site_url with dev_addr on local server.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,10 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Development Version
+
+* Bugfix: Override `site_url` with `dev_addr` on local server (#1317).
+
 ## Version 0.17.0 (2017-10-19)
 
 ### Major Additions to Version 0.17.0

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -347,16 +347,11 @@ true to halt processing when a broken link is found, false prints a warning.
 
 ### dev_addr
 
-Determines the address used when running `mkdocs serve`. Setting this allows you
-to use another port, or allows you to make the service accessible over your
-local network by using the `0.0.0.0` address.
+Determines the address used when running `mkdocs serve`. Must be of the format
+`IP:PORT`.
 
-As with all settings, you can set this from the command line, which can be
-useful, for example:
-
-```bash
-mkdocs serve --dev-addr=0.0.0.0:80  # Run on port 80, on the local network.
-```
+Allows a custom default to be set without the need to pass it through the
+`--dev_addr` option every time the `mkdocs serve` command is called.
 
 **default**: `'127.0.0.1:8000'`
 

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -103,7 +103,10 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             theme=theme,
             theme_dir=theme_dir
         )
+        # Override a few config settings after validation
         config['site_dir'] = tempdir
+        config['site_url'] = 'http://{0}/'.format(config['dev_addr'])
+
         live_server = livereload in ['dirty', 'livereload']
         dirty = livereload == 'dirty'
         build(config, live_server=live_server, dirty=dirty)


### PR DESCRIPTION
When serving locally, the `site_url` actually is the `dev_addr`, so the
config should relfect that. Note that this override must happen after
config validation so that the proper defaults are evaluated for the
`dev_addr` setting. It cannot happen as part of "post_validation" as
there is no way to know the dev server is running within the config
validation (for example, the dev_addr may not be None as the user could
have set the `dev_addr` setting in their config file). Overriding it
from the serve command is the least invasive method and guarantees it
only happens when the local dev server is being run.

Also cleaned up `dev_addr` docs, which were missleading in some respects
and actually encouraged using the dev server over a network.

Fixes #1317. 404 Error pages now work on the loval dev server when
the `site_url` in the config points to a subdir.