### PR TITLE
Link to GitHub issues from release notes.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -47,6 +47,7 @@ authors should review how [search and themes] interact.
 
 ### Other Changes and Additions to Development Version
 
+* Link to GitHub issues from release notes (#644).
 * Expand {sha} and {version} in gh-deploy commit message (#1410).
 * Compress `sitemap.xml` (#1130).
 * Defer loading JS scripts (#1380).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,9 @@ markdown_extensions:
         permalink: 
     - admonition
     - def_list
+    - mdx_gh_links:
+        user: mkdocs
+        repo: mkdocs
 
 copyright: Copyright &copy; 2014 <a href="https://twitter.com/_tomchristie">Tom Christie</a>, Maintained by the <a href="/about/release-notes/#maintenance-team">MkDocs Team</a>.
 google_analytics: ['UA-27795084-5', 'mkdocs.org']

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -4,3 +4,4 @@ livereload>=2.5.1
 Markdown>=2.5
 PyYAML>=3.10
 tornado>=4.1
+mdx_gh_links>=0.2

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands=mdl --style mdl_ruleset.rb README.md CONTRIBUTING.md docs/
 basepython = python2.7
 passenv=*
 deps=
+	mdx_gh_links
 	requests<=2.9.0
 	LinkChecker
 commands=


### PR DESCRIPTION
Uses the `mdx_gh_links` Markdown extension. Fixes #644.
