### PR TITLE
Workaround Safari bug when zooming to < 100%

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -181,6 +181,13 @@ footer {
 
 /* Show and affix the side nav when space allows it */
 @media (min-width: 992px) {
+    /* Workaround a Safari bug when zooming to < 100%
+       https://github.com/mkdocs/mkdocs/issues/1050 */
+    .col-md-9 {
+        box-sizing: border-box;  /* csslint allow: box-sizing */
+        padding-left: 25%;
+        width: 100%;
+    }
     .bs-sidebar .nav > .active > ul {
         display: block;
     }


### PR DESCRIPTION
Fixes #1050 

Tested on Safari 11.0.2 on Mac OS X Sierra.

Haven't tried with Cinder but I assume it's the same problem, Safari simply ignores the `width: 25%` of the `col-md-3` and pushes the `col-md-9` over it. Overriding the padding and width seems to work without affecting other browsers. It's a fairly hideous workaround but aren't they all.