### PR TITLE
Add a url filter to templates.

### DIFF
--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -111,4 +111,5 @@ class Theme(object):
         loader = jinja2.FileSystemLoader(self.dirs)
         env = jinja2.Environment(loader=loader)
         env.filters['tojson'] = filters.tojson
+        env.filters['url'] = filters.url_filter
         return env

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -8,8 +8,8 @@
         {% if page and page.is_homepage %}<meta name="description" content="{{ config['site_description'] }}">{% endif %}
         {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
         {% if page and page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
-        {% if config.site_favicon %}<link rel="shortcut icon" href="{{ base_url }}/{{ config.site_favicon }}">
-        {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
+        {% if config.site_favicon %}<link rel="shortcut icon" href="{{ config.site_favicon|url }}">
+        {% else %}<link rel="shortcut icon" href="{{ 'img/favicon.ico'|url }}">{% endif %}
       {%- endblock %}
 
       {%- block htmltitle %}
@@ -17,12 +17,12 @@
       {%- endblock %}
 
       {%- block styles %}
-        <link href="{{ base_url }}/css/bootstrap-custom.min.css" rel="stylesheet">
-        <link href="{{ base_url }}/css/font-awesome.min.css" rel="stylesheet">
-        <link href="{{ base_url }}/css/base.css" rel="stylesheet">
-        <link rel="stylesheet" href="{{ base_url }}/css/highlight.css">
-        {%- for path in extra_css %}
-        <link href="{{ path }}" rel="stylesheet">
+        <link href="{{ 'css/bootstrap-custom.min.css'|url }}" rel="stylesheet">
+        <link href="{{ 'css/font-awesome.min.css'|url }}" rel="stylesheet">
+        <link href="{{ 'css/base.css'|url }}" rel="stylesheet">
+        <link rel="stylesheet" href="{{ 'css/highlight.css'|url }}">
+        {%- for path in config['extra_css'] %}
+        <link href="{{ path|url }}" rel="stylesheet">
         {%- endfor %}
       {%- endblock %}
 
@@ -33,9 +33,9 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
         <![endif]-->
 
-        <script src="{{ base_url }}/js/jquery-1.10.2.min.js" defer></script>
-        <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js" defer></script>
-        <script src="{{ base_url }}/js/highlight.pack.js" defer></script>
+        <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
+        <script src="{{ 'js/bootstrap-3.0.3.min.js'|url }}" defer></script>
+        <script src="{{ 'js/highlight.pack.js'|url }}" defer></script>
       {%- endblock %}
 
       {%- block analytics %}
@@ -78,9 +78,9 @@
 
       {%- block scripts %}
         <script>var base_url = '{{ base_url }}';</script>
-        <script src="{{ base_url }}/js/base.js" defer></script>
-        {%- for path in extra_javascript %}
-        <script src="{{ path }}" defer></script>
+        <script src="{{ 'js/base.js'|url }}" defer></script>
+        {%- for path in config['extra_javascript'] %}
+        <script src="{{ path|url }}" defer></script>
         {%- endfor %}
       {%- endblock %}
 

--- a/mkdocs/themes/mkdocs/nav-sub.html
+++ b/mkdocs/themes/mkdocs/nav-sub.html
@@ -1,6 +1,6 @@
 {%- if not nav_item.children %}
 <li {% if nav_item.active %}class="active"{% endif %}>
-    <a href="{% if not nav_item.is_link %}{{ base_url }}/{% endif %}{{ nav_item.url }}">{{ nav_item.title }}</a>
+    <a href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
 </li>
 {%- else %}
   <li class="dropdown-submenu">

--- a/mkdocs/themes/mkdocs/nav.html
+++ b/mkdocs/themes/mkdocs/nav.html
@@ -14,7 +14,7 @@
             {%- endif %}
 
           {%- block site_name %}
-            <a class="navbar-brand" href="{{ base_url }}/{{ nav.homepage.url }}">{{ config.site_name }}</a>
+            <a class="navbar-brand" href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
           {%- endblock %}
         </div>
 
@@ -36,7 +36,7 @@
                     </li>
                 {%- else %}
                     <li {% if nav_item.active %}class="active"{% endif %}>
-                        <a href="{% if not nav_item.is_link %}{{ base_url }}/{% endif %}{{ nav_item.url }}">{{ nav_item.title }}</a>
+                        <a href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
                     </li>
                 {%- endif %}
                 {%- endfor %}
@@ -58,12 +58,12 @@
               {%- block next_prev %}
                 {%- if page and (page.next_page or page.previous_page) %}
                     <li {% if not page.previous_page %}class="disabled"{% endif %}>
-                        <a rel="next" {% if page.previous_page %}href="{{ base_url }}/{{ page.previous_page.url }}"{% endif %}>
+                        <a rel="next" {% if page.previous_page %}href="{{ page.previous_page.url|url }}"{% endif %}>
                             <i class="fa fa-arrow-left"></i> Previous
                         </a>
                     </li>
                     <li {% if not page.next_page %}class="disabled"{% endif %}>
-                        <a rel="prev" {% if page.next_page %}href="{{ base_url }}/{{ page.next_page.url }}"{% endif %}>
+                        <a rel="prev" {% if page.next_page %}href="{{ page.next_page.url|url }}"{% endif %}>
                             Next <i class="fa fa-arrow-right"></i>
                         </a>
                     </li>

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -8,8 +8,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% if page and page.is_homepage %}<meta name="description" content="{{ config.site_description }}">{% endif %}
   {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
-  {% if config.site_favicon %}<link rel="shortcut icon" href="{{ base_url }}/{{ config.site_favicon }}">
-  {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
+  {% if config.site_favicon %}<link rel="shortcut icon" href="{{ config.site_favicon|url }}">
+  {% else %}<link rel="shortcut icon" href="{{ 'img/favicon.ico'|url }}">{% endif %}
   {%- endblock %}
 
   {%- block htmltitle %}
@@ -19,11 +19,11 @@
   {%- block styles %}
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
 
-  <link rel="stylesheet" href="{{ base_url }}/css/theme.css" type="text/css" />
-  <link rel="stylesheet" href="{{ base_url }}/css/theme_extra.css" type="text/css" />
-  <link rel="stylesheet" href="{{ base_url }}/css/highlight.css">
-  {%- for path in extra_css %}
-  <link href="{{ path }}" rel="stylesheet">
+  <link rel="stylesheet" href="{{ 'css/theme.css'|url }}" type="text/css" />
+  <link rel="stylesheet" href="{{ 'css/theme_extra.css'|url }}" type="text/css" />
+  <link rel="stylesheet" href="{{ 'css/highlight.css'|url }}">
+  {%- for path in config['extra_css'] %}
+  <link href="{{ path|url }}" rel="stylesheet">
   {%- endfor %}
   {%- endblock %}
 
@@ -36,9 +36,9 @@
     var mkdocs_page_url = {{ page.abs_url|tojson|safe }};
   </script>
   {% endif %}
-  <script src="{{ base_url }}/js/jquery-2.1.1.min.js" defer></script>
-  <script src="{{ base_url }}/js/modernizr-2.8.3.min.js" defer></script>
-  <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js" defer></script>
+  <script src="{{ 'js/jquery-2.1.1.min.js'|url }}" defer></script>
+  <script src="{{ 'js/modernizr-2.8.3.min.js'|url }}" defer></script>
+  <script type="text/javascript" src="{{ 'js/highlight.pack.js'|url }}" defer></script>
   {%- endblock %}
 
   {%- block extrahead %} {% endblock %}
@@ -66,7 +66,7 @@
     <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
       <div class="wy-side-nav-search">
     {%- block site_name %}
-        <a href="{{ base_url }}/{{ nav.homepage.url }}" class="icon icon-home"> {{ config.site_name }}</a>
+        <a href="{{ nav.homepage.url|url }}" class="icon icon-home"> {{ config.site_name }}</a>
 	  {%- endblock %}
 	  {%- block search_button %}
         {% if 'search' in config['plugins'] %}{% include "searchbox.html" %}{% endif %}
@@ -93,7 +93,7 @@
       {# MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
       <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
         <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-        <a href="{{ base_url }}/{{ nav.homepage.url }}">{{ config.site_name }}</a>
+        <a href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
       </nav>
 
       {# PAGE CONTENT #}
@@ -121,9 +121,9 @@
 
   {%- block scripts %}
     <script>var base_url = '{{ base_url }}';</script>
-    <script src="{{ base_url }}/js/theme.js" defer></script>
-    {%- for path in extra_javascript %}
-      <script src="{{ path }}" defer></script>
+    <script src="{{ 'js/theme.js'|url }}" defer></script>
+    {%- for path in config['extra_javascript'] %}
+      <script src="{{ path|url }}" defer></script>
     {%- endfor %}
   {%- endblock %}
 

--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -1,6 +1,6 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">
-    <li><a href="{{ base_url }}/{{ nav.homepage.url }}">Docs</a> &raquo;</li>
+    <li><a href="{{ nav.homepage.url|url }}">Docs</a> &raquo;</li>
     {% if page %}
       {% for doc in page.ancestors %}
         {% if doc.link %}

--- a/mkdocs/themes/readthedocs/footer.html
+++ b/mkdocs/themes/readthedocs/footer.html
@@ -3,10 +3,10 @@
   {% if page and page.next_page or page.previous_page %}
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       {% if page.next_page %}
-        <a href="{{ base_url }}/{{ page.next_page.url }}" class="btn btn-neutral float-right" title="{{ page.next_page.title }}">Next <span class="icon icon-circle-arrow-right"></span></a>
+        <a href="{{ page.next_page.url|url }}" class="btn btn-neutral float-right" title="{{ page.next_page.title }}">Next <span class="icon icon-circle-arrow-right"></span></a>
       {% endif %}
       {% if page.previous_page %}
-        <a href="{{ base_url }}/{{ page.previous_page.url }}" class="btn btn-neutral" title="{{ page.previous_page.title }}"><span class="icon icon-circle-arrow-left"></span> Previous</a>
+        <a href="{{ page.previous_page.url|url }}" class="btn btn-neutral" title="{{ page.previous_page.title }}"><span class="icon icon-circle-arrow-left"></span> Previous</a>
       {% endif %}
     </div>
   {% endif %}

--- a/mkdocs/themes/readthedocs/nav.html
+++ b/mkdocs/themes/readthedocs/nav.html
@@ -1,5 +1,5 @@
 {%- if nav_item.url %}
-    <a class="{% if nav_item.active%}current{%endif%}" href="{% if not nav_item.is_link %}{{ base_url }}/{% endif %}{{ nav_item.url }}">{{ nav_item.title }}</a>
+    <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
 {%- else %}
     <span class="caption-text">{{ nav_item.title }}</span>
 {%- endif %}

--- a/mkdocs/themes/readthedocs/versions.html
+++ b/mkdocs/themes/readthedocs/versions.html
@@ -8,10 +8,10 @@
           <a href="{{ config.repo_url }}" class="icon icon-gitlab" style="float: left; color: #fcfcfc"> GitLab</a>
       {% endif %}
       {% if page.previous_page %}
-        <span><a href="{{ base_url }}/{{ page.previous_page.url }}" style="color: #fcfcfc;">&laquo; Previous</a></span>
+        <span><a href="{{ page.previous_page.url|url }}" style="color: #fcfcfc;">&laquo; Previous</a></span>
       {% endif %}
       {% if page.next_page %}
-        <span style="margin-left: 15px"><a href="{{ base_url }}/{{ page.next_page.url }}" style="color: #fcfcfc">Next &raquo;</a></span>
+        <span style="margin-left: 15px"><a href="{{ page.next_page.url|url }}" style="color: #fcfcfc">Next &raquo;</a></span>
       {% endif %}
     </span>
 </div>

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -297,28 +297,31 @@ def get_relative_url(url, other):
     relurl = posixpath.relpath(url, other)
     return relurl + '/' if url.endswith('/') else relurl
 
+def normalize_url(path, page=None, base=''):
+    """ Return a URL relative to the given page or using the base. """
+    path = path_to_url(path or '.')
+    # Allow links to be fully qualified URL's
+    parsed = urlparse(path)
+    if parsed.scheme or parsed.netloc or path.startswith('/'):
+        return path
+
+    # We must be looking at a local path.
+    if page is not None:
+        return get_relative_url(path, page.url)
+    else:
+        return posixpath.join(base, path)
+
 
 def create_media_urls(path_list, page=None, base=''):
     """
     Return a list of URLs relative to the given page or using the base.
     """
-    final_urls = []
+    urls = []
 
     for path in path_list:
-        path = path_to_url(path)
-        # Allow links to be fully qualified URL's
-        parsed = urlparse(path)
-        if parsed.netloc:
-            final_urls.append(path)
-            continue
-        # We must be looking at a local path.
-        if page is not None:
-            url = get_relative_url(path, page.url)
-        else:
-            url = posixpath.join(base, path)
-        final_urls.append(url)
+        urls.append(normalize_url(path, page, base))
 
-    return final_urls
+    return urls
 
 
 def create_relative_media_url(nav, url):

--- a/mkdocs/utils/filters.py
+++ b/mkdocs/utils/filters.py
@@ -1,6 +1,13 @@
 import json
 import jinja2
 
+from mkdocs.utils import normalize_url
+
 
 def tojson(obj, **kwargs):
     return jinja2.Markup(json.dumps(obj, **kwargs))
+
+@jinja2.contextfilter
+def url_filter(context, value):
+    """ A Template filter to normalize URLs. """
+    return normalize_url(value, page=context['page'], base=context['base_url'])


### PR DESCRIPTION
Currently all local URLs must be prepended with `base_url` while external 
links must not. However, we can have both types of links in the same 
collection. As prepreprocessing of extra_css and extra_javascript 
settings is deprecated, we need a way to indicate the URL should be 
prepended, but only if it needs to be. The same applies to external 
links included in the site navigation. 

Therefore, a new temaplte filter is provided which any URL can be passed 
to. If the URL is absolute, it is returned unaltered. If it is relative 
and the template context includes a `page` object, then a URL is 
returned reltive to the page object. Otherwise, the URL is returned with 
`base_url` prepended. This also results in cleaner output as paths are 
normailized (redundant `.` are removed). Of course, the `base_url` template 
variable remains (it is not being deprecated -- in fact the new filter 
relies on its existance) and template authors may continue to use it if 
they desire.

Docs still need updated and we may need a few tests.