### PR TITLE
Ignore absolute links in Markdown.

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -214,7 +214,8 @@ class _RelativePathTreeprocessor(Treeprocessor):
     def path_to_url(self, url):
         scheme, netloc, path, params, query, fragment = urlparse(url)
 
-        if scheme or netloc or not path or AMP_SUBSTITUTE in url or '.' not in os.path.split(path)[-1]:
+        if (scheme or netloc or not path or url.startswith('/')
+                or AMP_SUBSTITUTE in url or '.' not in os.path.split(path)[-1]):
             # Ignore URLs unless they are a relative link to a source file.
             # AMP_SUBSTITUTE is used internally by Markdown only for email.
             # No '.' in the last part of a path indicates path does not point to a file.

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -772,6 +772,13 @@ class RelativePathExtensionTests(LogTestCase):
             '<p><a href="http://example.com/index.md">external link</a></p>'
         )
 
+    @mock.patch('io.open', mock.mock_open(read_data='[absolute link](/path/to/file.md)'))
+    def test_absolute_link(self):
+        self.assertEqual(
+            self.get_rendered_result(['index.md']),
+            '<p><a href="/path/to/file.md">absolute link</a></p>'
+        )
+
     @mock.patch('io.open', mock.mock_open(read_data='<mail@example.com>'))
     def test_email_link(self):
         self.assertEqual(


### PR DESCRIPTION
Fixes #1621.