### PR TITLE
Paths in config file are relative to the config file.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -25,7 +25,7 @@ The current and past members of the MkDocs team.
 
 ### Major Additions to Development Version
 
-#### Path Based Settings are Relative to Configuration File (#543).
+#### Path Based Settings are Relative to Configuration File (#543)
 
 Previously any relative paths in the various configuration options were
 resolved relative to the current working directory. They are now resolved

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -25,6 +25,25 @@ The current and past members of the MkDocs team.
 
 ### Major Additions to Development Version
 
+#### Path Based Settings are Relative to Configuration File (#543).
+
+Previously any relative paths in the various configuration options were
+resolved relative to the current working directory. They are now resolved
+relative to the configuration file. As the documentation has always encouraged
+running the various MkDocs commands from the directory that contains the
+configuration file (project root), this change will not affect most users.
+However, it will make it much easier to implement automated builds or otherwise
+run commands from a location other than the project root.
+
+Simply use the `-f/--config-file` option and point it at the configuration file:
+
+```sh
+mkdocs build --config-file /path/to/my/config/file.yml
+```
+
+As previously, if no file is specified, MkDocs looks for a file named
+`mkdocs.yml` in the current working directory.
+
 #### Refactor Search Plugin
 
 The search plugin has been completely refactored to include support for the

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -215,9 +215,10 @@ If a set of key/value pairs, the following nested keys can be defined:
 
     #### custom_dir:
 
-    A directory to custom a theme. This can either be a relative directory, in
-    which case it is resolved relative to the directory containing your
-    configuration file, or it can be an absolute directory path.
+    A directory containing a custom theme. This can either be a relative
+    directory, in which case it is resolved relative to the directory containing
+    your configuration file, or it can be an absolute directory path from the
+    root of your local file system.
 
     See [styling your docs][theme_dir] for details if you would like to tweak an
     existing theme.
@@ -240,19 +241,19 @@ If a set of key/value pairs, the following nested keys can be defined:
 
 ### docs_dir
 
-Lets you set the directory containing the documentation source markdown files.
-This can either be a relative directory, in which case it is resolved relative
-to the directory containing your configuration file, or it can be an absolute
-directory path from the root of your local file system.
+The directory containing the documentation source markdown files. This can
+either be a relative directory, in which case it is resolved relative to the
+directory containing your configuration file, or it can be an absolute directory
+path from the root of your local file system.
 
 **default**: `'docs'`
 
 ### site_dir
 
-Lets you set the directory where the output HTML and other files are created.
-This can either be a relative directory, in which case it is resolved relative
-to the directory containing your configuration file, or it can be an absolute
-directory path from the root of your local file system.
+The directory where the output HTML and other files are created. This can either
+be a relative directory, in which case it is resolved relative to the directory
+containing your configuration file, or it can be an absolute directory path from
+the root of your local file system.
 
 **default**: `'site'`
 

--- a/docs/user-guide/custom-themes.md
+++ b/docs/user-guide/custom-themes.md
@@ -20,41 +20,48 @@ and their usage.
 ## Creating a custom theme
 
 The bare minimum required for a custom theme is a `main.html` [Jinja2 template]
-file. This should be placed in a directory which will be the `custom_dir` and it
-should be created next to the `mkdocs.yml` configuration file. Within
-`mkdocs.yml`, specify the theme `custom_dir` option and set it to the name of
-the directory containing `main.html`. For example, given this example project
-layout:
+file which is placed in a directory that is *not* a child of the [docs_dir].
+Within `mkdocs.yml`, set the theme.[custom_dir] option to the path of the
+directory containing `main.html`. The path should be relative to the
+configuration file. For example, given this example project layout:
 
-    mkdocs.yml
-    docs/
-        index.md
-        about.md
-    custom_theme/
-        main.html
-        ...
+```no-highlight
+mkdocs.yml
+docs/
+    index.md
+    about.md
+custom_theme/
+    main.html
+    ...
+```
 
-You would include the following settings in `mkdocs.yml` to use the custom theme
+... you would include the following settings in `mkdocs.yml` to use the custom theme
 directory:
 
-    theme:
-        name: null
-        custom_dir: 'custom_theme'
+```yaml
+theme:
+    name: null
+    custom_dir: 'custom_theme/'
+```
 
 !!! Note
 
