### PR TITLE
Hide empty lastmod tags in sitemap.xml

### DIFF
--- a/mkdocs/templates/sitemap.xml
+++ b/mkdocs/templates/sitemap.xml
@@ -5,14 +5,14 @@
         {% for nav_item in nav_item.children %}
     <url>
      <loc>{{ config.site_url }}{{ nav_item.abs_url }}</loc>
-     <lastmod>{{nav_item.update_date}}</lastmod>
+     {% if nav_item.update_date %}<lastmod>{{nav_item.update_date}}</lastmod>{% endif %}
      <changefreq>daily</changefreq>
     </url>
         {% endfor %}
     {% else %}
     <url>
      <loc>{{ config.site_url }}{{ nav_item.abs_url }}</loc>
-     <lastmod>{{nav_item.update_date}}</lastmod>
+     {% if nav_item.update_date %}<lastmod>{{nav_item.update_date}}</lastmod>{% endif %}
      <changefreq>daily</changefreq>
     </url>
     {% endif %}


### PR DESCRIPTION
Google Search Console complains about empty lastmod,
I validate sitemap.xml with empty lastmod, it is invalid as in this screenshot https://prnt.sc/j2w2ws