### PR TITLE
User friendly YAML parse errors.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -238,6 +238,7 @@ value to the `theme.custom_dir` option and a warning was issued. As of version
 
 ### Other Changes and Additions to Version 1.0
 
+* User friendly YAML parse errors (#1543).
 * Officially support Python 3.7.
 * A missing theme configuration file now raises an error.
 * Empty `extra_css` and `extra_javascript` settings no longer raise a warning.

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import logging
 import os
 import sys
+from yaml import YAMLError
 
 from mkdocs import exceptions
 from mkdocs import utils
@@ -129,7 +130,13 @@ class Config(utils.UserDict):
         self.data.update(patch)
 
     def load_file(self, config_file):
-        return self.load_dict(utils.yaml_load(config_file))
+        try:
+            return self.load_dict(utils.yaml_load(config_file))
+        except YAMLError as e:
+            # MkDocs knows and understands ConfigurationErrors
+            raise exceptions.ConfigurationError(
+                "MkDocs encountered as error parsing the configuration file: {}".format(e)
+            )
 
 
 def _open_config_file(config_file):


### PR DESCRIPTION
This provides a clearer error for users who have an invalid config file. 
Partially addresses #1543.