-    Generally, when building your own custom theme, the theme `name`
-    configuration setting would be set to `null`. However, if used in
-    combination with the `custom_dir` configuration value a custom theme can be
-    used to replace only specific parts of a built-in theme. For example, with
-    the above layout and if you set `name: "mkdocs"` then the `main.html` file
-    in the `custom_dir` would replace that in the theme but otherwise the
-    `mkdocs` theme would remain the same. This is useful if you want to make
+    Generally, when building your own custom theme, the theme.[name]
+    configuration setting would be set to `null`. However, if the
+    theme.[custom_dir] configuration value is used in combination with an
+    existing theme, the theme.[custom_dir] can be used to replace only specific
+    parts of a built-in theme. For example, with the above layout and if you set
+    `name: "mkdocs"` then the `main.html` file in the theme.[custom_dir] would
+    replace the file of the same name in the `mkdocs` theme but otherwise the
+    `mkdocs` theme would remain unchanged. This is useful if you want to make
     small adjustments to an existing theme.
 
     For more specific information, see [styling your docs].
 
 [styling your docs]: ./styling-your-docs.md#using-the-theme-custom_dir
+[custom_dir]: ./configuration.md#custom_dir
+[name]: ./configuration.md#name
+[docs_dir]:./configuration.md#docs_dir
 
 ## Basic theme
 

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -138,7 +138,7 @@ And then point your `mkdocs.yml` configuration file at the new directory:
 ```yaml
 theme:
     name: mkdocs
-    custom_dir: custom_theme
+    custom_dir: custom_theme/
 ```
 
 To override the 404 error page ("file not found"), add a new template file named

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -21,14 +21,14 @@ class Config(utils.UserDict):
     for running validation on the structure and contents.
     """
 
-    def __init__(self, schema):
+    def __init__(self, schema, fname=None):
         """
         The schema is a Python dict which maps the config name to a validator.
         """
 
         self._schema = schema
         self._schema_keys = set(dict(schema).keys())
-        self.fname = None
+        self.fname = fname
         self.data = {}
 
         self.user_configs = []
@@ -121,10 +121,6 @@ class Config(utils.UserDict):
         self.data.update(patch)
 
     def load_file(self, config_file):
-        fname = getattr(config_file, 'name', None)
-        if fname:
-            self.fname = fname
-
         return self.load_dict(utils.yaml_load(config_file))
 
 
@@ -173,11 +169,11 @@ def load_config(config_file=None, **kwargs):
             options.pop(key)
 
     config_file = _open_config_file(config_file)
-    options['config_file_path'] = getattr(config_file, 'name', '')
+    fname = options['config_file_path'] = getattr(config_file, 'name', '')
 
     # Initialise the config with the default schema .
     from mkdocs import config
-    cfg = Config(schema=config.DEFAULT_SCHEMA)
+    cfg = Config(schema=config.DEFAULT_SCHEMA, fname=fname)
     # First load the config file
     cfg.load_file(config_file)
     # Then load the options to overwrite anything in the config.

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -28,6 +28,7 @@ class Config(utils.UserDict):
 
         self._schema = schema
         self._schema_keys = set(dict(schema).keys())
+        self.fname = None
         self.data = {}
 
         self.user_configs = []
@@ -120,6 +121,10 @@ class Config(utils.UserDict):
         self.data.update(patch)
 
     def load_file(self, config_file):
+        fname = getattr(config_file, 'name', None)
+        if fname:
+            self.fname = fname
+
         return self.load_dict(utils.yaml_load(config_file))
 
 

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -21,14 +21,14 @@ class Config(utils.UserDict):
     for running validation on the structure and contents.
     """
 
-    def __init__(self, schema, fname=None):
+    def __init__(self, schema, config_file_path=None):
         """
         The schema is a Python dict which maps the config name to a validator.
         """
 
         self._schema = schema
         self._schema_keys = set(dict(schema).keys())
-        self.fname = fname
+        self.config_file_path = config_file_path
         self.data = {}
 
         self.user_configs = []
@@ -169,11 +169,11 @@ def load_config(config_file=None, **kwargs):
             options.pop(key)
 
     config_file = _open_config_file(config_file)
-    fname = options['config_file_path'] = getattr(config_file, 'name', '')
+    options['config_file_path'] = getattr(config_file, 'name', '')
 
     # Initialise the config with the default schema .
     from mkdocs import config
-    cfg = Config(schema=config.DEFAULT_SCHEMA, fname=fname)
+    cfg = Config(schema=config.DEFAULT_SCHEMA, config_file_path=options['config_file_path'])
     # First load the config file
     cfg.load_file(config_file)
     # Then load the options to overwrite anything in the config.

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -293,6 +293,21 @@ class FilesystemObject(Type):
         super(FilesystemObject, self).__init__(type_=utils.string_types, **kwargs)
         self.exists = exists
 
