### PR TITLE
1.0 deprecations

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -229,8 +229,9 @@ authors should review how [search and themes] interact.
 [search config]: ../user-guide/configuration.md#search
 [search and themes]: ../user-guide/custom-themes.md#search_and_themes
 
-### Other Changes and Additions to Development Version
+### Other Changes and Additions to Version 1.0
 
+* Empty `extra_css` and `extra_javascript` settings no longer raise a warning.
 * Add highlight.js configuration settings to built-in themes (#1284).
 * Close search modal when result is selected (#1527).
 * Add a level attribute to AnchorLinks (#1272).
@@ -404,7 +405,7 @@ and user created and third-party templates should be updated as outlined below:
 In previous versions of MkDocs, if the `extra_css` or `extra_javascript` config
 settings were empty, MkDocs would scan the `docs_dir` and auto-populate each
 setting with all of the CSS and JavaScript files found. On version 0.16 this
-behavior was deprecated and a warning was issued. In 1.0 any unlisted CSS and
+behavior was deprecated and a warning was issued. In 0.17 any unlisted CSS and
 JavaScript files will not be included in the HTML templates, however, a warning
 will be issued. In other words, they will still be copied to the `site-dir`, but
 they will not have any effect on the theme if they are not explicitly listed.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -229,6 +229,13 @@ authors should review how [search and themes] interact.
 [search config]: ../user-guide/configuration.md#search
 [search and themes]: ../user-guide/custom-themes.md#search_and_themes
 
+#### `theme_dir` Configuration Option fully Deprecated.
+
+As of version 0.17, the [custom_dir] option replaced the deprecated `theme_dir`
+option. If users had set the `theme_dir` option, MkDocs version 0.17 copied the
+value to the `theme.custom_dir` option and a warning was issued. As of version
+1.0, the value is no longer copied and an error is raised.
+
 ### Other Changes and Additions to Version 1.0
 
 * Empty `extra_css` and `extra_javascript` settings no longer raise a warning.
@@ -308,7 +315,7 @@ Support had been added to provide theme specific customizations. Theme authors
 can define default options as documented in [Theme Configuration]. A theme can
 now inherit from another theme, define various static templates to be rendered,
 and define arbitrary default variables to control behavior in the templates.
-The theme configuration is defined in a configuruation file named
+The theme configuration is defined in a configuration file named
 `mkdocs_theme.yml` which should be placed at the root of your template files. A
 warning will be raised if no configuration file is found and an error will be
 raised in a future release.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -229,7 +229,7 @@ authors should review how [search and themes] interact.
 [search config]: ../user-guide/configuration.md#search
 [search and themes]: ../user-guide/custom-themes.md#search_and_themes
 
-#### `theme_dir` Configuration Option fully Deprecated.
+#### `theme_dir` Configuration Option fully Deprecated
 
 As of version 0.17, the [custom_dir] option replaced the deprecated `theme_dir`
 option. If users had set the `theme_dir` option, MkDocs version 0.17 copied the
@@ -238,6 +238,7 @@ value to the `theme.custom_dir` option and a warning was issued. As of version
 
 ### Other Changes and Additions to Version 1.0
 
+* A missing theme configuration file now raises an error.
 * Empty `extra_css` and `extra_javascript` settings no longer raise a warning.
 * Add highlight.js configuration settings to built-in themes (#1284).
 * Close search modal when result is selected (#1527).

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -380,27 +380,6 @@ class SiteDir(Dir):
                  ).format(config['site_dir'], config['docs_dir']))
 
 
-class ThemeDir(Dir):
-    """
-    ThemeDir Config Option. Deprecated
-    """
-
-    def pre_validation(self, config, key_name):
-
-        if config.get(key_name) is None:
-            return
-
-        super(ThemeDir, self).pre_validation(config, key_name)
-
-        warning = ('The configuration option {0} has been deprecated and will '
-                   'be removed in a future release of MkDocs.')
-        self.warnings.append(warning)
-
-    def post_validation(self, config, key_name):
-        # The validation in the parent class this inherits from is not relevant here.
-        pass
-
-
 class Theme(BaseConfigOption):
     """
     Theme Config Option
@@ -437,15 +416,6 @@ class Theme(BaseConfigOption):
 
     def post_validation(self, config, key_name):
         theme_config = config[key_name]
-
-        # TODO: Remove when theme_dir is fully deprecated.
-        if config['theme_dir'] is not None:
-            if 'custom_dir' not in theme_config:
-                # Only pass in 'theme_dir' if it is set and 'custom_dir' is not set.
-                theme_config['custom_dir'] = config['theme_dir']
-            if not any(['theme' in c for c in config.user_configs]):
-                # If the user did not define a theme, but did define theme_dir, then remove default set in validate.
-                theme_config['name'] = None
 
         if not theme_config['name'] and 'custom_dir' not in theme_config:
             raise ValidationError("At least one of 'theme.name' or 'theme.custom_dir' must be defined.")

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -462,62 +462,6 @@ class Theme(BaseConfigOption):
         config[key_name] = theme.Theme(**theme_config)
 
 
-class Extras(OptionallyRequired):
-    """
-    Extras Config Option
-
-    Validate the extra configs are a list and issue a warning for any files
-    found in the docs_dir which are not listed here.
-
-    TODO: Delete this in a future release and use
-    `config_options.Type(list, default=[])` instead.
-    """
-
-    def __init__(self, file_match=None, **kwargs):
-        super(Extras, self).__init__(**kwargs)
-        self.file_match = file_match
-
-    def run_validation(self, value):
-        if isinstance(value, list):
-            return value
-        else:
-            raise ValidationError(
-                "Expected a list, got {0}".format(type(value)))
-
-    def walk_docs_dir(self, docs_dir):
-        if self.file_match is None:
-            raise StopIteration
-
-        for (dirpath, dirs, filenames) in os.walk(docs_dir, followlinks=True):
-            dirs.sort()
-            for filename in sorted(filenames):
-                fullpath = os.path.join(dirpath, filename)
-
-                # Some editors (namely Emacs) will create temporary symlinks
-                # for internal magic. We can just ignore these files.
-                if os.path.islink(fullpath):
-                    local_fullpath = os.path.join(dirpath, os.readlink(fullpath))
-                    if not os.path.exists(local_fullpath):
-                        continue
-
-                relpath = os.path.normpath(os.path.relpath(fullpath, docs_dir))
-                if self.file_match(relpath):
-                    yield relpath
-
-    def post_validation(self, config, key_name):
-        # Only issue warnings for missing files if the setting is empty
-        # as autopopulating only used to work if the setting was empty.
-        if not config[key_name]:
-            actual_files = list(self.walk_docs_dir(config['docs_dir']))
-            if actual_files:
-                self.warnings.append((
-                    "Some files in your 'docs_dir' are not listed in the '{0}' "
-                    "config setting and will be ignored by the theme. Add the "
-                    "following files to the '{0}' config setting if you want "
-                    "them to have an effect on the theme: ['{1}']"
-                ).format(key_name, "', '".join(actual_files)))
-
-
 class Nav(OptionallyRequired):
     """
     Nav Config Option

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -81,9 +81,8 @@ DEFAULT_SCHEMA = (
 
     # Specify which css or javascript files from the docs directory should be
     # additionally included in the site.
-    ('extra_css', config_options.Extras(file_match=utils.is_css_file, default=[])),
-    ('extra_javascript', config_options.Extras(
-        file_match=utils.is_javascript_file, default=[])),
+    ('extra_css', config_options.Type(list, default=[])),
+    ('extra_javascript', config_options.Type(list, default=[])),
 
     # Similar to the above, but each template (HTML or XML) will be build with
     # Jinja2 and the global context.

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -42,10 +42,6 @@ DEFAULT_SCHEMA = (
     # The directory where the site will be built to
     ('site_dir', config_options.SiteDir(default='site')),
 
-    # The directory of a theme to use if not using one of the builtin MkDocs
-    # themes.
-    ('theme_dir', config_options.ThemeDir(exists=True)),
-
     # A copyright notice to add to the footer of documentation.
     ('copyright', config_options.Type(utils.string_types)),
 

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -105,8 +105,6 @@ class ConfigTests(unittest.TestCase):
             configs = [
                 dict(),  # default theme
                 {"theme": "readthedocs"},  # builtin theme
-                {"theme_dir": mytheme},  # custom only
-                {"theme": "readthedocs", "theme_dir": custom},  # builtin and custom
                 {"theme": {'name': 'readthedocs'}},  # builtin as complex
                 {"theme": {'name': None, 'custom_dir': mytheme}},  # custom only as complex
                 {"theme": {'name': 'readthedocs', 'custom_dir': custom}},  # builtin and custom as complex
@@ -136,19 +134,6 @@ class ConfigTests(unittest.TestCase):
                     }
                 }, {
                     'dirs': [os.path.join(theme_dir, 'readthedocs'), mkdocs_templates_dir],
-                    'static_templates': ['404.html', 'sitemap.xml'],
-                    'vars': {
-                        'include_search_page': True,
-                        'search_index_only': False,
-                        'highlightjs': True,
-                        'hljs_languages': []
-                    }
-                }, {
-                    'dirs': [mytheme, mkdocs_templates_dir],
-                    'static_templates': ['sitemap.xml'],
-                    'vars': {}
-                }, {
-                    'dirs': [custom, os.path.join(theme_dir, 'readthedocs'), mkdocs_templates_dir],
                     'static_templates': ['404.html', 'sitemap.xml'],
                     'vars': {
                         'include_search_page': True,
@@ -194,10 +179,7 @@ class ConfigTests(unittest.TestCase):
 
             for config_contents, result in zip(configs, results):
 
-                c = config.Config(schema=(
-                    ('theme', config_options.Theme(default='mkdocs')),
-                    ('theme_dir', config_options.ThemeDir(exists=True)),
-                ))
+                c = config.Config(schema=(('theme', config_options.Theme(default='mkdocs')),))
                 c.load_dict(config_contents)
                 errors, warnings = c.validate()
                 self.assertEqual(len(errors), 0)

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -83,12 +83,10 @@ class Theme(object):
                 theme_config = utils.yaml_load(f)
         except IOError as e:
             log.debug(e)
-            # TODO: Change this warning to an error in a future version
-            log.warning(
+            raise ValidationError(
                 "The theme '{0}' does not appear to have a configuration file. "
                 "Please upgrade to a current version of the theme.".format(name)
             )
-            return
 
         log.debug("Loaded theme configuration for '%s' from '%s': %s", name, file_path, theme_config)
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -193,27 +193,6 @@ def is_markdown_file(path):
     return any(fnmatch.fnmatch(path.lower(), '*{0}'.format(x)) for x in markdown_extensions)
 
 
-def is_css_file(path):
-    """
-    Return True if the given file path is a CSS file.
-    """
-    ext = os.path.splitext(path)[1].lower()
-    return ext in [
-        '.css',
-    ]
-
-
-def is_javascript_file(path):
-    """
-    Return True if the given file path is a Javascript file.
-    """
-    ext = os.path.splitext(path)[1].lower()
-    return ext in [
-        '.js',
-        '.javascript'
-    ]
-
-
 def is_html_file(path):
     """
     Return True if the given file path is an HTML file.


### PR DESCRIPTION
Finalize some deprecations started in version 0.17. 

* Empty `extra_css` and `extra_javascript` settings no longer raise a warning.
* `theme_dir` config fully Deprecated. 
* Missing theme config file raises an error.