### PR TITLE
Add a title attribute to the search input

### DIFF
--- a/mkdocs/themes/mkdocs/search-modal.html
+++ b/mkdocs/themes/mkdocs/search-modal.html
@@ -12,7 +12,7 @@
                 </p>
                 <form role="form">
                     <div class="form-group">
-                        <input type="text" class="form-control" placeholder="Search..." id="mkdocs-search-query">
+                        <input type="text" class="form-control" placeholder="Search..." id="mkdocs-search-query" title="Type search term here">
                     </div>
                 </form>
                 <div id="mkdocs-search-results"></div>

--- a/mkdocs/themes/readthedocs/search.html
+++ b/mkdocs/themes/readthedocs/search.html
@@ -6,7 +6,7 @@
 
   <form id="content_search" action="search.html">
     <span role="status" aria-live="polite" class="ui-helper-hidden-accessible"></span>
-    <input name="q" id="mkdocs-search-query" type="text" class="search_input search-query ui-autocomplete-input" placeholder="Search the Docs" autocomplete="off" autofocus>
+    <input name="q" id="mkdocs-search-query" type="text" class="search_input search-query ui-autocomplete-input" placeholder="Search the Docs" autocomplete="off" autofocus title="Type search term here">
   </form>
 
   <div id="mkdocs-search-results" class="search-results">

--- a/mkdocs/themes/readthedocs/searchbox.html
+++ b/mkdocs/themes/readthedocs/searchbox.html
@@ -1,5 +1,5 @@
 <div role="search">
   <form id ="rtd-search-form" class="wy-form" action="{{ base_url }}/search.html" method="get">
-    <input type="text" name="q" placeholder="Search docs" />
+    <input type="text" name="q" placeholder="Search docs" title="Type search term here" />
   </form>
 </div>


### PR DESCRIPTION
Currently the input does not have any label or title which means is is not correctly identified by assistive technologies such as screen reader.
(You can read more about it in [this WCAG guideline](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H65).)