### PR TITLE
fix docs error --dev-addr instead of --dev_addr

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -389,7 +389,7 @@ Determines the address used when running `mkdocs serve`. Must be of the format
 `IP:PORT`.
 
 Allows a custom default to be set without the need to pass it through the
-`--dev_addr` option every time the `mkdocs serve` command is called.
+`--dev-addr` option every time the `mkdocs serve` command is called.
 
 **default**: `'127.0.0.1:8000'`
 


### PR DESCRIPTION
relative to #1637 