### PR TITLE
Make test_doc_dir_in_site_dir work with custom build path

### DIFF
--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -239,7 +239,7 @@ class ConfigTests(unittest.TestCase):
             {'docs_dir': '.', 'site_dir': '.'},
             {'docs_dir': 'docs', 'site_dir': ''},
             {'docs_dir': '', 'site_dir': ''},
-            {'docs_dir': j('..', 'mkdocs', 'docs'), 'site_dir': 'docs'},
+            {'docs_dir': 'docs', 'site_dir': 'docs'},
         )
 
         conf = {


### PR DESCRIPTION
The previous version worked only when `../mkdocs` was pointing back to the current directory.

Fixes #1490.