### PR TITLE
Use Unicode for server temp dir.

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -94,7 +94,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
     # Create a temporary build directory, and set some options to serve it
     # PY2 returns a byte string by default. The Unicode prefix ensures a Unicode
     # string is returned. And it makes MkDocs temp dirs easier to identify.
-    tempdir = tempfile.mkdtemp(prefix='mkdocs_')
+    site_dir = tempfile.mkdtemp(prefix='mkdocs_')
 
     def builder():
         log.info("Building documentation...")
@@ -103,10 +103,10 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             dev_addr=dev_addr,
             strict=strict,
             theme=theme,
-            theme_dir=theme_dir
+            theme_dir=theme_dir,
+            site_dir=site_dir
         )
         # Override a few config settings after validation
-        config['site_dir'] = tempdir
         config['site_url'] = 'http://{0}/'.format(config['dev_addr'])
 
         live_server = livereload in ['dirty', 'livereload']
@@ -121,8 +121,8 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
         host, port = config['dev_addr']
 
         if livereload in ['livereload', 'dirty']:
-            _livereload(host, port, config, builder, tempdir)
+            _livereload(host, port, config, builder, site_dir)
         else:
-            _static_server(host, port, tempdir)
+            _static_server(host, port, site_dir)
     finally:
-        shutil.rmtree(tempdir)
+        shutil.rmtree(site_dir)

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -92,7 +92,9 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
     """
 
     # Create a temporary build directory, and set some options to serve it
-    tempdir = tempfile.mkdtemp()
+    # PY2 returns a byte string by default. The Unicode prefix ensures a Unicode
+    # string is returned. And it makes MkDocs temp dirs easier to identify.
+    tempdir = tempfile.mkdtemp(prefix='mkdocs_')
 
     def builder():
         log.info("Building documentation...")


### PR DESCRIPTION
The serve command overwrites the the site_dir and can cause a crash when
clean_directory tries to remove files with Unicode chars in their
filenames if the paths are byte strings. As os.path.join and friends
will return a byte string (in PY2) if any part is passed in is a byte
string, we must ensure all parts are Unicode strings. By passing a
Unicode string to prefix, tempfile.mkdtemp returns a Unicode string
rather than the default byte string in PY2. Fixes #1516.

This needs tests. However, the entire `mkdocs.commands.serve` module is untested, so this will have to wait until I have time to create tests for the entire module. I suspect lots of mock objects will be involved.