+    def pre_validation(self, config, key_name):
+        value = config[key_name]
+
+        if os.path.isabs(value):
+            return
+
+        if config.fname is None:
+            # Unable to determine absolute path of the config file; fall back
+            # to trusting the relative path
+            return
+
+        config_dir = os.path.dirname(config.fname)
+        value = os.path.join(config_dir, value)
+        config[key_name] = value
+
     def run_validation(self, value):
         value = super(FilesystemObject, self).run_validation(value)
         if self.exists and not self.existence_test(value):

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -450,7 +450,12 @@ class Theme(BaseConfigOption):
 
         # Ensure custom_dir is an absolute path
         if 'custom_dir' in theme_config and not os.path.isabs(theme_config['custom_dir']):
-            theme_config['custom_dir'] = os.path.abspath(theme_config['custom_dir'])
+            config_dir = os.path.dirname(config.config_file_path)
+            theme_config['custom_dir'] = os.path.join(config_dir, theme_config['custom_dir'])
+
+        if 'custom_dir' in theme_config and not os.path.isdir(theme_config['custom_dir']):
+            raise ValidationError("The path set in {name}.custom_dir ('{path}') does not exist.".
+                                  format(path=theme_config['custom_dir'], name=self.name))
 
         config[key_name] = theme.Theme(**theme_config)
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -302,12 +302,12 @@ class FilesystemObject(Type):
         if os.path.isabs(value):
             return
 
-        if config.fname is None:
+        if config.config_file_path is None:
             # Unable to determine absolute path of the config file; fall back
             # to trusting the relative path
             return
 
-        config_dir = os.path.dirname(config.fname)
+        config_dir = os.path.dirname(config.config_file_path)
         value = os.path.join(config_dir, value)
         config[key_name] = value
 
@@ -329,11 +329,11 @@ class Dir(FilesystemObject):
     name = 'directory'
 
     def post_validation(self, config, key_name):
-        if config.fname is None:
+        if config.config_file_path is None:
             return
 
         # Validate that the dir is not the parent dir of the config file.
