### PR TITLE
Fix monospace code rendering on Android

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -95,7 +95,7 @@ pre code {
     border: none;
     white-space: pre;
     word-wrap: normal;
-    font-family: monospace,serif;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: 12px;
 }
 


### PR DESCRIPTION
The `font-family: monospace,serif;` was not working on Android 8 Chrome 69, causing code blocks to render with some variable width serif font. This change copies the --font-family-monospace variable value from the bootstrap css file in the same directory. You could alternatively use `var(--font-family-monospace)` or even remove the `font-family` declaration here and rely on the style for pre in `bootstrap.custom.min.css`.