### PR TITLE
[WIP] extra vars in markdown

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -199,6 +199,7 @@ def build_extra_templates(extra_templates, config, site_navigation=None):
             'template_context', context, template_name=extra_template, config=config
         )
 
+        print(context)
         output_content = template.render(context)
 
         # Run `post_template` plugin events.

--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -7,6 +7,7 @@ This consists of building a set of interlinked page and header objects.
 """
 
 from __future__ import unicode_literals
+from jinja2 import Template
 import datetime
 import logging
 import markdown
@@ -292,6 +293,10 @@ class Page(object):
             extensions=extensions,
             extension_configs=config['mdx_configs'] or {}
         )
+
+        rendered_md = Template(self.markdown)
+        self.markdown = rendered_md.render(extra=config.get('extra'))
+
         self.content = md.convert(self.markdown)
         self.toc = toc.TableOfContents(getattr(md, 'toc', ''))
 


### PR DESCRIPTION
Thanks for the great lib 
have a usecase that requires the "extra" vars to be made available in the markdown. This is a major feature not sure why its not by default?