### PR TITLE
Fix search for third-party themes.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,6 +23,8 @@ The current and past members of the MkDocs team.
 
 ## Development Version
 
+* Bugfix: Add some theme specific settings to the search plugin for third party
+  themes (#1316).
 * Bugfix: Override `site_url` with `dev_addr` on local server (#1317).
 
 ## Version 0.17.0 (2017-10-19)

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -441,6 +441,7 @@ setting to an empty list:
 
 ```yaml
 plugins: []
+```
 
 **default**: `['search']` (the "search" plugin included with MkDocs).
 

--- a/mkdocs/contrib/legacy_search/__init__.py
+++ b/mkdocs/contrib/legacy_search/__init__.py
@@ -17,11 +17,13 @@ class SearchPlugin(BasePlugin):
 
     def on_config(self, config, **kwargs):
         "Add plugin templates and scripts to config."
-        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
-        config['theme'].dirs.append(path)
-        config['theme'].static_templates.add('search.html')
-        config['extra_javascript'].append('search/require.js')
-        config['extra_javascript'].append('search/search.js')
+        if 'include_search_page' in config['theme'] and config['theme']['include_search_page']:
+            config['theme'].static_templates.add('search.html')
+        if not ('search_index_only' in config['theme'] and config['theme']['search_index_only']):
+            path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
+            config['theme'].dirs.append(path)
+            config['extra_javascript'].append('search/require.js')
+            config['extra_javascript'].append('search/search.js')
         return config
 
     def on_pre_build(self, config, **kwargs):

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -124,11 +124,11 @@ class ConfigTests(unittest.TestCase):
             {
                 'dirs': [os.path.join(theme_dir, 'mkdocs'), mkdocs_templates_dir],
                 'static_templates': ['404.html', 'sitemap.xml'],
-                'vars': {}
+                'vars': {'include_search_page': False, 'search_index_only': False}
             }, {
                 'dirs': [os.path.join(theme_dir, 'readthedocs'), mkdocs_templates_dir],
                 'static_templates': ['404.html', 'sitemap.xml'],
-                'vars': {}
+                'vars': {'include_search_page': True, 'search_index_only': False}
             }, {
                 'dirs': [mytheme, mkdocs_templates_dir],
                 'static_templates': ['sitemap.xml'],
@@ -136,11 +136,11 @@ class ConfigTests(unittest.TestCase):
             }, {
                 'dirs': [custom, os.path.join(theme_dir, 'readthedocs'), mkdocs_templates_dir],
                 'static_templates': ['404.html', 'sitemap.xml'],
-                'vars': {}
+                'vars': {'include_search_page': True, 'search_index_only': False}
             }, {
                 'dirs': [os.path.join(theme_dir, 'readthedocs'), mkdocs_templates_dir],
                 'static_templates': ['404.html', 'sitemap.xml'],
-                'vars': {}
+                'vars': {'include_search_page': True, 'search_index_only': False}
             }, {
                 'dirs': [mytheme, mkdocs_templates_dir],
                 'static_templates': ['sitemap.xml'],
@@ -148,11 +148,16 @@ class ConfigTests(unittest.TestCase):
             }, {
                 'dirs': [custom, os.path.join(theme_dir, 'readthedocs'), mkdocs_templates_dir],
                 'static_templates': ['404.html', 'sitemap.xml'],
-                'vars': {}
+                'vars': {'include_search_page': True, 'search_index_only': False}
             }, {
                 'dirs': [os.path.join(theme_dir, 'mkdocs'), mkdocs_templates_dir],
                 'static_templates': ['404.html', 'sitemap.xml', 'foo.html'],
-                'vars': {'show_sidebar': False, 'some_var': 'bar'}
+                'vars': {
+                    'show_sidebar': False,
+                    'some_var': 'bar',
+                    'include_search_page': False,
+                    'search_index_only': False
+                }
             }
         )
 

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -28,7 +28,7 @@ class ThemeTests(unittest.TestCase):
             [os.path.join(theme_dir, 'mkdocs'), mkdocs_templates_dir]
         )
         self.assertEqual(theme.static_templates, set(['404.html', 'sitemap.xml']))
-        self.assertEqual(get_vars(theme), {})
+        self.assertEqual(get_vars(theme), {'include_search_page': False, 'search_index_only': False})
 
     def test_custom_dir(self):
         custom = tempfile.mkdtemp()

--- a/mkdocs/themes/mkdocs/mkdocs_theme.yml
+++ b/mkdocs/themes/mkdocs/mkdocs_theme.yml
@@ -2,3 +2,6 @@
 
 static_templates:
     - 404.html
+
+include_search_page: false
+search_index_only: false

--- a/mkdocs/themes/readthedocs/mkdocs_theme.yml
+++ b/mkdocs/themes/readthedocs/mkdocs_theme.yml
@@ -1,5 +1,7 @@
 # Config options for 'readthedocs' theme
 
 static_templates:
-    # - search.html  <= this gets added by the extension. It should be excluded without the extension
     - 404.html
+
+include_search_page: true
+search_index_only: false


### PR DESCRIPTION
Added theme customization settings to the search plugin:

* include_search_page: Determines whether the search plugin expects the
theme to provide a dedicated search page via a template located at
`search/search.html`.

* search_index_only: Determines whether the search plugin should only
generate a search index or a complete search solution.

Themes should define these settings in their `mkdocs_theme.yml` config file.
Documentation has been updated as well. Fixes #1315.

Note: while we would not normally add new settings (features) in a point
(bugfix) release, this is fixing a regression for third party themes.
Therefore, it is a "bugfix" and appropriate for a point release.