### PR TITLE
Fixed default link in new page

### DIFF
--- a/mkdocs/commands/new.py
+++ b/mkdocs/commands/new.py
@@ -8,7 +8,7 @@ import os
 config_text = 'site_name: My Docs\n'
 index_text = """# Welcome to MkDocs
 
-For full documentation visit [mkdocs.org](https://mkdocs.org).
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
 
 ## Commands
 

--- a/mkdocs/tests/integration/minimal/docs/testing.md
+++ b/mkdocs/tests/integration/minimal/docs/testing.md
@@ -1,6 +1,6 @@
 # Welcome to MkDocs
 
-For full documentation visit [mkdocs.org](https://mkdocs.org).
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
 
 ## Commands
 

--- a/mkdocs/tests/integration/unicode/docs/Übersicht.md
+++ b/mkdocs/tests/integration/unicode/docs/Übersicht.md
@@ -1,6 +1,6 @@
 Welcome to MkDocs
 
-For full documentation visit [mkdocs.org](https://mkdocs.org).
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
 
 ## Commands
 

--- a/mkdocs/tests/integration/unicode/docs/♪.md
+++ b/mkdocs/tests/integration/unicode/docs/♪.md
@@ -1,6 +1,6 @@
 Welcome to MkDocs
 
-For full documentation visit [mkdocs.org](https://mkdocs.org).
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
 
 ## Commands
 


### PR DESCRIPTION
Just using "https://mkdocs.org" yields a certificate error because that is the GitHub wildcard certificate, so the domains don't match.