### PR TITLE
Include *.md files inside mkdocs/tests/integration in the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.md
 include LICENSE
-recursive-include mkdocs *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff *.woff2 *.xml *.mustache *mkdocs_theme.yml
+recursive-include mkdocs *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff *.woff2 *.xml *.mustache *mkdocs_theme.yml *.md
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Currently, the tarball contains only a part of the files needed for the tests:
```bash
$ wget -q "https://files.pythonhosted.org/packages/8a/cc/593faba2554b0a950249b0240417319de67f3e2ee5b70755c49b70be043a/mkdocs-0.17.3.tar.gz"
$ tar xzf mkdocs-0.17.3.tar.gz
$ cd mkdocs-0.17.3/
$ ls -l mkdocs/tests/integration
total 8
drwxr-xr-x 4 dmitry dmitry 4096 Mar  7 19:55 complicated_config
drwxr-xr-x 3 dmitry dmitry 4096 Mar  7 19:55 subpages
```

While in the Git checkout there are four directories instead of two:
```bash
$ ls -l mkdocs/tests/integration
total 16
drwxr-xr-x 4 dmitry dmitry 4096 May 20 13:06 complicated_config
drwxr-xr-x 3 dmitry dmitry 4096 May 20 13:06 minimal
drwxr-xr-x 3 dmitry dmitry 4096 May 20 13:06 subpages
drwxr-xr-x 3 dmitry dmitry 4096 May 20 13:06 unicode
```

This merge request makes sure that for the next release the tarball will contain all the needed files.