### PR TITLE
Prevent reinjection of extra Javascript files on reload

### DIFF
--- a/mkdocs/contrib/legacy_search/__init__.py
+++ b/mkdocs/contrib/legacy_search/__init__.py
@@ -22,8 +22,9 @@ class SearchPlugin(BasePlugin):
         if not ('search_index_only' in config['theme'] and config['theme']['search_index_only']):
             path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
             config['theme'].dirs.append(path)
-            config['extra_javascript'].append('search/require.js')
-            config['extra_javascript'].append('search/search.js')
+            for extra_js in ('search/require.js', 'search/search.js'):
+                if extra_js not in config['extra_javascript']:
+                    config['extra_javascript'].append(extra_js)
         return config
 
     def on_pre_build(self, config, **kwargs):


### PR DESCRIPTION
The search plugin would add its extra Javascript on each reload polluting the HTML