### PR TITLE
Fix building for Read the Docs' mirror

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,7 @@
+build:
+  image: latest
+
+python:
+  setup_py_install: true
+
+requirements_file: requirements/project.txt


### PR DESCRIPTION
The Read the Docs [mirror of the documentation](https://mkdocs.readthedocs.io/en/stable/) does not build correctly. The main issue is that the dependencies (notably the `mdx_gh_links` extension) was not installed. Here's a [recent build](https://readthedocs.org/projects/mkdocs/builds/7552464/) as an example.

This proposed PR uses [Read the Docs' yaml config](https://docs.readthedocs.io/en/latest/yaml-config.html) to specify the requirements file and to install mkdocs from the synced repository. That way the same version of mkdocs is used to build the documentation as the version that the repo contains (eg. 0.17.5 is used to build 0.17.5 and so on).