### PR TITLE
Allow broken Nav without failing building the rest of the docs

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,7 +23,21 @@ The current and past members of the MkDocs team.
 
 ## Development Version
 
+* Compress `sitemap.xml` (#1130).
+* Defer loading JS scripts (#1380).
+* Add a title attribute to the search input (#1379).
+* Update RespondJS to latest version (#1398).
+* Always load Google Analytics over HTTPS (#1397).
+* Improve scrolling frame rate (#1394).
+* Provide more version info. (#1393).
+* Refactor `writing-your-docs.md` (#1392).
+* Workaround Safari bug when zooming to &lt; 100% (#1389).
+* Remove addition of `clicky` class to body and animations. (#1387).
+* Prevent search plugin from reinjecting `extra_javascript` files (#1388).
 * Refactor `copy_media_files` util function for more flexibility (#1370).
+* Remove PyPI Deployment Docs (#1360).
+* Update links to Python-Markdown library (#1360).
+* Document how to generate manpages for MkDocs commands (#686).
 
 ## Version 0.17.2 (2017-11-15)
 

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -252,7 +252,10 @@ class Page(object):
                     source = f.read()
             except IOError:
                 log.error('File not found: %s', self.abs_input_path)
-                raise
+                if not config['strict']:
+                    source = '404'
+                else:
+                    raise
 
         self.markdown, self.meta = meta.get_data(source)
 

--- a/mkdocs/tests/nav_tests.py
+++ b/mkdocs/tests/nav_tests.py
@@ -848,3 +848,19 @@ class SiteNavigationTests(unittest.TestCase):
 
         for idx, page in enumerate(site_navigation.walk_pages()):
             self.assertEqual(page.edit_url, expected_results[idx])
+
+    def test_missing_source_raises_exception(self):
+
+        def _test():
+            cfg = load_config(strict = True)
+            return nav.Page('missing test page', 'missing.md', 'uri_context', cfg).read_source(cfg)
+
+        self.assertRaises(IOError, _test)
+
+    def test_missing_source_is_allowed(self):
+        cfg = load_config(strict = False)
+        page = nav.Page('missing test page', 'missing.md', 'uri_context', cfg)
+        page.read_source(cfg)
+
+        self.assertEqual(page.markdown, "404")
+        self.assertFalse(page.meta)


### PR DESCRIPTION
We've noticed when many teams are contributing to a single mkdocs file, broken TOC files will eventually happen. and the mkdocs build breaks. It'd be nice to have the option to continue the build, and replace broken TOC pages with a 404 page. 

Looking for input on what exactly that 404 page should look like, for now I've literally just put the text "404" on the page!