### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
-[wheel]
+[bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Helps project comply with its own license:

> Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

Additionally, rename [wheel] section to `[bdist_wheel]` as the former is legacy. For additional details, see:

https://github.com/pypa/wheel/blob/3dc261abc98a5e43bc7fcf5783d080aaf8f9f0cf/wheel/bdist_wheel.py#L127-L133

http://pythonwheels.com/