### PR TITLE
Remove PyPI Deployment Docs.

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -447,11 +447,11 @@ plugins: []
 
 [custom themes]: custom-themes.md
 [variables that are available]: custom-themes.md#template-variables
-[pymdk-extensions]: https://pythonhosted.org/Markdown/extensions/index.html
-[pymkd]: https://pythonhosted.org/Markdown/
-[smarty]: https://pythonhosted.org/Markdown/extensions/smarty.html
-[exts]:https://pythonhosted.org/Markdown/extensions/index.html
-[3rd]: https://github.com/waylan/Python-Markdown/wiki/Third-Party-Extensions
+[pymdk-extensions]: https://python-markdown.github.io/extensions/
+[pymkd]: https://python-markdown.github.io/
+[smarty]: https://python-markdown.github.io/extensions/smarty/
+[exts]: https://python-markdown.github.io/extensions/
+[3rd]: https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions
 [configuring pages and navigation]: writing-your-docs.md#configure-pages-and-navigation
 [theme_dir]: styling-your-docs.md#using-the-theme_dir
 [styling your docs]: styling-your-docs.md

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -58,42 +58,6 @@ public repository.
 [features]: http://read-the-docs.readthedocs.io/en/latest/features.html
 [theme]: /user-guide/styling-your-docs.md
 
-## PyPI
-
-If you maintain a [Python] project which is hosted on the [Python Package
-Index][PyPI] (PyPI), you can use the hosting provided at [pythonhosted.org] to
-host documentation for your project. Run the following commands from your
-project's root directory to upload your documentation:
-
-```sh
-mkdocs build
-python setup.py upload_docs --upload-dir=site
-```
-
-Your documentation will be hosted at `https://pythonhosted.org/<projectname>/`
-where `<projectname>` is the name you used to register your project with PyPI.
-
-There are a few prerequisites for the above to work:
-
-1. You must be using [Setuptools] in your `setup.py` script ([Distutils] does
-   not offer an `upload_docs` command).
-1. Your project must already be registered with PyPI (use `python setup.py
-   register`).
-1. Your `mkdocs.yml` config file and your "docs" directory (value assigned to
-   the [docs_dir] configuration option) are presumed to be in the root directory
-   of your project alongside your `setup.py` script.
-1. It is assumed that the default value (`"site"`) is assigned to the [site_dir]
-   configuration option in your `mkdocs.yaml` config file. If you have set a
-   different value, assign that value to the `--upload-dir` option.
-
-[Python]: http://www.python.org/
-[PyPI]: https://pypi.python.org/pypi
-[pythonhosted.org]: https://pythonhosted.org/
-[Setuptools]: https://pythonhosted.org/setuptools/
-[Distutils]: https://docs.python.org/2/distutils/
-[docs_dir]: configuration.md#docs_dir
-[site_dir]: configuration.md#site_dir
-
 ## Other Providers
 
 Any hosting provider which can serve static files can be used to serve


### PR DESCRIPTION
PyPI's documentation hosting has been deprecated, and in fact, it
is no longer possable to upload documentation to PyPI. Therefore,
it is a disservice to our users to document how to deploy to that
service.

See the mailing list dicussions for the official announcement:
https://mail.python.org/pipermail/distutils-sig/2015-May/026327.html
https://mail.python.org/pipermail/distutils-sig/2015-May/026381.html

As a result of that, Python-Markdown has moved its documentation to
https://python-markdown.github.io/. See Python-Markdown/markdown#601
for details. The docs now point to the new location.

The Python-Markdown GitHub repo was also moved to
https://github.com/Python-Markdown/markdown so any links to the repo
have been updated as well.