### PR TITLE
Remove last slash from repository URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: http://www.mkdocs.org
 site_description: Project documentation with Markdown.
 site_author: MkDocs Team
 
-repo_url: https://github.com/mkdocs/mkdocs/
+repo_url: https://github.com/mkdocs/mkdocs
 edit_uri: ""
 
 pages:


### PR DESCRIPTION
I think that it is more natural for this repository URL linked from the project document to have no last slash.

For example, the last with no slash URL even search results of Google have been indexed.
![google-search](https://user-images.githubusercontent.com/221802/35767650-ab393fec-0933-11e8-8fda-eb36dec19720.png)

What do you think? 