### PR TITLE
Switch from nose to unittest.

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -108,7 +108,7 @@ def _build_theme_template(template_name, env, files, config, nav):
     try:
         template = env.get_template(template_name)
     except TemplateNotFound:
-        log.warn("Template skipped: '{}' not found in theme directories.".format(template_name))
+        log.warning("Template skipped: '{}' not found in theme directories.".format(template_name))
         return
 
     output = _build_template(template_name, template, files, config, nav)
@@ -132,14 +132,14 @@ def _build_extra_template(template_name, files, config, nav):
 
     file = files.get_file_from_path(template_name)
     if file is None:
-        log.warn("Template skipped: '{}' not found in docs_dir.".format(template_name))
+        log.warning("Template skipped: '{}' not found in docs_dir.".format(template_name))
         return
 
     try:
         with open(file.abs_src_path, 'r', encoding='utf-8', errors='strict') as f:
             template = jinja2.Template(f.read())
     except Exception as e:
-        log.warn("Error reading template '{}': {}".format(template_name, e))
+        log.warning("Error reading template '{}': {}".format(template_name, e))
         return
 
     output = _build_template(template_name, template, files, config, nav)

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -68,7 +68,7 @@ def _check_version(branch):
     previousv = parse_version(m.group()) if m else None
     currentv = parse_version(mkdocs.__version__)
     if not previousv:
-        log.warn('Version check skipped: No version specified in previous deployment.')
+        log.warning('Version check skipped: No version specified in previous deployment.')
     elif currentv > previousv:
         log.info(
             'Previous deployment was done with MkDocs version {}; '

--- a/mkdocs/commands/new.py
+++ b/mkdocs/commands/new.py
@@ -39,7 +39,8 @@ def new(output_dir):
         os.mkdir(output_dir)
 
     log.info('Writing config file: %s', config_path)
-    open(config_path, 'w', encoding='utf-8').write(config_text)
+    with open(config_path, 'w', encoding='utf-8') as f:
+        f.write(config_text)
 
     if os.path.exists(index_path):
         return
@@ -47,4 +48,5 @@ def new(output_dir):
     log.info('Writing initial docs: %s', index_path)
     if not os.path.exists(docs_dir):
         os.mkdir(docs_dir)
-    open(index_path, 'w', encoding='utf-8').write(index_text)
+    with open(index_path, 'w', encoding='utf-8') as f:
+        f.write(index_text)

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -389,7 +389,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @tempdir(files={'testing.html': '<p>page content</p>'})
     @mock.patch('mkdocs.utils.write_file')
     def test_build_page_dirty_not_modified(self, site_dir, mock_write_file):
-        cfg = load_config(site_dir=site_dir, nav=['index.md'], plugins=[])
+        cfg = load_config(site_dir=site_dir, nav=['testing.md'], plugins=[])
         files = Files([File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])])
         nav = get_navigation(files, cfg)
         page = files.documentation_pages()[0].page

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -55,6 +55,7 @@ class ConfigBaseTests(unittest.TestCase):
             self.assertEqual(cfg['site_name'], 'MkDocs Test')
         finally:
             os.remove(config_file.name)
+            temp_dir.cleanup()
 
     def test_load_from_missing_file(self):
 

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -409,7 +409,7 @@ class SiteDirTest(unittest.TestCase):
 
         j = os.path.join
         # The parent dir is not the same on every system, so use the actual dir name
-        parent_dir = os.path.abspath(mkdocs.__file__).split(os.sep)[-3]
+        parent_dir = mkdocs.__file__.split(os.sep)[-3]
 
         test_configs = (
             {'docs_dir': j('site', 'docs'), 'site_dir': 'site'},

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -409,7 +409,7 @@ class SiteDirTest(unittest.TestCase):
 
         j = os.path.join
         # The parent dir is not the same on every system, so use the actual dir name
-        parent_dir = mkdocs.__file__.split(os.sep)[-3]
+        parent_dir = os.path.abspath(mkdocs.__file__).split(os.sep)[-3]
 
         test_configs = (
             {'docs_dir': j('site', 'docs'), 'site_dir': 'site'},

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -187,7 +187,7 @@ class SearchIndexTests(unittest.TestCase):
 
         stripper.feed("<h1>Testing</h1><p>Content</p>")
 
-        self.assertEquals(stripper.data, ["Testing", "Content"])
+        self.assertEqual(stripper.data, ["Testing", "Content"])
 
     def test_content_parser(self):
 
@@ -196,7 +196,7 @@ class SearchIndexTests(unittest.TestCase):
         parser.feed('<h1 id="title">Title</h1>TEST')
         parser.close()
 
-        self.assertEquals(parser.data, [search_index.ContentSection(
+        self.assertEqual(parser.data, [search_index.ContentSection(
             text=["TEST"],
             id_="title",
             title="Title"
@@ -209,7 +209,7 @@ class SearchIndexTests(unittest.TestCase):
         parser.feed("<h1>Title</h1>TEST")
         parser.close()
 
-        self.assertEquals(parser.data, [search_index.ContentSection(
+        self.assertEqual(parser.data, [search_index.ContentSection(
             text=["TEST"],
             id_=None,
             title="Title"
@@ -222,7 +222,7 @@ class SearchIndexTests(unittest.TestCase):
         parser.feed("Content Before H1 <h1>Title</h1>TEST")
         parser.close()
 
-        self.assertEquals(parser.data, [search_index.ContentSection(
+        self.assertEqual(parser.data, [search_index.ContentSection(
             text=["TEST"],
             id_=None,
             title="Title"
@@ -234,7 +234,7 @@ class SearchIndexTests(unittest.TestCase):
 
         parser.feed("No H1 or H2<span>Title</span>TEST")
 
-        self.assertEquals(parser.data, [])
+        self.assertEqual(parser.data, [])
 
     def test_find_toc_by_id(self):
         """

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -138,7 +138,7 @@ class PageTests(unittest.TestCase):
         cfg = load_config()
         fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
         pg = Page('Foo', fl, cfg)
-        self.assertRegexpMatches(pg.update_date, r'\d{4}-\d{2}-\d{2}')
+        self.assertRegex(pg.update_date, r'\d{4}-\d{2}-\d{2}')
         self.assertEqual(pg.url, 'testing/')
         self.assertEqual(pg.abs_url, None)
         self.assertEqual(pg.canonical_url, None)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,2 @@
 coverage
 flake8
-nose

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ deps=
     py{35,36,37,38,py3}-{unittests,min-req}: -rrequirements/test.txt
 commands=
     {envpython} --version
-    py{35,36,37,38,py3}-{unittests,min-req}: {envbindir}/nosetests --with-coverage --cover-package mkdocs mkdocs
+    py{35,36,37,38,py3}-{unittests,min-req}:  {envbindir}/coverage run --source=mkdocs --omit 'mkdocs/tests/*' -m unittest discover -p '*tests.py' mkdocs
+    py{35,36,37,38,py3}-{unittests,min-req}: {envbindir}/coverage report --show-missing
     py{35,36,37,38,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds
 
 [testenv:flake8]


### PR DESCRIPTION
The nose docs state:

> Nose has been in maintenance mode for the past several years and will
> likely cease without a new person/team to take over maintainership.
> New projects should consider using Nose2, py.test, or just plain
> unittest/unittest2.

As we aren't really using any of nose's features, its easiest to switch
to the standard lib unittest.

**Note** This is currently experimental. I'm checking to see how many tests fail and if there are differences across platforms. Is it more work than its worth?