### PR TITLE
Up version to 1.0.dev

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,9 +21,9 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
-## Development Version
+## Version 1.0 (2018-??-??)
 
-### Major Additions to Development Version
+### Major Additions to Version 1.0
 
 #### Internal Refactor of Pages, Files, and Navigation
 
@@ -226,6 +226,10 @@ authors should review how [search and themes] interact.
 * Remove PyPI Deployment Docs (#1360).
 * Update links to Python-Markdown library (#1360).
 * Document how to generate manpages for MkDocs commands (#686).
+
+## Version 0.17.5 (2018-07-06)
+
+* Bugfix: Fix Python 3.7 and PEP 479 incompatibility (#1518).
 
 ## Version 0.17.4
 

--- a/mkdocs/__init__.py
+++ b/mkdocs/__init__.py
@@ -4,4 +4,4 @@
 from __future__ import unicode_literals
 
 # For acceptable version formats, see https://www.python.org/dev/peps/pep-0440/
-__version__ = '0.17.2'
+__version__ = '1.0.dev0'


### PR DESCRIPTION
I should have done this a while ago. At least back when I broke out the 0.17 branch to backport some bug fixes (0.17.3).