### PR TITLE
Make the tests pass when git is not installed

### DIFF
--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -67,8 +67,9 @@ class TestGitHubDeploy(unittest.TestCase):
     @mock.patch('mkdocs.commands.gh_deploy._is_cwd_git_repo', return_value=True)
     @mock.patch('mkdocs.commands.gh_deploy._get_current_sha', return_value='shashas')
     @mock.patch('mkdocs.commands.gh_deploy._get_remote_url', return_value=(None, None))
+    @mock.patch('mkdocs.commands.gh_deploy._check_version')
     @mock.patch('mkdocs.commands.gh_deploy.ghp_import.ghp_import', return_value=(True, ''))
-    def test_deploy(self, mock_import, get_remote, get_sha, is_repo):
+    def test_deploy(self, mock_import, check_version, get_remote, get_sha, is_repo):
 
         config = load_config(
             remote_branch='test',
@@ -78,9 +79,10 @@ class TestGitHubDeploy(unittest.TestCase):
     @mock.patch('mkdocs.commands.gh_deploy._is_cwd_git_repo', return_value=True)
     @mock.patch('mkdocs.commands.gh_deploy._get_current_sha', return_value='shashas')
     @mock.patch('mkdocs.commands.gh_deploy._get_remote_url', return_value=(None, None))
+    @mock.patch('mkdocs.commands.gh_deploy._check_version')
     @mock.patch('mkdocs.commands.gh_deploy.ghp_import.ghp_import', return_value=(True, ''))
     @mock.patch('os.path.isfile', return_value=False)
-    def test_deploy_no_cname(self, mock_isfile, mock_import, get_remote,
+    def test_deploy_no_cname(self, mock_isfile, mock_import, check_version, get_remote,
                              get_sha, is_repo):
 
         config = load_config(
@@ -92,8 +94,9 @@ class TestGitHubDeploy(unittest.TestCase):
     @mock.patch('mkdocs.commands.gh_deploy._get_current_sha', return_value='shashas')
     @mock.patch('mkdocs.commands.gh_deploy._get_remote_url', return_value=(
         u'git@', u'mkdocs/mkdocs.git'))
+    @mock.patch('mkdocs.commands.gh_deploy._check_version')
     @mock.patch('mkdocs.commands.gh_deploy.ghp_import.ghp_import', return_value=(True, ''))
-    def test_deploy_hostname(self, mock_import, get_remote, get_sha, is_repo):
+    def test_deploy_hostname(self, mock_import, check_version, get_remote, get_sha, is_repo):
 
         config = load_config(
             remote_branch='test',
@@ -126,9 +129,12 @@ class TestGitHubDeploy(unittest.TestCase):
         gh_deploy.gh_deploy(config, ignore_version=True)
         check_version.assert_not_called()
 
+    @mock.patch('mkdocs.commands.gh_deploy._is_cwd_git_repo', return_value=True)
+    @mock.patch('mkdocs.commands.gh_deploy._get_current_sha', return_value='shashas')
+    @mock.patch('mkdocs.commands.gh_deploy._check_version')
     @mock.patch('mkdocs.utils.ghp_import.ghp_import')
     @mock.patch('mkdocs.commands.gh_deploy.log')
-    def test_deploy_error(self, mock_log, mock_import):
+    def test_deploy_error(self, mock_log, mock_import, check_version, get_sha, is_repo):
         error_string = 'TestError123'
         mock_import.return_value = (False, error_string)
 


### PR DESCRIPTION
The tests are supposed to pass when Git is not installed.

However recently two commits broke it:
- in ef93dc6b a new test was added which did not have the necessary mocks;
- in e5c2459f the `_check_version` function was added, and the tests did not have mocks for it.

With this pull requests, the tests pass again without Git.