### PR TITLE
Correct `extra_*` config setting regressions.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,10 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Development Version
+
+* Bugfix: Correct `extra_*` config setting regressions (#1335 & #1336).
+
 ## Version 0.17.1 (2017-10-30)
 
 * Bugfix: Support `repo_url` with missing ending slash. (#1321).

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -450,7 +450,7 @@ class Extras(OptionallyRequired):
 
     def run_validation(self, value):
         if isinstance(value, list):
-            return list(os.path.normcase(path) for path in value)
+            return value
         else:
             raise ValidationError(
                 "Expected a list, got {0}".format(type(value)))
@@ -476,18 +476,17 @@ class Extras(OptionallyRequired):
                     yield relpath
 
     def post_validation(self, config, key_name):
-        missing_extras = []
-        for filename in self.walk_docs_dir(config['docs_dir']):
-            if filename not in config[key_name]:
-                missing_extras.append(filename)
-
-        if missing_extras:
-            self.warnings.append((
-                "Some files in your 'docs_dir' are not listed in the '{0}' "
-                "config setting and will be ignored by the theme. Add the "
-                "following files to the '{0}' config setting if you want "
-                "them to have an effect on the theme: ['{1}']"
-            ).format(key_name, "', '".join(missing_extras)))
+        # Only issue warnings for missing files if the setting is empty
+        # as autopopulating only used to work if the setting was empty.
+        if not config[key_name]:
+            actual_files = list(self.walk_docs_dir(config['docs_dir']))
+            if actual_files:
+                self.warnings.append((
+                    "Some files in your 'docs_dir' are not listed in the '{0}' "
+                    "config setting and will be ignored by the theme. Add the "
+                    "following files to the '{0}' config setting if you want "
+                    "them to have an effect on the theme: ['{1}']"
+                ).format(key_name, "', '".join(actual_files)))
 
 
 class Pages(OptionallyRequired):


### PR DESCRIPTION
The warning for missing files should only be issued if the config
setting is empty. The warning only exists because we disabled
autopopulating of the settings. Autopopulating only used to run
when the setting was empty so the warning is not nessecary if
the setting has been populated.

Given the above, no string comparisons need to be made as we
only need to check if any files exist when empty. Therefore, we
don't actually need to normalize paths. As we are no longer
modifying users' strings, they can again put any string in their
config, such as URLs of CDNs.

Fixes #1335 & #1336.