### PR TITLE
Use .svg badges in README instead of .png

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Project documentation with Markdown.
 Everyone interacting in the MkDocs project's codebases, issue trackers, chat
 rooms, and mailing lists is expected to follow the [PyPA Code of Conduct].
 
-[appveyor-image]: https://img.shields.io/appveyor/ci/d0ugal/mkdocs/master.png
+[appveyor-image]: https://img.shields.io/appveyor/ci/d0ugal/mkdocs/master.svg
 [appveyor-link]: https://ci.appveyor.com/project/d0ugal/mkdocs
 [codecov-image]: http://codecov.io/github/mkdocs/mkdocs/coverage.svg?branch=master
 [codecov-link]: http://codecov.io/github/mkdocs/mkdocs?branch=master
 [landscape-image]: https://landscape.io/github/mkdocs/mkdocs/master/landscape.svg?style=flat-square
 [landscape-link]: https://landscape.io/github/mkdocs/mkdocs/master
-[pypi-v-image]: https://img.shields.io/pypi/v/mkdocs.png
+[pypi-v-image]: https://img.shields.io/pypi/v/mkdocs.svg
 [pypi-v-link]: https://pypi.python.org/pypi/mkdocs
-[travis-image]: https://img.shields.io/travis/mkdocs/mkdocs/master.png
+[travis-image]: https://img.shields.io/travis/mkdocs/mkdocs/master.svg
 [travis-link]: https://travis-ci.org/mkdocs/mkdocs
 
 [mkdocs]: http://www.mkdocs.org

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ rooms, and mailing lists is expected to follow the [PyPA Code of Conduct].
 [appveyor-link]: https://ci.appveyor.com/project/d0ugal/mkdocs
 [codecov-image]: http://codecov.io/github/mkdocs/mkdocs/coverage.svg?branch=master
 [codecov-link]: http://codecov.io/github/mkdocs/mkdocs?branch=master
-[landscape-image]: https://landscape.io/github/mkdocs/mkdocs/master/landscape.svg?style=flat-square
+[landscape-image]: https://landscape.io/github/mkdocs/mkdocs/master/landscape.svg?style=flat
 [landscape-link]: https://landscape.io/github/mkdocs/mkdocs/master
 [pypi-v-image]: https://img.shields.io/pypi/v/mkdocs.svg
 [pypi-v-link]: https://pypi.python.org/pypi/mkdocs


### PR DESCRIPTION
The png versions of the badges can appear blurry on certain screen sizes. For me they look like this:

![image](https://user-images.githubusercontent.com/6610341/36924498-aba94506-1e66-11e8-88df-72d282230430.png)

This PR uses the svg versions instead, which fixes that issue. It also uses the rounded version of the landscape.io 'health' badge to match the others.

![image](https://user-images.githubusercontent.com/6610341/36924688-8511d72c-1e67-11e8-9900-097375c1af4f.png)



