### PR TITLE
Add a second level of 'strict'.

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -30,7 +30,7 @@ class DuplicateFilter(object):
 
 log = logging.getLogger(__name__)
 log.addFilter(DuplicateFilter())
-log.addFilter(utils.warning_filter)
+log.addFilter(utils.log_counter)
 
 
 def get_context(nav, files, config, page=None, base_url=''):
@@ -300,8 +300,8 @@ def build(config, live_server=False, dirty=False):
     # Run `post_build` plugin events.
     config['plugins'].run_event('post_build', config=config)
 
-    if config['strict'] and utils.warning_filter.count:
-        raise SystemExit('\nExited with {} warnings in strict mode.'.format(utils.warning_filter.count))
+    if config['strict'] and utils.log_counter.WARNING > 0:
+        raise SystemExit('\nExited with {} warnings in strict mode.'.format(utils.log_counter.WARNING))
 
     log.info('Documentation built in %.2f seconds', time() - start)
 

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -10,7 +10,7 @@ from mkdocs import utils
 
 
 log = logging.getLogger(__name__)
-log.addFilter(utils.warning_filter)
+log.addFilter(utils.log_counter)
 
 
 class Files(object):

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -4,10 +4,10 @@ from __future__ import unicode_literals
 import logging
 
 from mkdocs.structure.pages import Page
-from mkdocs.utils import string_types, nest_paths, urlparse, warning_filter
+from mkdocs.utils import string_types, nest_paths, urlparse, log_counter
 
 log = logging.getLogger(__name__)
-log.addFilter(warning_filter)
+log.addFilter(log_counter)
 
 
 class Navigation(object):

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -13,10 +13,10 @@ from markdown.treeprocessors import Treeprocessor
 from markdown.util import AMP_SUBSTITUTE
 
 from mkdocs.structure.toc import get_toc
-from mkdocs.utils import meta, urlparse, urlunparse, urljoin, urlunquote, get_markdown_title, warning_filter
+from mkdocs.utils import meta, urlparse, urlunparse, urljoin, urlunquote, get_markdown_title, log_counter
 
 log = logging.getLogger(__name__)
-log.addFilter(warning_filter)
+log.addFilter(log_counter)
 
 
 class Page(object):

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -10,7 +10,7 @@ from mkdocs.utils import filters
 from mkdocs.config.base import ValidationError
 
 log = logging.getLogger(__name__)
-log.addFilter(utils.warning_filter)
+log.addFilter(utils.log_counter)
 
 
 class Theme(object):

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -394,15 +394,15 @@ def nest_paths(paths):
     return nested
 
 
-class WarningFilter(logging.Filter):
-    """ Counts all WARNING level log messages. """
-    count = 0
+class CountLogFilter(logging.Filter):
+    """ Counts log messages by level. """
+    def __init__(self):
+        self.DEBUG = self.INFO = self.WARNING = self.ERROR = self.CRITICAL = 0
 
     def filter(self, record):
-        if record.levelno == logging.WARNING:
-            self.count += 1
+        setattr(self, record.levelname, getattr(self, record.levelname, 0) + 1)
         return True
 
 
 # A global instance to use throughout package
-warning_filter = WarningFilter()
+log_counter = CountLogFilter()


### PR DESCRIPTION
This is an experimental solution to #1755 to see if it makes sense. The plan is to add a new logging level between `info` and `warning` named `notice`. Then `--strict --strict` would increase the severity and the build would exit/fail if any `notice` messages were logged. A single `--strict` would  maintain its current behavior and only exit/fail on `warning`, but not `notice`.

So far I have only refactored the log counter to count all levels, not just warnings.