### PR TITLE
Fix search result url in default theme

### DIFF
--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -10,7 +10,7 @@ function getSearchTermFromLocation() {
 }
 
 function formatResult (location, title, summary) {
-  return '<article><h3><a href="' + base_url + location + '">'+ title + '</a></h3><p>' + summary +'</p></article>';
+  return '<article><h3><a href="' + base_url + '/' + location + '">'+ title + '</a></h3><p>' + summary +'</p></article>';
 }
 
 function displayResults (results) {


### PR DESCRIPTION
After the pages refractor #1504 (good work btw) the resulting urls are malformed (relatives) when using the search feature in the default theme.

It can be reproduced with a simple search. Given this directory structure:
```
docs/
├── foo.md
└── index.md
```
Searching for `foo` will result in `http://127.0.0.1:8000/.foo/` instead of `http://127.0.0.1:8000/foo/`