### PR TITLE
Worker search query string

### DIFF
--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -32,7 +32,6 @@ function displayResults (results) {
 function doSearch () {
   var query = document.getElementById('mkdocs-search-query').value;
   if (query.length > 2) {
-    console.log('Searching with query: ' + query);
     if (!window.Worker) {
       displayResults(search(query));
     } else {
@@ -49,7 +48,6 @@ function initSearch () {
   if (search_input) {
     search_input.addEventListener("keyup", doSearch);
   }
-
   var term = getSearchTermFromLocation();
   if (term) {
     search_input.value = term;
@@ -58,7 +56,9 @@ function initSearch () {
 }
 
 function onWorkerMessage (e) {
-  if (e.data.results) {
+  if (e.data.allowSearch) {
+    initSearch();
+  } else if (e.data.results) {
     var results = e.data.results;
     displayResults(results);
   }
@@ -70,6 +70,7 @@ if (!window.Worker) {
   $.getScript(base_url + "/search/worker.js").done(function () {
     console.log('Loaded worker');
     init();
+    window.postMessage = initSearch;
   }).fail(function (jqxhr, settings, exception) {
     console.error('Could not load worker.js');
   });
@@ -79,16 +80,3 @@ if (!window.Worker) {
   searchWorker.postMessage({init: true});
   searchWorker.onmessage = onWorkerMessage;
 }
-
-$(function() {
-  var search_input = document.getElementById('mkdocs-search-query');
-  if (search_input) {
-    search_input.addEventListener("keyup", doSearch);
-  }
-
-  var term = getSearchTermFromLocation();
-  if (term) {
-    search_input.value = term;
-    doSearch();
-  }
-});

--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -70,7 +70,9 @@ if (!window.Worker) {
   $.getScript(base_url + "/search/worker.js").done(function () {
     console.log('Loaded worker');
     init();
-    window.postMessage = initSearch;
+    window.postMessage = function (msg) {
+      onWorkerMessage({data: msg});
+    };
   }).fail(function (jqxhr, settings, exception) {
     console.error('Could not load worker.js');
   });

--- a/mkdocs/contrib/search/templates/search/worker.js
+++ b/mkdocs/contrib/search/templates/search/worker.js
@@ -84,6 +84,7 @@ function onScriptsLoaded () {
     console.log('Lunr index built, search ready');
   }
   allowSearch = true;
+  postMessage({allowSearch: true});
 }
 
 function init () {

--- a/mkdocs/contrib/search/templates/search/worker.js
+++ b/mkdocs/contrib/search/templates/search/worker.js
@@ -84,7 +84,7 @@ function onScriptsLoaded () {
     console.log('Lunr index built, search ready');
   }
   allowSearch = true;
-  postMessage({allowSearch: true});
+  postMessage({allowSearch: allowSearch});
 }
 
 function init () {

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -128,8 +128,11 @@ pre .cs, pre .c {
  * Additions specific to the search functionality provided by MkDocs
  */
 
-.search-results article {
+.search-results {
     margin-top: 23px;
+}
+
+.search-results article {
     border-top: 1px solid #E1E4E5;
     padding-top: 24px;
 }

--- a/mkdocs/themes/readthedocs/js/theme.js
+++ b/mkdocs/themes/readthedocs/js/theme.js
@@ -13,19 +13,27 @@ $( document ).ready(function() {
 
     // Keyboard navigation
     document.addEventListener("keydown", function(e) {
-        if ($(e.target).is(':input')) return true;
-        var key = e.which || e.keyCode || window.event && window.event.keyCode;
-        var page;
-        switch (key) {
-            case 78:  // n
-                page = $('[role="navigation"] a:contains(Next):first').prop('href');
-                break;
-            case 80:  // p
-                page = $('[role="navigation"] a:contains(Previous):first').prop('href');
-                break;
-            default: break;
-        }
-        if (page) window.location.href = page;
+      var key = e.which || e.keyCode || window.event && window.event.keyCode;
+      var page;
+      switch (key) {
+          case 78:  // n
+              page = $('[role="navigation"] a:contains(Next):first').prop('href');
+              break;
+          case 80:  // p
+              page = $('[role="navigation"] a:contains(Previous):first').prop('href');
+              break;
+          case 13:  // enter
+              if (e.target === document.getElementById('mkdocs-search-query')) {
+                e.preventDefault();
+              }
+              break;
+          default: break;
+      }
+      if ($(e.target).is(':input')) {
+        return true;
+      } else if (page) {
+        window.location.href = page;
+      }
     });
 
     $(document).on('click', "[data-toggle='rst-current-version']", function() {


### PR DESCRIPTION
Fixes #1584 

We had a copy of `initSearch` running on document ready in `main.js` which was causing the race condition with the fetching of the index and initialization.

We now explictly send a message from the initialization code to start off search for the query string if any.

I also tweaked the behaviour of the search input for the RTD theme so it does not reload the page when pressing Enter.