### PR TITLE
Added an offset parameter to the scrollspy for more accurate detection

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -39,13 +39,7 @@ ul.nav .main {
 /*
  * The code below adds some padding to the top of the current anchor target so
  * that, when navigating to it, the header isn't hidden by the navbar at the
- * top. This is especially complicated because we want to *remove* the padding
- * after navigation so that hovering over the header shows the permalink icon
- * correctly. Thus, we create a CSS animation to remove the extra padding after
- * a second. We have two animations so that navigating to an anchor within the
- * page always restarts the animation.
- *
- * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ * top.
  */
 :target::before {
     content: "";
@@ -53,25 +47,6 @@ ul.nav .main {
     margin-top: -75px;
     height: 75px;
     pointer-events: none;
-    animation: 0s 1s forwards collapse-anchor-padding-1;
-}
-
-.clicky :target::before {
-  animation-name: collapse-anchor-padding-2;
-}
-
-@keyframes collapse-anchor-padding-1 {
-    to {
-        margin-top: 0;
-        height: 0;
-    }
-}
-
-@keyframes collapse-anchor-padding-2 {
-    to {
-        margin-top: 0;
-        height: 0;
-    }
 }
 
 h1 {

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -78,12 +78,7 @@ $(document).ready(function() {
 
 $('body').scrollspy({
     target: '.bs-sidebar',
-});
-
-/* Toggle the `clicky` class on the body when clicking links to let us
-   retrigger CSS animations. See ../css/base.css for more details. */
-$('a').click(function(e) {
-    $('body').toggleClass('clicky');
+    offset: 100
 });
 
 /* Prevent disabled links from causing a page reload */


### PR DESCRIPTION
Fixes #406 

Added an offset parameter to the scrollspy for slightly accurate detection.
Removed animations and the addition of the `clicky` class which seemed to confuse scrollspy.

![scrollspy](https://user-images.githubusercontent.com/6739793/35186453-79803ba4-fe0c-11e7-9c0d-0b39ee7b7396.gif)
