### PR TITLE
Fix RTD Navigation bug.

### DIFF
--- a/mkdocs/themes/readthedocs/nav.html
+++ b/mkdocs/themes/readthedocs/nav.html
@@ -1,7 +1,7 @@
-{%- if nav_item.url %}
-    <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
-{%- else %}
+{%- if nav_item.is_section %}
     <span class="caption-text">{{ nav_item.title }}</span>
+{%- else %}
+    <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
 {%- endif %}
 
 {%- if nav_item == page or nav_item.children %}


### PR DESCRIPTION
Fixes #1575.

The pages refactor resulted in the URL of the homepage being an empty string, which was causing the template to fail to recognize the nav item as a page and treating it like a section. By actually checking the item type, we avoid that problem.