### PR TITLE
Ensure deploy commit message points at correct sha.

### DIFF
--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -18,9 +18,9 @@ def _is_cwd_git_repo():
     return proc.wait() == 0
 
 
-def _get_current_sha():
+def _get_current_sha(repo_path):
 
-    proc = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'],
+    proc = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], cwd=repo_path,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     stdout, _ = proc.communicate()
@@ -57,7 +57,7 @@ def gh_deploy(config, message=None, force=False):
 
     if message is None:
         message = default_message
-    sha = _get_current_sha()
+    sha = _get_current_sha(os.path.dirname(config.config_file_path))
     message = message.format(version=mkdocs.__version__, sha=sha)
 
     remote_branch = config['remote_branch']

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -31,7 +31,7 @@ def load_config(**cfg):
     if 'docs_dir' not in cfg:
         # Point to an actual dir to avoid a 'does not exist' error on validation.
         cfg['docs_dir'] = os.path.join(path_base, 'docs')
-    conf = config.Config(schema=config.DEFAULT_SCHEMA)
+    conf = config.Config(schema=config.DEFAULT_SCHEMA, config_file_path=cfg['config_file_path'])
     conf.load_dict(cfg)
 
     errors_warnings = conf.validate()

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import unittest
 import mock
 
-from mkdocs.config import load_config
+from mkdocs.tests.base import load_config
 from mkdocs.commands import gh_deploy
 
 
@@ -28,7 +28,7 @@ class TestGitHubDeploy(unittest.TestCase):
 
         mock_popeno().communicate.return_value = (b'6d98394\n', b'')
 
-        self.assertEqual(gh_deploy._get_current_sha(), u'6d98394')
+        self.assertEqual(gh_deploy._get_current_sha('.'), u'6d98394')
 
     @mock.patch('subprocess.Popen')
     def test_get_remote_url_ssh(self, mock_popeno):


### PR DESCRIPTION
If/when deploying to usr/org pages, the deploy script is run from the
Pages repo, not the project repo. Therefore, we need to get the current
sha from the project repo. Related to #1455 and #1376.