### PR TITLE
Noted support for python 3.6

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ $ pip --version
 pip 1.5.2
 ```
 
-MkDocs supports Python versions 2.7, 3.3, 3.4, 3.5 and pypy.
+MkDocs supports Python versions 2.7, 3.3, 3.4, 3.5, 3.6 and pypy.
 
 #### Installing Python
 


### PR DESCRIPTION
"Officially added support for Python 3.6 (#1296)" as of version 0.17.0.

Source: http://www.mkdocs.org/about/release-notes/#version-0170-2017-10-19