### PR TITLE
Use web worker to build Lunr index

### DIFF
--- a/mkdocs/contrib/legacy_search/__init__.py
+++ b/mkdocs/contrib/legacy_search/__init__.py
@@ -22,9 +22,8 @@ class SearchPlugin(BasePlugin):
         if not ('search_index_only' in config['theme'] and config['theme']['search_index_only']):
             path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
             config['theme'].dirs.append(path)
-            for extra_js in ('search/require.js', 'search/search.js'):
-                if extra_js not in config['extra_javascript']:
-                    config['extra_javascript'].append(extra_js)
+            if 'search/main.js' not in config['extra_javascript']:
+                config['extra_javascript'].append('search/main.js')
         return config
 
     def on_pre_build(self, config, **kwargs):

--- a/mkdocs/contrib/legacy_search/templates/search/main.js
+++ b/mkdocs/contrib/legacy_search/templates/search/main.js
@@ -1,0 +1,63 @@
+function getSearchTermFromLocation() {
+  var sPageURL = window.location.search.substring(1);
+  var sURLVariables = sPageURL.split('&');
+  for (var i = 0; i < sURLVariables.length; i++) {
+    var sParameterName = sURLVariables[i].split('=');
+    if (sParameterName[0] == 'q') {
+      return decodeURIComponent(sParameterName[1].replace(/\+/g, '%20'));
+    }
+  }
+}
+
+function formatResult (location, title, summary) {
+  return '<article><h3><a href="'+ location + '">'+ title + '</a></h3><p>' + summary +'</p></article>';
+}
+
+function onWorkerMessage (e) {
+  if (e.data.results) {
+    var results = e.data.results;
+    var search_results = document.getElementById("mkdocs-search-results");
+    while (search_results.firstChild) {
+      search_results.removeChild(search_results.firstChild);
+    }
+    if (results.length > 0){
+      for (var i=0; i < results.length; i++){
+        var result = results[i];
+        var html = formatResult(result.location, result.title, result.summary);
+        search_results.insertAdjacentHTML('beforeend', html);
+      }
+    } else {
+        search_results.insertAdjacentHTML('beforeend', "<p>No results found</p>");
+    }
+  }
+}
+
+function search () {
+  var query = document.getElementById('mkdocs-search-query').value;
+  if (query.length > 2) {
+    console.log('Sending search query for: ' + query);
+    searchWorker.postMessage({query: query});
+  }
+}
+
+if (!window.Worker) {
+  console.error('Web Worker API not supported');
+  // TODO: load legacy search.js?
+} else {
+  var searchWorker = new Worker("/search/worker.js");
+  searchWorker.postMessage({baseUrl: base_url});
+  searchWorker.onmessage = onWorkerMessage;
+
+  $(function() {
+    var search_input = document.getElementById('mkdocs-search-query');
+    if (search_input) {
+      search_input.addEventListener("keyup", search);
+    }
+
+    var term = getSearchTermFromLocation();
+    if (term) {
+      search_input.value = term;
+      search();
+    }
+  });
+}

--- a/mkdocs/contrib/legacy_search/templates/search/worker.js
+++ b/mkdocs/contrib/legacy_search/templates/search/worker.js
@@ -1,0 +1,51 @@
+importScripts('lunr.min.js');
+
+var base_url = '.';
+var index;
+var documents = {};
+
+function onLoad () {
+  var data = JSON.parse(this.responseText);
+  index = lunr(function () {
+    this.field('title', {boost: 10});  // TODO: Lunr v2 deprecated this in favour of searches like ^10
+    this.field('text');
+    this.ref('location');
+  });
+  for (var i=0; i < data.docs.length; i++) {
+    var doc = data.docs[i];
+    doc.location = base_url + doc.location;
+    index.add(doc);
+    documents[doc.location] = doc;
+  }
+}
+
+function init () {
+  var oReq = new XMLHttpRequest();
+  oReq.addEventListener("load", onLoad);
+  oReq.open("GET", '/search/search_index.json');
+  oReq.send();
+}
+
+function search (query) {
+  var resultDocuments = [];
+  var results = index.search(query);
+  for (var i=0; i < results.length; i++){
+    var result = results[i];
+    doc = documents[result.ref];
+    doc.base_url = base_url;
+    doc.summary = doc.text.substring(0, 200);
+    resultDocuments.push(doc);
+  }
+  return resultDocuments;
+}
+
+onmessage = function (e) {
+  if (e.data.baseUrl) {
+    base_url = e.data.baseUrl;
+    init();
+  } else if (e.data.query) {
+    postMessage({ results: search(e.data.query) });
+  } else {
+    console.error("Worker - Unrecognized message: " + e);
+  }
+};


### PR DESCRIPTION
Addresses #1218, #859 and #1127 

Reading the discussion on #859 I decided to give the Web Workers API a try and got a working solution using them. In the process I managed to remove require.js and mustache from the dependencies which seemed overkill for our use case.

I'm not completely replacing the previous code since it's possible the user's browser [might not the Web Workers API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API#Browser_compatibility). Based on our target browser versions we can discuss if we  load or remove the previous version.

I also realised it'd be quite simple to upgrade to the current version Lunr and maybe include [additional language support](https://lunrjs.com/guides/language_support.html) but would require some changes to the configuration, we can discuss it outside the context of this PR.