### PR TITLE
Warn on relative paths in nav.

### DIFF
--- a/mkdocs/exceptions.py
+++ b/mkdocs/exceptions.py
@@ -11,4 +11,4 @@ class ConfigurationError(MkDocsException):
 
 
 class MarkdownNotFound(MkDocsException):
-    """A linked local Markdown file isn't found in the table of contents."""
+    """A linked local Markdown file isn't found in the documents."""

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 import logging
 
 from mkdocs.structure.pages import Page
-from mkdocs.utils import string_types, nest_paths
+from mkdocs.utils import string_types, nest_paths, urlparse
+from mkdocs.exceptions import ConfigurationError
 
 log = logging.getLogger(__name__)
 
@@ -124,13 +125,26 @@ def get_navigation(files, config):
             Page(None, file, config)
 
     links = _get_by_type(items, Link)
-    if links:
-        # Assume all links are external.
-        log.debug(
-            'The following paths are included in the "nav" configuration, '
-            'but do not exist in the docs directory:\n  - {}'.format(
-                '\n  - '.join([link.url for link in links]))
-        )
+    for link in links:
+        scheme, netloc, path, params, query, fragment = urlparse(link.url)
+        if scheme or netloc:
+            log.debug(
+                "An external link to '{}' is included in "
+                "the 'nav' configuration.".format(link.url)
+            )
+        elif link.url.startswith('/'):
+            log.debug(
+                "An absolute path to '{}' is included in the 'nav' configuration, "
+                "which presumably points to an external resource.".format(link.url)
+            )
+        else:
+            msg = (
+                "A relative path to '{}' is included in the 'nav' configuration, "
+                "which does not exist in the docs directory".format(link.url)
+            )
+            log.warning(msg)
+            if config['strict']:
+                raise ConfigurationError(msg)
     return Navigation(items, pages)
 
 


### PR DESCRIPTION
Note that prior to 1.0 this was handled as part of the config 
validation. Now that it is moved out of config validation, we no longer 
have the option to collect all wartnings and then raise an error on 
strict mode. We now exist on the first error and never get to any later 
errors.

Closes #1604.