### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ rooms, and mailing lists is expected to follow the [PyPA Code of Conduct].
 [landscape-image]: https://landscape.io/github/mkdocs/mkdocs/master/landscape.svg?style=flat
 [landscape-link]: https://landscape.io/github/mkdocs/mkdocs/master
 [pypi-v-image]: https://img.shields.io/pypi/v/mkdocs.svg
-[pypi-v-link]: https://pypi.python.org/pypi/mkdocs
+[pypi-v-link]: https://pypi.org/project/mkdocs/
 [travis-image]: https://img.shields.io/travis/mkdocs/mkdocs/master.svg
 [travis-link]: https://travis-ci.org/mkdocs/mkdocs
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html