### PR TITLE
Added a new setting: output_directory_structure. A value of 'default'…

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -357,7 +357,8 @@ is output as /test/page_name.html`.
 | about.md         | /about         | /about/index.html         | /      | /about.html         |
 
 !!! note
-  When `output_directory_structure` is set to `copy`, the `use_directory_urls` setting has no effect.
+    When `output_directory_structure` is set to `copy`, the `use_directory_urls` setting
+    has no effect.
 
 **default**: `default`
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -354,7 +354,7 @@ Source file      | `default`      | Generated HTML            | `copy` | Generat
 -----------------|----------------|---------------------------|--------|--------------------
 index.md         | /              | /                         | /      | /index.html
 api/api-guide.md | /api/api-guide | /api/api-guide/index.html | /api/  | /api/api-guide.html
-about.md         | /about         | /about/index.html         | /      | /about.html        
+about.md         | /about         | /about/index.html         | /      | /about.html
 
 !!! note
     When `output_directory_structure` is set to `copy`, the `use_directory_urls`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -337,6 +337,25 @@ it create links that point directly to the target *file* rather than the target
 
 **default**: `true`
 
+### output_directory_structure
+
+This setting controls the structure of the output directories and the file names of the output files.
+
+When `output_directory_structure` is set to `default`, MKDocs outputs using the `page_name/index.html` directory/file structure.
+
+When `output_directory_structure` is set to `copy`, MKDocs copies the source directory structure and source file names, but replaces the original file name extensions with `.html`. For example: `test/page_name.md is output as /test/page_name.html`.
+
+| Source file      | output_directory_structure: default | Generated HTML                 | output_directory_structure: copy | Generated HTML      |
+|------------------|-------------------------------------|--------------------------------|----------------------------------|---------------------|
+| index.md         | /                                   | /                              | /                                | /index.html         |
+| api/api-guide.md | /api/api-guide                      | /api/api-guide/index.html      | /api/                            | /api/api-guide.html |
+| about.md         | /about                              | /about/index.html              | /                                | /about.html         |
+
+!!! note
+  When `output_directory_structure` is set to `copy`, the `use_directory_urls` setting has no effect.
+
+**default**: `default`
+
 ### strict
 
 Determines if a broken link to a page within the documentation is considered a

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -339,17 +339,22 @@ it create links that point directly to the target *file* rather than the target
 
 ### output_directory_structure
 
-This setting controls the structure of the output directories and the file names of the output files.
+This setting controls the structure of the output directories and the
+file names of the output files.
 
-When `output_directory_structure` is set to `default`, MKDocs outputs using the `page_name/index.html` directory/file structure.
+When `output_directory_structure` is set to `default`, MKDocs outputs using
+the `page_name/index.html` directory/file structure.
 
-When `output_directory_structure` is set to `copy`, MKDocs copies the source directory structure and source file names, but replaces the original file name extensions with `.html`. For example: `test/page_name.md is output as /test/page_name.html`.
+When `output_directory_structure` is set to `copy`, MKDocs copies the
+source directory structure and source file names, but replaces the
+original file name extensions with `.html`. For example: `test/page_name.md
+is output as /test/page_name.html`.
 
-| Source file      | output_directory_structure: default | Generated HTML                 | output_directory_structure: copy | Generated HTML      |
-|------------------|-------------------------------------|--------------------------------|----------------------------------|---------------------|
-| index.md         | /                                   | /                              | /                                | /index.html         |
-| api/api-guide.md | /api/api-guide                      | /api/api-guide/index.html      | /api/                            | /api/api-guide.html |
-| about.md         | /about                              | /about/index.html              | /                                | /about.html         |
+| Source file      | `default`      | Generated HTML            | `copy` | Generated HTML      |
+|------------------|----------------|---------------------------|--------|---------------------|
+| index.md         | /              | /                         | /      | /index.html         |
+| api/api-guide.md | /api/api-guide | /api/api-guide/index.html | /api/  | /api/api-guide.html |
+| about.md         | /about         | /about/index.html         | /      | /about.html         |
 
 !!! note
   When `output_directory_structure` is set to `copy`, the `use_directory_urls` setting has no effect.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -350,15 +350,15 @@ source directory structure and source file names, but replaces the
 original file name extensions with `.html`. For example: `test/page_name.md
 is output as /test/page_name.html`.
 
-| Source file      | `default`      | Generated HTML            | `copy` | Generated HTML      |
-|------------------|----------------|---------------------------|--------|---------------------|
-| index.md         | /              | /                         | /      | /index.html         |
-| api/api-guide.md | /api/api-guide | /api/api-guide/index.html | /api/  | /api/api-guide.html |
-| about.md         | /about         | /about/index.html         | /      | /about.html         |
+Source file      | `default`      | Generated HTML            | `copy` | Generated HTML
+-----------------|----------------|---------------------------|--------|--------------------
+index.md         | /              | /                         | /      | /index.html
+api/api-guide.md | /api/api-guide | /api/api-guide/index.html | /api/  | /api/api-guide.html
+about.md         | /about         | /about/index.html         | /      | /about.html        
 
 !!! note
-    When `output_directory_structure` is set to `copy`, the `use_directory_urls` setting
-    has no effect.
+    When `output_directory_structure` is set to `copy`, the `use_directory_urls`
+    setting has no effect.
 
 **default**: `default`
 

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -118,6 +118,10 @@ DEFAULT_SCHEMA = (
     # options (as the value).
     ('plugins', config_options.Plugins(default=['search'])),
 
-    # the structure of the output directories and files. A value of 'default' uses the default `<page_name>/index.html` directory structure. A value of 'copy' copies the file names and folder structure of the source files and folders and adjusts all internal links to point to the files in these locations. 
+    # the structure of the output directories and files. A value of 'default'
+    # uses the default `<page_name>/index.html` directory structure.
+    # A value of 'copy' copies the file names and folder structure of the source
+    # files and folders and adjusts all internal links to point to
+    # the files in these locations.
     ('output_directory_structure', config_options.Type(utils.string_types, default='default')),
 )

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -117,4 +117,7 @@ DEFAULT_SCHEMA = (
     # A key value pair should be the string name (as the key) and a dict of config
     # options (as the value).
     ('plugins', config_options.Plugins(default=['search'])),
+
+    # the structure of the output directories and files. A value of 'default' uses the default `<page_name>/index.html` directory structure. A value of 'copy' copies the file names and folder structure of the source files and folders and adjusts all internal links to point to the files in these locations. 
+    ('output_directory_structure', config_options.Type(utils.string_types, default='default')),
 )

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -44,6 +44,7 @@ class SiteNavigation(object):
             config, self.url_context)
         self.homepage = self.pages[0] if self.pages else None
         self.use_directory_urls = config['use_directory_urls']
+        self.output_directory_structure = config['output_directory_structure']
 
     def __str__(self):
         return ''.join([str(item) for item in self])
@@ -152,7 +153,7 @@ class Page(object):
     def __init__(self, title, path, url_context, config):
 
         self._title = title
-        self.abs_url = utils.get_url_path(path, config['use_directory_urls'])
+        self.abs_url = utils.get_url_path(path, config['use_directory_urls'], config['output_directory_structure'])
         self.active = False
         self.url_context = url_context
 
@@ -167,7 +168,7 @@ class Page(object):
 
         # Relative and absolute paths to the input markdown file and output html file.
         self.input_path = path
-        self.output_path = utils.get_html_path(path)
+        self.output_path = utils.get_html_path(path, config['output_directory_structure'])
         self.abs_input_path = os.path.join(config['docs_dir'], self.input_path)
         self.abs_output_path = os.path.join(config['site_dir'], self.output_path)
 

--- a/mkdocs/relative_path_ext.py
+++ b/mkdocs/relative_path_ext.py
@@ -86,7 +86,7 @@ def path_to_url(url, nav, strict):
             # to the user and leave the URL as it is.
             log.warning(msg)
             return url
-        path = utils.get_url_path(target_file, nav.use_directory_urls)
+        path = utils.get_url_path(target_file, nav.use_directory_urls, nav.output_directory_structure)
         path = nav.url_context.make_relative(path)
     else:
         path = utils.get_url_path(path).lstrip('/')

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -26,6 +26,16 @@ class UtilsTests(unittest.TestCase):
             html_path = utils.get_html_path(file_path)
             self.assertEqual(html_path, expected_html_path)
 
+        expected_results_copy = {
+            'index.md': 'index.html',
+            'api-guide.md': 'api-guide.html',
+            'api-guide/index.md': 'api-guide/index.html',
+            'api-guide/testing.md': 'api-guide/testing.html',
+        }
+        for file_path, expected_html_path in expected_results_copy.items():
+            html_path = utils.get_html_path(file_path, "copy")
+            self.assertEqual(html_path, expected_html_path)
+
     def test_url_path(self):
         expected_results = {
             'index.md': '/',
@@ -35,6 +45,16 @@ class UtilsTests(unittest.TestCase):
         }
         for file_path, expected_html_path in expected_results.items():
             html_path = utils.get_url_path(file_path)
+            self.assertEqual(html_path, expected_html_path)
+
+        expected_results_copy = {
+            'index.md': '/index.html',
+            'api-guide.md': '/api-guide.html',
+            'api-guide/index.md': '/api-guide/index.html',
+            'api-guide/testing.md': '/api-guide/testing.html',
+        }
+        for file_path, expected_html_path in expected_results_copy.items():
+            html_path = utils.get_url_path(file_path, True, "copy")
             self.assertEqual(html_path, expected_html_path)
 
     def test_is_markdown_file(self):

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -179,23 +179,36 @@ def copy_media_files(from_dir, to_dir, exclude=None, dirty=False):
                 copy_file(source_path, output_path)
 
 
-def get_html_path(path):
+def get_html_path(path, output_directory_structure="default"):
     """
     Map a source file path to an output html path.
+
+    If 'output_directory_structure' is 'default'
 
     Paths like 'index.md' will be converted to 'index.html'
     Paths like 'about.md' will be converted to 'about/index.html'
     Paths like 'api-guide/core.md' will be converted to 'api-guide/core/index.html'
+
+    If 'output_directory_structure' is 'copy' the  file names and folder structure of the source will be copied to the output directory.
+
+    Paths like 'index.md' will be converted to 'index.html'
+    Paths like 'about.md' will be converted to 'about.html'
+    Paths like 'api-guide/core.md' will be converted to 'api-guide/core.html'
+
     """
     path = os.path.splitext(path)[0]
+    if output_directory_structure == "copy":
+        return path + '.html'
     if os.path.basename(path) == 'index':
         return path + '.html'
     return "/".join((path, 'index.html'))
 
 
-def get_url_path(path, use_directory_urls=True):
+def get_url_path(path, use_directory_urls=True, output_directory_structure="default"):
     """
     Map a source file path to an output html path.
+
+    If 'output_directory_structure' is 'default'
 
     Paths like 'index.md' will be converted to '/'
     Paths like 'about.md' will be converted to '/about/'
@@ -203,10 +216,18 @@ def get_url_path(path, use_directory_urls=True):
 
     If `use_directory_urls` is `False`, returned URLs will include the a trailing
     `index.html` rather than just returning the directory path.
+
+    If 'output_directory_structure' is 'copy' the  file names and folder structure
+    of the source will be copied to the output directory.
+
+    Paths like 'index.md' will be converted to '/index.html'
+    Paths like 'about.md' will be converted to '/about.html'
+    Paths like 'api-guide/core.md' will be converted to '/api-guide/core.html'
+
     """
-    path = get_html_path(path)
+    path = get_html_path(path, output_directory_structure)
     url = '/' + path.replace(os.path.sep, '/')
-    if use_directory_urls:
+    if output_directory_structure == "default" and use_directory_urls:
         return url[:-len('index.html')]
     return url
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -189,7 +189,8 @@ def get_html_path(path, output_directory_structure="default"):
     Paths like 'about.md' will be converted to 'about/index.html'
     Paths like 'api-guide/core.md' will be converted to 'api-guide/core/index.html'
 
-    If 'output_directory_structure' is 'copy' the  file names and folder structure of the source will be copied to the output directory.
+    If 'output_directory_structure' is 'copy' the  file names and
+    folder structure of the source will be copied to the output directory.
 
     Paths like 'index.md' will be converted to 'index.html'
     Paths like 'about.md' will be converted to 'about.html'


### PR DESCRIPTION
Added a new configuration setting: output_directory_structure. A value of 'default'  creates <page_name>/index.html as per original MKDocs code. A value of 'copy' copies the source directory structure and file names verbatim (except for replacing file name extensions with '.html'). This allows for a flat file structure at the root directory if desired.