### PR TITLE
Defer scripts

### DIFF
--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -33,9 +33,9 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
-        <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
-        <script src="{{ base_url }}/js/highlight.pack.js"></script>
+        <script src="{{ base_url }}/js/jquery-1.10.2.min.js" defer></script>
+        <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js" defer></script>
+        <script src="{{ base_url }}/js/highlight.pack.js" defer></script>
       {%- endblock %}
 
       {%- block analytics %}
@@ -78,9 +78,9 @@
 
       {%- block scripts %}
         <script>var base_url = '{{ base_url }}';</script>
-        <script src="{{ base_url }}/js/base.js"></script>
+        <script src="{{ base_url }}/js/base.js" defer></script>
         {%- for path in extra_javascript %}
-        <script src="{{ path }}"></script>
+        <script src="{{ path }}" defer></script>
         {%- endfor %}
       {%- endblock %}
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -36,9 +36,9 @@
     var mkdocs_page_url = {{ page.abs_url|tojson|safe }};
   </script>
   {% endif %}
-  <script src="{{ base_url }}/js/jquery-2.1.1.min.js"></script>
-  <script src="{{ base_url }}/js/modernizr-2.8.3.min.js"></script>
-  <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js"></script>
+  <script src="{{ base_url }}/js/jquery-2.1.1.min.js" defer></script>
+  <script src="{{ base_url }}/js/modernizr-2.8.3.min.js" defer></script>
+  <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js" defer></script>
   {%- endblock %}
 
   {%- block extrahead %} {% endblock %}
@@ -121,9 +121,9 @@
 
   {%- block scripts %}
     <script>var base_url = '{{ base_url }}';</script>
-    <script src="{{ base_url }}/js/theme.js"></script>
+    <script src="{{ base_url }}/js/theme.js" defer></script>
     {%- for path in extra_javascript %}
-      <script src="{{ path }}"></script>
+      <script src="{{ path }}" defer></script>
     {%- endfor %}
   {%- endblock %}
 


### PR DESCRIPTION
Currently, page rendering is delayed until all scripts are loaded. But these scripts are not essential to the main content.
The `defer` attribute allows the browser to render the page before the scripts are completely loaded so the user can see the webpage earlier.