### PR TITLE
Tornado 5.0 raises error on install with older Python versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'livereload>=2.5.1',
         'Markdown>=2.3.1',
         'PyYAML>=3.10',
-        'tornado>=4.1',
+        'tornado>=4.1,<5.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
changed to `"tornado>=4.1,<5.0"` in setup.py

This broke installation via pip for me. 