### PR TITLE
Added an update in the documentation for Tables

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -216,6 +216,29 @@ Left         | Center        | Right
 Left         | Center        | Right
 ```
 
+Do note that there needs to be an empty line above the table.
+This will not render into a table
+
+```no-highlight
+Some text above the table
+| First Header | Second Header | Third Header |
+| ------------ | ------------- | ------------ |
+| Content Cell | Content Cell  | Content Cell |
+| Content Cell | Content Cell  | Content Cell |
+```
+
+This will render into a table:
+
+```no-highlight
+Some text above the table
+
+| First Header | Second Header | Third Header |
+| ------------ | ------------- | ------------ |
+| Content Cell | Content Cell  | Content Cell |
+| Content Cell | Content Cell  | Content Cell |
+```
+
+
 ### Fenced code blocks
 
 The first line should contain 3 or more backtick (`` ` ``) characters, and the

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -216,28 +216,8 @@ Left         | Center        | Right
 Left         | Center        | Right
 ```
 
-Do note that there needs to be an empty line above the table.
-This will not render into a table
-
-```no-highlight
-Some text above the table
-| First Header | Second Header | Third Header |
-| ------------ | ------------- | ------------ |
-| Content Cell | Content Cell  | Content Cell |
-| Content Cell | Content Cell  | Content Cell |
-```
-
-This will render into a table:
-
-```no-highlight
-Some text above the table
-
-| First Header | Second Header | Third Header |
-| ------------ | ------------- | ------------ |
-| Content Cell | Content Cell  | Content Cell |
-| Content Cell | Content Cell  | Content Cell |
-```
-
+Note that a table must be surrounded by blank lines. There must be a blank line 
+before and after the table.
 
 ### Fenced code blocks
 

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -389,8 +389,8 @@ Note that table cells cannot contain any block level elements and cannot contain
 multiple lines of text. They can, however, include inline Markdown as defined in
 Markdown's [syntax] rules.
 
-Additionally, a table must be surrounded by blank lines. There must be a blank line 
-before and after the table.
+Additionally, a table must be surrounded by blank lines. There must be a blank
+line before and after the table.
 
 [tables]: https://python-markdown.github.io/extensions/tables/
 


### PR DESCRIPTION
Added a section in the documentation for formatting tables.
You need an empty line above the table in order for it to render.

Maybe there is a better way of phrasing it than I did, but please add it to the docs, as it would be helpful.