### PR TITLE
Add length support to toc.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,6 +23,7 @@ The current and past members of the MkDocs team.
 
 ## Development Version
 
+* Bugfix: Add length support to `mkdocs.toc.TableOfContext` (#1325).
 * Bugfix: Add some theme specific settings to the search plugin for third party
   themes (#1316).
 * Bugfix: Override `site_url` with `dev_addr` on local server (#1317).

--- a/mkdocs/toc.py
+++ b/mkdocs/toc.py
@@ -32,6 +32,9 @@ class TableOfContents(object):
     def __iter__(self):
         return iter(self.items)
 
+    def __len__(self):
+        return len(self.items)
+
     def __str__(self):
         return ''.join([str(item) for item in self])
 


### PR DESCRIPTION
This could be useful in templates. Fixes #1325.