### PR TITLE
Support Unicode characters in file paths

### DIFF
--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -321,3 +321,30 @@ class UtilsTests(unittest.TestCase):
                     os.chmod(src, stat.S_IRUSR | stat.S_IWUSR)
             shutil.rmtree(src_dir)
             shutil.rmtree(dst_dir)
+
+    def test_unicode_clean_directory(self):
+        temp_dir = tempfile.mkdtemp()
+        utf8_directory = os.path.join(temp_dir, '导航')
+        utf8_utf8_directory = os.path.join(utf8_directory, '导航')
+        ascii_directory = os.path.join(temp_dir, 'bar')
+        ascii_ascii_directory = os.path.join(ascii_directory, 'bar')
+
+        os.makedirs(utf8_utf8_directory)
+        os.makedirs(ascii_ascii_directory)
+
+        utf_8_path = os.path.join(utf8_utf8_directory, 'foo.txt')
+        ascii_path = os.path.join(ascii_ascii_directory, 'foo.txt')
+
+        with open(utf_8_path, 'w') as f:
+            f.write('content')
+
+        with open(ascii_path, 'w') as f:
+            f.write('content')
+
+        try:
+            utils.clean_directory(utf8_directory)
+            utils.clean_directory(ascii_directory)
+            self.assertTrue(os.path.exists(utf_8_path), False)
+            self.assertTrue(os.path.exists(ascii_path), False)
+        finally:
+            shutil.rmtree(temp_dir)

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -344,7 +344,9 @@ class UtilsTests(unittest.TestCase):
         try:
             utils.clean_directory(utf8_directory)
             utils.clean_directory(ascii_directory)
-            self.assertTrue(os.path.exists(utf_8_path), False)
-            self.assertTrue(os.path.exists(ascii_path), False)
+            self.assertFalse(os.path.exists(utf_8_path))
+            self.assertFalse(os.path.exists(ascii_path))
+            self.assertFalse(os.path.exists(utf8_utf8_directory))
+            self.assertFalse(os.path.exists(ascii_ascii_directory))
         finally:
             shutil.rmtree(temp_dir)

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -12,6 +12,7 @@ import stat
 
 from mkdocs import nav, utils, exceptions
 from mkdocs.tests.base import dedent, load_config
+from mkdocs.utils.ghp_import import dec
 
 
 class UtilsTests(unittest.TestCase):
@@ -324,7 +325,9 @@ class UtilsTests(unittest.TestCase):
 
     def test_unicode_clean_directory(self):
         temp_dir = tempfile.mkdtemp()
-        utf8_directory = os.path.join(temp_dir, '导航')
+        utf8_temp_dir = os.path.join(dec('tmp'), dec('tmp_utf8'))
+
+        utf8_directory = os.path.join(utf8_temp_dir, '导航')
         utf8_utf8_directory = os.path.join(utf8_directory, '导航')
         ascii_directory = os.path.join(temp_dir, 'bar')
         ascii_ascii_directory = os.path.join(ascii_directory, 'bar')
@@ -350,3 +353,4 @@ class UtilsTests(unittest.TestCase):
             self.assertFalse(os.path.exists(ascii_ascii_directory))
         finally:
             shutil.rmtree(temp_dir)
+            shutil.rmtree(utf8_temp_dir)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -19,6 +19,7 @@ import yaml
 import fnmatch
 
 from mkdocs import exceptions
+from .ghp_import import dec
 
 try:                                                        # pragma: no cover
     from urllib.parse import urlparse, urlunparse, urljoin  # noqa
@@ -143,11 +144,8 @@ def clean_directory(directory):
 
         # Don't remove hidden files from the directory. We never copy files
         # that are hidden, so we shouldn't delete them either.
-        try:
-            if entry.startswith('.'):
-                continue
-        except UnicodeDecodeError:
-            pass
+        if dec(entry).startswith('.'):
+            continue
 
         path = os.path.join(directory, entry)
         if os.path.isdir(path):

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -144,7 +144,8 @@ def clean_directory(directory):
 
         # Don't remove hidden files from the directory. We never copy files
         # that are hidden, so we shouldn't delete them either.
-        if dec(entry).startswith('.'):
+        entry = dec(entry)
+        if entry.startswith('.'):
             continue
 
         path = os.path.join(directory, entry)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -143,8 +143,11 @@ def clean_directory(directory):
 
         # Don't remove hidden files from the directory. We never copy files
         # that are hidden, so we shouldn't delete them either.
-        if entry.startswith('.'):
-            continue
+        try:
+            if entry.startswith('.'):
+                continue
+        except UnicodeDecodeError:
+            pass
 
         path = os.path.join(directory, entry)
         if os.path.isdir(path):


### PR DESCRIPTION
when I have unicode directory name under docs,  such as '导航', when I change the content under the direcory, and the mkdoc server auto detect the change and make build, it will throw UnicodeDecodeError:
```
[E 180306 16:13:35 ioloop:638] Exception in callback <bound method type.poll_tasks of <class 'livereload.handlers.LiveReloadHandler'>>
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/site-packages/tornado/ioloop.py", line 1026, in _run
        return self.callback()
      File "/usr/lib/python2.7/site-packages/livereload/handlers.py", line 67, in poll_tasks
        filepath, delay = cls.watcher.examine()
      File "/usr/lib/python2.7/site-packages/livereload/watcher.py", line 73, in examine
        func and func()
      File "/usr/lib/python2.7/site-packages/mkdocs/commands/serve.py", line 112, in builder
        build(config, live_server=live_server, dirty=dirty)
      File "/usr/lib/python2.7/site-packages/mkdocs/commands/build.py", line 259, in build
        utils.clean_directory(config['site_dir'])
      File "/usr/lib/python2.7/site-packages/mkdocs/utils/__init__.py", line 138, in clean_directory
        if entry.startswith('.'):
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 0: ordinal not in range(128)

```