### PR TITLE
Fix mkdocs theme TOC.

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -27,6 +27,7 @@ ul.nav .main {
 
 .col-md-3 {
     padding-left: 0;
+    z-index: 1;
 }
 
 .col-md-9 {


### PR DESCRIPTION
The sidebar was under the left margin of the main content and not 
clickable. This moves the sidebar to the top so it is accessable. Not 
sure when this got broken. Maybe #1387 or #1389 or #1395.