### PR TITLE
Add support for YAML meta data.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -180,6 +180,35 @@ mkdocs build --config-file /path/to/my/config/file.yml
 As previously, if no file is specified, MkDocs looks for a file named
 `mkdocs.yml` in the current working directory.
 
+#### Added support for YAML Meta-Data (#1542)
+
+Previously, MkDocs only supported MultiMarkdown style meta-data, which does not
+recognize different data types and is rather limited. MkDocs now also supports
+YAML style meta-data in Markdown documents. MkDocs relies on the the presence or
+absence of the deliminators (`---` or `...`) to determine whether YAML style
+meta-data or MultiMarkdown style meta-data is being used.
+
+Previously MkDocs would recognize MultiMarkdown style meta-data between the
+deliminators. Now, if the deliminators are detected, but the content between the
+deliminators is not valid YAML meta-data, MkDocs does not attempt to parse the
+content as MultiMarkdown style meta-data. Therefore, MultiMarkdowns style
+meta-data must not include the deliminators. See the [MultiMarkdown style
+meta-data documentation] for details.
+
+Prior to version 0.17, MkDocs returned all meta-data values as a list of strings
+(even a single line would return a list of one string). In version 0.17, that
+behavior was changed to return each value as a single string (multiple lines
+were joined), which some users found limiting (see #1471). That behavior
+continues for MultiMarkdown style meta-data in the current version. However,
+YAML style meta-data supports the full range of "safe" YAML data types.
+Therefore, it is recommended that any complex meta-data make use of the YAML
+style (see the [YAML style meta-data documentation] for details). In fact, a
+future version of MkDocs may deprecate support for MultiMarkdown style
+meta-data.
+
+[MultiMarkdown style meta-data documentation]: ../user-guide/writing-your-docs.md#multimarkdown-style-meta-data
+[YAML style meta-data documentation]: ../user-guide/writing-your-docs.md#yaml-style-meta-data
+
 #### Refactor Search Plugin
 
 The search plugin has been completely refactored to include support for the

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -326,43 +326,13 @@ appropriately for the rendered document.
 
 ### Meta-Data
 
-MkDocs includes support for [MultiMarkdown] style meta-data (often called
-front-matter). Meta-data consists of a series of keywords and values defined at
-the beginning of a Markdown document like this:
-
-```no-highlight
-Title:   My Document
-Summary: A brief description of my document.
-Authors: Waylan Limberg
-         Tom Christie
-Date:    January 23, 2018
-blank-value:
-some_url: http://example.com
-
-This is the first paragraph of the document.
-```
-
-The keywords are case-insensitive and may consist of letters, numbers,
-underscores and dashes and must end with a colon. The values consist of anything
-following the colon on the line and may even be blank.
-
-If a line is indented by 4 or more spaces, that line is assumed to be an
-additional line of the value for the previous keyword. A keyword may have as
-many lines as desired.
-
-The first blank line ends all meta-data for the document. Therefore, the first
-line of a document must not be blank.
-
-Alternatively, you may use YAML style deliminators to mark the start and/or end
-of your meta-data. When doing so, the first line of your document must be `---`.
-The meta-data ends at the first blank line or the first line containing an end
-deliminator (either `---` or `...`), whichever comes first. Even though YAML
-deliminators are supported, meta-data is not parsed as YAML.
-
-All meta-data is stripped from the document prior to being processing by
-Python-Markdown. The keys and values are passed by MkDocs to the page template.
-Therefore, if a theme includes support, the values of any keys can be displayed
-on the page. See the documentation for your theme for information about which
+MkDocs includes support for both YAML and MultiMarkdown style meta-data (often
+called front-matter). Meta-data consists of a series of keywords and values
+defined at the beginning of a Markdown document, which are stripped from the
+document prior to it being processing by Python-Markdown. The key/value pairs
+are passed by MkDocs to the page template. Therefore, if a theme includes
+support, the values of any keys can be displayed on the page or used to control
+the page rendering. See your theme's documentation for information about which
 keys may be supported, if any.
 
 In addition to displaying information in a template, MkDocs includes support for
@@ -393,6 +363,77 @@ specific page. The following keys are supported:
     Upon finding a title for a page, MkDoc does not continue checking any
     additional sources in the above list.
 
+#### YAML Style Meta-Data
+
+YAML style meta-data consists of [YAML] key/value pairs wrapped in YAML style
+deliminators to mark the start and/or end of the meta-data. The first line of
+a document must be `---`. The meta-data ends at the first line containing an
+end deliminator (either `---` or `...`). The content between the deliminators is
+parsed as [YAML].
+
+```no-highlight
+---
+title: My Document
+summary: A brief description of my document.
+authors:
+    - Waylan Limberg
+    - Tom Christie
+date: 2018-07-10
+some_url: http://example.com
+---
+This is the first paragraph of the document.
+```
+
+YAML is able to detect data types. Therefore, in the above example, the values
+of `title`, `summary` and `some_url` are strings, the value of `authors` is a
+list of strings and the value of `date` is a `datetime.date` object. Note that
+the YAML keys are case sensitive and MkDocs expects keys to be all lowercase.
+The top level of the YAML must be a collection of key/value pairs, which results
+in a Python `dict` being returned. If any other type is returned or the YAML
+parser encounters an error, then MkDocs does not recognize the section as
+meta-data, the page's `meta` attribute will be empty, and the section is not
+removed from the document.
+
+#### MultiMarkdown Style Meta-Data
+
+MultiMarkdown style meta-data uses a format first introduced by the
+[MultiMarkdown] project. The data consists of a series of keywords and values
+defined at the beginning of a Markdown document, like this:
+
+```no-highlight
+Title:   My Document
+Summary: A brief description of my document.
+Authors: Waylan Limberg
+         Tom Christie
+Date:    January 23, 2018
+blank-value:
+some_url: http://example.com
+
+This is the first paragraph of the document.
+```
+
+The keywords are case-insensitive and may consist of letters, numbers,
+underscores and dashes and must end with a colon. The values consist of anything
+following the colon on the line and may even be blank.
+
+If a line is indented by 4 or more spaces, that line is assumed to be an
+additional line of the value for the previous keyword. A keyword may have as
+many lines as desired. All lines are joined into a single string.
+
+The first blank line ends all meta-data for the document. Therefore, the first
+line of a document must not be blank.
+
+!!! note
+
+    MkDocs does not support YAML style deliminators (`---` or `...`) for
+    MultiMarkdown style meta-data. In fact, MkDocs relies on the the presence or
+    absence of the deliminators to determine whether YAML style meta-data or
+    MultiMarkdown style meta-data is being used. If the deliminators are
+    detected, but the content between the deliminators is not valid YAML
+    meta-data, MkDocs does not attempt to parse the content as MultiMarkdown
+    style meta-data.
+
+[YAML]: http://yaml.org
 [MultiMarkdown]: http://fletcherpenney.net/MultiMarkdown_Syntax_Guide#metadata
 [nav]: configuration.md#nav
 

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -19,12 +19,6 @@ from mkdocs.exceptions import MarkdownNotFound
 log = logging.getLogger(__name__)
 
 
-@meta.transformer()
-def default(value):
-    """ By default, return all meta values as strings. """
-    return ' '.join(value)
-
-
 class Page(object):
     def __init__(self, title, file, config):
         file.page = self

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -35,13 +35,17 @@ Extracts, parses and transforms MultiMarkdown style data from documents.
 
 
 import re
-
+import yaml
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
 
 #####################################################################
 # Data Parser                                                       #
 #####################################################################
 
-YAML_RE = re.compile(r'^-{3}[ \t]*\n(.*?\n)(?:\.{3}|-{3})[ \t]*\n', re.UNICODE|re.DOTALL)
+YAML_RE = re.compile(r'^-{3}[ \t]*\n(.*?\n)(?:\.{3}|-{3})[ \t]*\n', re.UNICODE | re.DOTALL)
 META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
 META_MORE_RE = re.compile(r'^([ ]{4}|\t)(\s*)(?P<value>.*)')
 
@@ -63,7 +67,7 @@ def get_data(doc):
                 doc = doc[m.end():].lstrip('\n')
             else:
                 data = {}
-        except:
+        except Exception:
             pass
         return doc, data
 

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -38,139 +38,58 @@ import re
 
 
 #####################################################################
-# Transformer Collection                                            #
-#####################################################################
-
-class TransformerCollection(object):
-    """
-    A collecton of transformers.
-
-    A transformer is a callable that accepts a single argument (the value to be transformed)
-    and returns a transformed value.
-    """
-
-    def __init__(self, items=None, default=None):
-        """
-        Create a transformer collection.
-
-        `items`: A dictionary which points to a transformer for each key (optional).
-
-        `default`: The default transformer (optional). If no default is provided,
-        then the values of unknown keys are returned unaltered.
-        """
-
-        self._registery = items or {}
-        self.default = default or (lambda v: v)
-
-    def register(self, key=None):
-        """
-        Decorator which registers a transformer for the given key.
-
-        If no key is provided, a "default" transformer is registered.
-        """
-
-        def wrap(fn):
-            if key:
-                self._registery[key] = fn
-            else:
-                self.default = fn
-            return fn
-        return wrap
-
-    def transform(self, key, value):
-        """
-        Calls the transformer for the given key and returns the transformed value.
-        """
-
-        if key in self._registery:
-            return self._registery[key](value)
-        return self.default(value)
-
-    def transform_dict(self, data):
-        """
-        Calls the transformer for each item in a dictionary and returns a new dictionary.
-        """
-
-        newdata = {}
-        for k, v in data.items():
-            newdata[k] = self.transform(k, v)
-        return newdata
-
-
-# The global default transformer collection.
-tc = TransformerCollection()
-
-
-def transformer(key=None):
-    """
-    Decorator which registers a transformer for the given key.
-
-    If no key is provided, a "default" transformer is registered.
-    """
-
-    def wrap(fn):
-        tc.register(key)(fn)
-        return fn
-    return wrap
-
-
-#####################################################################
 # Data Parser                                                       #
 #####################################################################
 
-
-BEGIN_RE = re.compile(r'^-{3}(\s.*)?')
+YAML_RE = re.compile(r'^-{3}[ \t]*\n(.*?\n)(?:\.{3}|-{3})[ \t]*\n', re.UNICODE|re.DOTALL)
 META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
 META_MORE_RE = re.compile(r'^([ ]{4}|\t)(\s*)(?P<value>.*)')
-END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
 
 
-def get_raw_data(doc):
+def get_data(doc):
     """
-    Extract raw meta-data from a text document.
+    Extract meta-data from a text document.
 
     Returns a tuple of document and a data dict.
     """
+    data = {}
 
+    # First try YAML
+    m = YAML_RE.match(doc)
+    if m:
+        try:
+            data = yaml.load(m.group(1), SafeLoader)
+            if isinstance(data, dict):
+                doc = doc[m.end():].lstrip('\n')
+            else:
+                data = {}
+        except:
+            pass
+        return doc, data
+
+    # No YAML deliminators. Try MultiMarkdown style
     lines = doc.replace('\r\n', '\n').replace('\r', '\n').split('\n')
 
-    if lines and BEGIN_RE.match(lines[0]):
-        lines.pop(0)
-
-    data = {}
     key = None
     while lines:
         line = lines.pop(0)
 
-        if line.strip() == '' or END_RE.match(line):
-            break  # blank line or end deliminator - done
+        if line.strip() == '':
+            break  # blank line - done
         m1 = META_RE.match(line)
         if m1:
             key = m1.group('key').lower().strip()
             value = m1.group('value').strip()
-            try:
-                data[key].append(value)
-            except KeyError:
-                data[key] = [value]
+            if key in data:
+                data[key] += '\n{}'.format(value)
+            else:
+                data[key] = value
         else:
             m2 = META_MORE_RE.match(line)
             if m2 and key:
                 # Add another line to existing key
-                data[key].append(m2.group('value').strip())
+                data[key] += '\n{}'.format(m2.group('value').strip())
             else:
                 lines.insert(0, line)
                 break  # no meta data - done
     return '\n'.join(lines).lstrip('\n'), data
-
-
-def get_data(doc, transformers=tc):
-    """
-    Extract meta-data from a text document.
-
-    `transformers`: A TransformerCollection used to transform data values.
-
-    Returns a tuple of document and a (transformed) data dict.
-    """
-
-    doc, rawdata = get_raw_data(doc)
-    return doc, transformers.transform_dict(rawdata)

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -38,7 +38,7 @@ import re
 import yaml
 try:
     from yaml import CSafeLoader as SafeLoader
-except ImportError:
+except ImportError:  # pragma: no cover
     from yaml import SafeLoader
 
 #####################################################################
@@ -85,14 +85,14 @@ def get_data(doc):
             key = m1.group('key').lower().strip()
             value = m1.group('value').strip()
             if key in data:
-                data[key] += '\n{}'.format(value)
+                data[key] += ' {}'.format(value)
             else:
                 data[key] = value
         else:
             m2 = META_MORE_RE.match(line)
             if m2 and key:
                 # Add another line to existing key
-                data[key] += '\n{}'.format(m2.group('value').strip())
+                data[key] += ' {}'.format(m2.group('value').strip())
             else:
                 lines.insert(0, line)
                 break  # no meta data - done


### PR DESCRIPTION
Still needs tests and docs.

If the frontmatter is surrounded by YAML deliminators, then it is parsed 
as YAML. Otherwise it is parsed as Multimarkdown meta-data and returned 
as a string only.

This should address #1471.