### PR TITLE
Remove template exclusion

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -60,6 +60,7 @@ your global navigation uses more than one level, things will likely be broken.
 * Bugfix: Ensure theme files do not override `docs_dir` files (#1671).
 * Bugfix: Do not normalize URL fragments (#1655).
 * Add canonical tag to `readthedocs` theme (#1669).
+* No longer ignore a directory named `templates` inside of `docs_dir`. (#1699)
 
 ## Version 1.0.4 (2018-09-07)
 

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -133,7 +133,7 @@ def _build_extra_template(template_name, files, config, nav):
 
     log.debug("Building extra template: {}".format(template_name))
 
-    file = files.get_file_from_path(template_name)
+    file = files.get_extra_template_file_from_path(template_name)
     if file is None:
         log.warn("Template skipped: '{}' not found in docs_dir.".format(template_name))
         return

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -218,7 +218,7 @@ class File(object):
 def get_files(config):
     """ Walk the `docs_dir` and return a Files collection. """
     files = []
-    exclude = ['.*', '/templates']
+    exclude = ['.*']
 
     for source_dir, dirnames, filenames in os.walk(config['docs_dir'], followlinks=True):
         relative_dir = os.path.relpath(source_dir, config['docs_dir'])

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -220,6 +220,10 @@ def get_files(config):
     files = []
     exclude = ['.*']
 
+    # Exclude `extra_templates` in case they are in `docs_dir`
+    for extra_template in config['extra_templates']:
+        exclude.append("/" + extra_template)
+
     for source_dir, dirnames, filenames in os.walk(config['docs_dir'], followlinks=True):
         relative_dir = os.path.relpath(source_dir, config['docs_dir'])
 

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -564,8 +564,7 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         'bar.jpg',
         'bar.js',
         'bar.md',
-        '.dotfile',
-        'templates/foo.html'
+        '.dotfile'
     ])
     def test_get_files(self, tdir):
         config = load_config(docs_dir=tdir, extra_css=['bar.css'], extra_javascript=['bar.js'])

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -564,10 +564,13 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         'bar.jpg',
         'bar.js',
         'bar.md',
-        '.dotfile'
+        '.dotfile',
+        'extra/template1.html',
+        'extra/template2.html'
     ])
     def test_get_files(self, tdir):
-        config = load_config(docs_dir=tdir, extra_css=['bar.css'], extra_javascript=['bar.js'])
+        config = load_config(docs_dir=tdir, extra_css=['bar.css'], extra_javascript=['bar.js'],
+                             extra_templates=['extra/template1.html', 'extra/template2.html'])
         files = get_files(config)
         expected = ['index.md', 'bar.css', 'bar.html', 'bar.jpg', 'bar.js', 'bar.md']
         self.assertIsInstance(files, Files)


### PR DESCRIPTION
To quote @waylan from #1152:

> There is no "exclude" of any kind. It was never anticipated that non-documentation would be in the docs_dir... And quite frankly, why would anyone actually want that?

In my case, I have a directory of documentation called `templates` that I'd really like to add. From what I can tell, a `templates` directory inside of `docs_dir` isn't referenced anywhere. Is this safe to remove?