### PR TITLE
Warning about the usage of absolute paths in links

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -201,6 +201,9 @@ Please see the [project license](license.md) for further details.
 When the MkDocs build runs, these Markdown links will automatically be
 transformed into an HTML hyperlink to the appropriate HTML page.
 
+!!! warning
+    Using absolute paths with links is not officially supported. Relative paths are adjusted by MkDocs to ensure they are always relative to the page. Absolute paths are not modified at all. This means that your links using absolute paths might work fine in your local environment but they might break once you deploy them to your production server.
+
 If the target documentation file is in another directory you'll need to make
 sure to include any relative directory path in the link.
 

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -202,7 +202,11 @@ When the MkDocs build runs, these Markdown links will automatically be
 transformed into an HTML hyperlink to the appropriate HTML page.
 
 !!! warning
-    Using absolute paths with links is not officially supported. Relative paths are adjusted by MkDocs to ensure they are always relative to the page. Absolute paths are not modified at all. This means that your links using absolute paths might work fine in your local environment but they might break once you deploy them to your production server.
+    Using absolute paths with links is not officially supported. Relative paths
+    are adjusted by MkDocs to ensure they are always relative to the page. Absolute
+    paths are not modified at all. This means that your links using absolute paths
+    might work fine in your local environment but they might break once you deploy
+    them to your production server.
 
 If the target documentation file is in another directory you'll need to make
 sure to include any relative directory path in the link.


### PR DESCRIPTION
Regarding #1757. An update to the docs to warn about the dangers of absolute paths in links.

I am not sure if you guys manually break lines or there is some tool to do it, so I just left them as is for now. I know it's not going to be merged like this, but I couldn't find anything on this in the contributing guidelines. Let me know what's the official way to go about this an I'll fix it.
