### PR TITLE
Backport temp fix for tornado 5 update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'livereload>=2.5.1',
         'Markdown>=2.3.1',
         'PyYAML>=3.10',
-        'tornado>=4.1',
+        'tornado>=4.1,<5.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Changed to `"tornado>=4.1,<5.0"` in 0.17 branch. See #1427 for more info.