### PR TITLE
update pyyaml to fix CVE-2017-18342

### DIFF
--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -2,6 +2,6 @@ click==3.3
 Jinja2==2.7.1
 livereload==2.5.1
 Markdown==2.5
-PyYAML==3.13
+PyYAML==4.2b4
 tornado==4.1
 mdx_gh_links>=0.2

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -2,6 +2,6 @@ click>=3.3
 Jinja2>=2.7.1
 livereload>=2.5.1
 Markdown>=2.5
-PyYAML>=3.13
+PyYAML>=4.2b4
 tornado>=5.0
 mdx_gh_links>=0.2

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'livereload>=2.5.1',
         'lunr[languages]>=0.5.2',
         'Markdown>=2.3.1',
-        'PyYAML>=3.10',
+        'PyYAML>=4.2b4',
         'tornado>=5.0'
     ],
     python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',


### PR DESCRIPTION
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.  See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18342

PyYAML released 4.1 but then pulled it from PyPi.  See https://github.com/yaml/pyyaml/issues/207 for some discussion.  https://github.com/yaml/pyyaml/tree/release/4.2 is the ongoing release branch, but nothing has been committed since July when 4.2b4 was released to PyPi

I have a project using my fork, with PyYaml updated to 4.2b4 and everything seems to be working fine. 
 Additionally the travis tests passed (and my project that includes mkdocs no longer triggers a vulnerability alert due to the unsafe version of PyYAML).
