### PR TITLE
Use exclude keyword to skip markdown files

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,10 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Development Version
+
+* Internal refactor to make util functions more flexible (#1370).
+
 ## Version 0.17.2 (2017-11-15)
 
 * Bugfix: Correct `extra_*` config setting regressions (#1335 & #1336).

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,7 +23,7 @@ The current and past members of the MkDocs team.
 
 ## Development Version
 
-* Internal refactor to make util functions more flexible (#1370).
+* Refactor `copy_media_files` util function for more flexibility (#1370).
 
 ## Version 0.17.2 (2017-11-15)
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -41,6 +41,14 @@ else:                           # pragma: no cover
 
 log = logging.getLogger(__name__)
 
+markdown_patterns = [
+    '*.markdown',
+    '*.mdown',
+    '*.mkdn',
+    '*.mkd',
+    '*.md'
+]
+
 
 def yaml_load(source, loader=yaml.Loader):
     """
@@ -145,11 +153,12 @@ def clean_directory(directory):
             os.unlink(path)
 
 
-def copy_media_files(from_dir, to_dir, exclude=None, dirty=False):
+def copy_media_files(from_dir, to_dir, exclude=markdown_patterns, dirty=False):
     """
     Recursively copy all files except markdown and exclude[ed] files into another directory.
 
     `exclude` accepts a list of Unix shell-style wildcards (`['*.py', '*.pyc']`).
+
     Note that `exclude` only operates on file names, not directories.
     """
     for (source_dir, dirnames, filenames) in os.walk(from_dir, followlinks=True):
@@ -168,15 +177,14 @@ def copy_media_files(from_dir, to_dir, exclude=None, dirty=False):
         dirnames[:] = [d for d in dirnames if not d.startswith('.')]
 
         for filename in filenames:
-            if not is_markdown_file(filename):
-                source_path = os.path.join(source_dir, filename)
-                output_path = os.path.join(output_dir, filename)
+            source_path = os.path.join(source_dir, filename)
+            output_path = os.path.join(output_dir, filename)
 
-                # Do not copy when using --dirty if the file has not been modified
-                if dirty and (modified_time(source_path) < modified_time(output_path)):
-                    continue
+            # Do not copy when using --dirty if the file has not been modified
+            if dirty and (modified_time(source_path) < modified_time(output_path)):
+                continue
 
-                copy_file(source_path, output_path)
+            copy_file(source_path, output_path)
 
 
 def get_html_path(path):
@@ -222,13 +230,7 @@ def is_markdown_file(path):
     http://superuser.com/questions/249436/file-extension-for-markdown-files
     """
     ext = os.path.splitext(path)[1].lower()
-    return ext in [
-        '.markdown',
-        '.mdown',
-        '.mkdn',
-        '.mkd',
-        '.md',
-    ]
+    return any(fnmatch.fnmatch(ext, pattern) for pattern in markdown_patterns)
 
 
 def is_css_file(path):

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -41,12 +41,12 @@ else:                           # pragma: no cover
 
 log = logging.getLogger(__name__)
 
-markdown_patterns = [
-    '*.markdown',
-    '*.mdown',
-    '*.mkdn',
-    '*.mkd',
-    '*.md'
+markdown_extensions = [
+    '.markdown',
+    '.mdown',
+    '.mkdn',
+    '.mkd',
+    '.md'
 ]
 
 
@@ -153,7 +153,8 @@ def clean_directory(directory):
             os.unlink(path)
 
 
-def copy_media_files(from_dir, to_dir, exclude=markdown_patterns, dirty=False):
+def copy_media_files(from_dir, to_dir,
+                     exclude=['*{0}'.format(x) for x in markdown_extensions], dirty=False):
     """
     Recursively copy all files except markdown and exclude[ed] files into another directory.
 
@@ -229,8 +230,7 @@ def is_markdown_file(path):
 
     http://superuser.com/questions/249436/file-extension-for-markdown-files
     """
-    ext = os.path.splitext(path)[1].lower()
-    return any(fnmatch.fnmatch(ext, pattern) for pattern in markdown_patterns)
+    return any(fnmatch.fnmatch(path.lower(), '*{0}'.format(x)) for x in markdown_extensions)
 
 
 def is_css_file(path):


### PR DESCRIPTION
This change slightly modifies the functionality of the copy_media_files() function by changing the behavior of the unused exclude option to be a list extensions rather than a list of Unix shell patterns.

This function is only called in `mkdocs/commands/build.py` and does not use the functionality.

I also add a variable to define markdown extensions in a single place.

This change will *greatly* simplify life for a plugin developer who wishes to reused this functionality (namely me).

So my plugin to copy markdown files can simply consist of:

```python
utils.copy_media_files(config['docs_dir'], config['site_dir'], exclude = [], dirty=True)
```

in a `post_build` event.

I understand this may get rejected as there is a private refactor in progress for the next release, but please consider allowing for a similarly flexible util function in the future.