### PR TITLE
Exclude code block style from Markdownlint

### DIFF
--- a/mdl_ruleset.rb
+++ b/mdl_ruleset.rb
@@ -5,3 +5,6 @@ rule 'MD013', :line_length => 80, :code_blocks => false, :tables => false
 
 # Set Ordered list item prefix to "ordered" (use 1. 2. 3. not 1. 1. 1.)
 rule 'MD029', :style => "ordered"
+
+# Exclude code block style
+exclude_rule 'MD046'


### PR DESCRIPTION
The Python-Markdown parser includes support for fenced code blocks, but only at the root level of the document. Therefore, a code block nested in a list item must be an indented block. At the same time, MkDocs' code highlighting relies on the language identifier in fenced code blocks to avoid bad guesses. Given the above, we want to allow mixing both styles of code blocks and the way to allow that is to disable Markdown Lint [rule MD046](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md046---code-block-style).

This new rule was introduced in Markdownlint version [0.5.0](https://github.com/markdownlint/markdownlint/blob/master/CHANGELOG.md#v050) and is currently causing the [tests to fail](https://travis-ci.org/mkdocs/mkdocs/jobs/399711017). This was first discovered in #1526.