### PR TITLE
Update Release Notes regarding Search plugin.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -44,10 +44,12 @@ own custom behaviors. See the included documentation for a full explanation of
 the API.
 
 The previously built-in search functionality has been removed and wrapped in a
-plugin (named "search") with no changes in behavior. If no plugins setting is
-defined in the config, then the `search` plugin will be included by default.
-See the [configuration][plugin_config] documentation for information on
-overriding the default.
+plugin (named "search") with no changes in behavior. When MkDocs builds, the
+search index is now written to `search/search_index.json` instead of 
+`mkdocs/search_index.json`. If no plugins setting is defined in the config, 
+then the `search` plugin will be included by default. See the 
+[configuration][plugin_config] documentation for information on overriding the
+default.
 
 [Plugin API]: ../user-guide/plugins.md
 [plugin_config]: ../user-guide/configuration.md#plugins

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -45,9 +45,9 @@ the API.
 
 The previously built-in search functionality has been removed and wrapped in a
 plugin (named "search") with no changes in behavior. When MkDocs builds, the
-search index is now written to `search/search_index.json` instead of 
-`mkdocs/search_index.json`. If no plugins setting is defined in the config, 
-then the `search` plugin will be included by default. See the 
+search index is now written to `search/search_index.json` instead of
+`mkdocs/search_index.json`. If no plugins setting is defined in the config,
+then the `search` plugin will be included by default. See the
 [configuration][plugin_config] documentation for information on overriding the
 default.
 


### PR DESCRIPTION
Outline that the path where the search index is written to has changed slightly from `mkdocs/` to `search/`.

See https://github.com/mkdocs/mkdocs/blob/0.16/mkdocs/commands/build.py#L342 vs https://github.com/mkdocs/mkdocs/blob/master/mkdocs/contrib/legacy_search/__init__.py#L40