-        if os.path.dirname(config.fname) == config[key_name]:
+        if os.path.dirname(config.config_file_path) == config[key_name]:
             raise ValidationError(
                 ("The '{0}' should not be the parent directory of the config "
                  "file. Use a child directory instead so that the config file "
@@ -644,7 +644,7 @@ class Plugins(OptionallyRequired):
         self.config_file_path = None
 
     def pre_validation(self, config, key_name):
-        self.config_file_path = config.fname
+        self.config_file_path = config.config_file_path
 
     def run_validation(self, value):
         if not isinstance(value, (list, tuple)):

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -42,10 +42,10 @@ class BasePlugin(object):
     config_scheme = ()
     config = {}
 
-    def load_config(self, options):
+    def load_config(self, options, fname=None):
         """ Load config from a dict of options. Returns a tuple of (errors, warnings)."""
 
-        self.config = Config(schema=self.config_scheme)
+        self.config = Config(schema=self.config_scheme, fname=fname)
         self.config.load_dict(options)
 
         return self.config.validate()

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -42,10 +42,10 @@ class BasePlugin(object):
     config_scheme = ()
     config = {}
 
-    def load_config(self, options, fname=None):
+    def load_config(self, options, config_file_path=None):
         """ Load config from a dict of options. Returns a tuple of (errors, warnings)."""
 
-        self.config = Config(schema=self.config_scheme, fname=fname)
+        self.config = Config(schema=self.config_scheme, config_file_path=config_file_path)
         self.config.load_dict(options)
 
         return self.config.validate()

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -275,7 +275,7 @@ class DirTest(unittest.TestCase):
     def test_doc_dir_is_config_dir(self):
         cfg = Config(
             [('docs_dir', config_options.Dir())],
-            fname=os.path.join(os.path.abspath('.'), 'mkdocs.yml'),
+            config_file_path=os.path.join(os.path.abspath('.'), 'mkdocs.yml'),
         )
 
         test_config = {

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -6,6 +6,7 @@ import unittest
 import mkdocs
 from mkdocs import utils
 from mkdocs.config import config_options
+from mkdocs.config.base import Config
 
 
 class OptionallyRequiredTest(unittest.TestCase):
@@ -272,18 +273,21 @@ class DirTest(unittest.TestCase):
                           option.validate, [])
 
     def test_doc_dir_is_config_dir(self):
+        cfg = Config(
+            [('docs_dir', config_options.Dir())],
+            fname=os.path.join(os.path.abspath('.'), 'mkdocs.yml'),
+        )
 
         test_config = {
-            'config_file_path': os.path.join(os.path.abspath('.'), 'mkdocs.yml'),
             'docs_dir': '.'
         }
 
-        docs_dir = config_options.Dir()
+        cfg.load_dict(test_config)
 
-        test_config['docs_dir'] = docs_dir.validate(test_config['docs_dir'])
+        fails, warns = cfg.validate()
 
-        self.assertRaises(config_options.ValidationError,
-                          docs_dir.post_validation, test_config, 'docs_dir')
+        self.assertEqual(len(fails), 1)
+        self.assertEqual(len(warns), 0)
 
 
 class SiteDirTest(unittest.TestCase):
@@ -293,12 +297,23 @@ class SiteDirTest(unittest.TestCase):
         site_dir = config_options.SiteDir()
         docs_dir = config_options.Dir()
 
-        config['config_file_path'] = os.path.join(os.path.abspath('..'), 'mkdocs.yml')
+        fname = os.path.join(os.path.abspath('..'), 'mkdocs.yml')
 
         config['docs_dir'] = docs_dir.validate(config['docs_dir'])
         config['site_dir'] = site_dir.validate(config['site_dir'])
-        site_dir.post_validation(config, 'site_dir')
-        return True  # No errors were raised
+
+        schema = [
+            ('site_dir', site_dir),
+            ('docs_dir', docs_dir),
+        ]
+        cfg = Config(schema, fname)
+        cfg.load_dict(config)
+        failed, warned = cfg.validate()
+
+        if failed:
+            raise config_options.ValidationError(failed)
+
+        return True
 
     def test_doc_dir_in_site_dir(self):
 

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -7,6 +7,13 @@ import shutil
 import tempfile
 import unittest
 
+try:
+    # py>=3.2
+    from tempfile import TemporaryDirectory
+except ImportError:
+    from backports.tempfile import TemporaryDirectory
+
+
 import mkdocs
 from mkdocs import config
 from mkdocs import utils
@@ -81,7 +88,11 @@ class ConfigTests(unittest.TestCase):
         pages:
         - 'Introduction': 'index.md'
         """)
-        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        temp_dir = TemporaryDirectory()
+        temp_path = temp_dir.name
+        os.mkdir(os.path.join(temp_path, 'docs'))
+        config_path = os.path.join(temp_path, 'mkdocs.yml')
+        config_file = open(config_path, 'w')
         try:
             config_file.write(ensure_utf(file_contents))
             config_file.flush()
@@ -91,7 +102,7 @@ class ConfigTests(unittest.TestCase):
             self.assertEqual(result['site_name'], expected_result['site_name'])
             self.assertEqual(result['pages'], expected_result['pages'])
         finally:
-            os.remove(config_file.name)
+            temp_dir.cleanup()
 
     def test_theme(self):
 

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import unittest
 import mock
+import os
 
 from mkdocs import plugins
 from mkdocs import utils
@@ -30,19 +31,24 @@ class DummyPlugin(plugins.BasePlugin):
 class TestPluginClass(unittest.TestCase):
 
     def test_valid_plugin_options(self):
+        test_dir = 'test'
 
         options = {
             'foo': 'some value',
-            'dir': 'test',
+            'dir': test_dir,
         }
+
+        cfg_fname = os.path.join('tmp', 'test', 'fname.yml')
+        cfg_fname = os.path.abspath(cfg_fname)
+
+        cfg_dirname = os.path.dirname(cfg_fname)
+        expected = os.path.join(cfg_dirname, test_dir)
 
         expected = {
             'foo': 'some value',
             'bar': 0,
-            'dir': '/tmp/test',
+            'dir': expected,
         }
-
-        cfg_fname = '/tmp/mkdocs.yml'  # fake path
 
         plugin = DummyPlugin()
         errors, warnings = plugin.load_config(options, fname=cfg_fname)

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -51,7 +51,7 @@ class TestPluginClass(unittest.TestCase):
         }
 
         plugin = DummyPlugin()
-        errors, warnings = plugin.load_config(options, fname=cfg_fname)
+        errors, warnings = plugin.load_config(options, config_file_path=cfg_fname)
         self.assertEqual(plugin.config, expected)
         self.assertEqual(errors, [])
         self.assertEqual(warnings, [])

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -14,7 +14,8 @@ from mkdocs import config
 class DummyPlugin(plugins.BasePlugin):
     config_scheme = (
         ('foo', config.config_options.Type(utils.string_types, default='default foo')),
-        ('bar', config.config_options.Type(int, default=0))
+        ('bar', config.config_options.Type(int, default=0)),
+        ('dir', config.config_options.Dir(exists=False)),
     )
 
     def on_pre_page(self, content, **kwargs):
@@ -31,16 +32,20 @@ class TestPluginClass(unittest.TestCase):
     def test_valid_plugin_options(self):
 
         options = {
-            'foo': 'some value'
+            'foo': 'some value',
+            'dir': 'test',
         }
 
         expected = {
             'foo': 'some value',
-            'bar': 0
+            'bar': 0,
+            'dir': '/tmp/test',
         }
 
+        cfg_fname = '/tmp/mkdocs.yml'  # fake path
+
         plugin = DummyPlugin()
-        errors, warnings = plugin.load_config(options)
+        errors, warnings = plugin.load_config(options, fname=cfg_fname)
         self.assertEqual(plugin.config, expected)
         self.assertEqual(errors, [])
         self.assertEqual(warnings, [])
@@ -132,7 +137,8 @@ class TestPluginConfig(unittest.TestCase):
         self.assertIsInstance(cfg['plugins']['sample'], plugins.BasePlugin)
         expected = {
             'foo': 'default foo',
-            'bar': 0
+            'bar': 0,
+            'dir': None,
         }
         self.assertEqual(cfg['plugins']['sample'].config, expected)
 
@@ -154,7 +160,8 @@ class TestPluginConfig(unittest.TestCase):
         self.assertIsInstance(cfg['plugins']['sample'], plugins.BasePlugin)
         expected = {
             'foo': 'foo value',
-            'bar': 42
+            'bar': 42,
+            'dir': None,
         }
         self.assertEqual(cfg['plugins']['sample'].config, expected)
 
@@ -194,7 +201,8 @@ class TestPluginConfig(unittest.TestCase):
         self.assertIsInstance(cfg['plugins']['sample'], plugins.BasePlugin)
         expected = {
             'foo': 'default foo',
-            'bar': 0
+            'bar': 0,
+            'dir': None,
         }
         self.assertEqual(cfg['plugins']['sample'].config, expected)
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps=
     py{27,34,35,36,py,py3}-{unittests,integration}: -rrequirements/project.txt
     py{27,34,35,36,py,py3}-min-req: -rrequirements/project-min.txt
     py{27,34,35,36,py,py3}-{unittests,min-req}: -rrequirements/test.txt
+    py27-{unittests,min-req}: backports.tempfile
 commands=
     {envpython} --version
     py{27,34,35,36,py,py3}-{unittests,min-req}: {envbindir}/nosetests --with-coverage --cover-package mkdocs mkdocs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-{unittests,integration,min-req},
+    py{27,34,35,36,py,py3}-{unittests,integration,min-req},
     flake8, markdown-lint, linkchecker, jshint, csslint
 
 [testenv]
@@ -9,7 +9,7 @@ deps=
     py{27,34,35,36,py,py3}-{unittests,integration}: -rrequirements/project.txt
     py{27,34,35,36,py,py3}-min-req: -rrequirements/project-min.txt
     py{27,34,35,36,py,py3}-{unittests,min-req}: -rrequirements/test.txt
-    py27-{unittests,min-req}: backports.tempfile
+    py{27,py}-{unittests,min-req}: backports.tempfile
 commands=
     {envpython} --version
     py{27,34,35,36,py,py3}-{unittests,min-req}: {envbindir}/nosetests --with-coverage --cover-package mkdocs mkdocs


### PR DESCRIPTION
Ran into #543 today, saw that no one had started working on this, so decided to take a stab at it. I used `pre_validation` to coerce relative paths to absolute paths, which worked for my use case. 

Two things I wasn't sure of where to go with:
1. What happens if `Config.load_file` is passed something without a filename? I found a few tests where that was the case, but couldn't think of a use case otherwise. I reverted to the current behavior in this scenario (relative paths are left alone, so they're relative to the current working directory).
2. A few of the tests relied on the current behavior (they processed config files in `/tmp`, and relied on  the existence `./docs` in order to pass validation. I cleaned up the tests, but used `tempfile.TemporaryDirectory`, which doesn't exist in py<3.2. Installing `backports.tempfile` took care of that, but made the imports a little more complex (you'll see them in the `*_tests.py` files).

Thanks for making this project available!

Fixes #543 