### PR TITLE
Overhaul events

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -242,7 +242,7 @@ def build(config, live_server=False, dirty=False):
     config = config['plugins'].run_event('config', config)
 
     # Run `pre_build` plugin events.
-    config['plugins'].run_event('pre_build', config)
+    config['plugins'].run_event('pre_build', config=config)
 
     if not dirty:
         log.info("Cleaning site directory")
@@ -298,7 +298,7 @@ def build(config, live_server=False, dirty=False):
         _build_page(file.page, config, files, nav, env, dirty)
 
     # Run `post_build` plugin events.
-    config['plugins'].run_event('post_build', config)
+    config['plugins'].run_event('post_build', config=config)
 
     if config['strict'] and utils.warning_filter.count:
         raise SystemExit('\nExited with {} warnings in strict mode.'.format(utils.warning_filter.count))

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -81,7 +81,7 @@ class PluginCollection(OrderedDict):
             if callable(method):
                 self._register_event(event_name[3:], method)
 
-    def run_event(self, name, item, **kwargs):
+    def run_event(self, name, item=None, **kwargs):
         """
         Run all registered methods of an event.
 
@@ -90,8 +90,12 @@ class PluginCollection(OrderedDict):
         be modified by the event method.
         """
 
+        pass_item = item is not None
         for method in self.events[name]:
-            result = method(item, **kwargs)
+            if pass_item:
+                result = method(item, **kwargs)
+            else:
+                result = method(**kwargs)
             # keep item if method returned `None`
             if result is not None:
                 item = result

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -85,7 +85,8 @@ class PluginCollection(OrderedDict):
         """
         Run all registered methods of an event.
 
-        `item` is the object to be modified and returned by the event method.
+        `item` is the object to be modified or replaced and returned by the event method.
+        If it isn't given the event method creates a new object to be returned.
         All other keywords are variables for context, but would not generally
         be modified by the event method.
         """

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -123,8 +123,8 @@ class Page(object):
             self.edit_url = None
 
     def read_source(self, config):
-        source = config['plugins'].run_event('page_read_source', None, config=config, page=self)
-        if source is None:
+        source = config['plugins'].run_event('page_read_source', self, config=config)
+        if source is not self:
             try:
                 with io.open(self.file.abs_src_path, 'r', encoding='utf-8-sig', errors='strict') as f:
                     source = f.read()

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -123,8 +123,10 @@ class Page(object):
             self.edit_url = None
 
     def read_source(self, config):
-        source = config['plugins'].run_event('page_read_source', self, config=config)
-        if source is not self:
+        source = config['plugins'].run_event(
+            'page_read_source', page=self, config=config
+        )
+        if source is not None:
             try:
                 with io.open(self.file.abs_src_path, 'r', encoding='utf-8-sig', errors='strict') as f:
                     source = f.read()

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -126,7 +126,7 @@ class Page(object):
         source = config['plugins'].run_event(
             'page_read_source', page=self, config=config
         )
-        if source is not None:
+        if source is None:
             try:
                 with io.open(self.file.abs_src_path, 'r', encoding='utf-8-sig', errors='strict') as f:
                     source = f.read()

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -27,6 +27,14 @@ class DummyPlugin(plugins.BasePlugin):
         """ do nothing (return None) to not modify item. """
         return None
 
+    def on_page_read_source(self, **kwargs):
+        """ create new source by prepending `foo` config value to 'source'. """
+        return '{} {}'.format(self.config['foo'], 'source')
+
+    def on_pre_build(self, **kwargs):
+        """ do nothing (return None). """
+        return None
+
 
 class TestPluginClass(unittest.TestCase):
 
@@ -115,6 +123,20 @@ class TestPluginCollection(unittest.TestCase):
         plugin.load_config({'foo': 'new'})
         collection['foo'] = plugin
         self.assertEqual(collection.run_event('nav', 'nav item'), 'nav item')
+
+    def test_event_empty_item(self):
+        collection = plugins.PluginCollection()
+        plugin = DummyPlugin()
+        plugin.load_config({'foo': 'new'})
+        collection['foo'] = plugin
+        self.assertEqual(collection.run_event('page_read_source'), 'new source')
+
+    def test_event_empty_item_returns_None(self):
+        collection = plugins.PluginCollection()
+        plugin = DummyPlugin()
+        plugin.load_config({'foo': 'new'})
+        collection['foo'] = plugin
+        self.assertEqual(collection.run_event('pre_build'), None)
 
     def test_run_undefined_event_on_collection(self):
         collection = plugins.PluginCollection()

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -20,8 +20,8 @@ class DummyPlugin(plugins.BasePlugin):
     )
 
     def on_pre_page(self, content, **kwargs):
-        """ prepend `foo` config value to page content. """
-        return ' '.join((self.config['foo'], content))
+        """ modify page content by prepending `foo` config value. """
+        return '{} {}'.format(self.config['foo'], content)
 
     def on_nav(self, item, **kwargs):
         """ do nothing (return None) to not modify item. """


### PR DESCRIPTION
The current event implementation is a bit limited. The idea of having events revolve around an item is cool; you pass an item to run_event, it loops through all the available event handlers, calls them with the item and if they return anything it reassigns the item to the return value, finally returning the item's final iteration, possibly completely different from the one passed in. Unfortunately this doesn't accommodate events that don't revolve around an item, which are only used as callbacks, such as pre_build and post_build, or even events that are for creating a new item, such as page_read_source.

I've changed `run_event` by making `item` optional (defaulting to `None`). If an item isn't provided it doesn't get passed to the event handlers. This doesn't mean that the event handlers can't make their own items to be returned, the items they create just don't get passed to the next handlers. This allows both callback-based and creation-based events to coincide.