### PR TITLE
contributing.md: fix typos, add link

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -49,10 +49,16 @@ to the git repository.
 
 ## Running the tests
 
-To run the tests, it is recommended that you use [Tox]. This just needs
-[pip](https://pypi.org/project/pip/) to be installed and then the test suite
-can be run for MkDocs by running the command `tox` in the root of your MkDocs
-repository.
+To run the tests, it is recommended that you use
+[Tox](https://pypi.org/project/tox/).
+
+Install Tox using [pip](https://pypi.org/project/pip/) by running the
+following command:
+```
+pip install tox
+```
+Then the test suite can be run for MkDocs by running the command `tox` in the
+root of your MkDocs repository.
 
 It will attempt to run the tests against all of the Python versions we
 support. So don't be concerned if you are missing some and they fail. The rest

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -54,9 +54,11 @@ To run the tests, it is recommended that you use
 
 Install Tox using [pip](https://pypi.org/project/pip/) by running the
 following command:
+
 ```
 pip install tox
 ```
+
 Then the test suite can be run for MkDocs by running the command `tox` in the
 root of your MkDocs repository.
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -50,7 +50,7 @@ to the git repository.
 ## Running the tests
 
 To run the tests, it is recommended that you use [Tox]. This just needs
-to be pip installed and then the test suite can be ran for MkDocs but running
+[pip](https://pypi.org/project/pip/) to be installed and then the test suite can be run for MkDocs by running
 the command `tox` in the root of your MkDocs repository.
 
 It will attempt to run the tests against all of the Python versions we

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -49,16 +49,9 @@ to the git repository.
 
 ## Running the tests
 
-To run the tests, it is recommended that you use
-[Tox](https://pypi.org/project/tox/).
+To run the tests, it is recommended that you use [tox].
 
-Install Tox using [pip](https://pypi.org/project/pip/) by running the
-following command:
-
-```
-pip install tox
-```
-
+Install Tox using [pip] by running the command `pip install tox`.
 Then the test suite can be run for MkDocs by running the command `tox` in the
 root of your MkDocs repository.
 
@@ -73,6 +66,7 @@ it to your fork and send a pull request. For a change to be accepted it will
 most likely need to have tests and documentation if it is a new feature.
 
 [virtualenv]: https://virtualenv.pypa.io/en/latest/userguide.html
+[pip]: https://pip.pypa.io/en/stable/
 [tox]: https://tox.readthedocs.io/en/latest/
 [travis]: https://travis-ci.org/repositories
 [PyPA Code of Conduct]: https://www.pypa.io/en/latest/code-of-conduct/

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -50,8 +50,9 @@ to the git repository.
 ## Running the tests
 
 To run the tests, it is recommended that you use [Tox]. This just needs
-[pip](https://pypi.org/project/pip/) to be installed and then the test suite can be run for MkDocs by running
-the command `tox` in the root of your MkDocs repository.
+[pip](https://pypi.org/project/pip/) to be installed and then the test suite
+can be run for MkDocs by running the command `tox` in the root of your MkDocs
+repository.
 
 It will attempt to run the tests against all of the Python versions we
 support. So don't be concerned if you are missing some and they fail. The rest


### PR DESCRIPTION
* contributing.md:52-53

"needs
to be pip installed ..." 
-> "needs
[pip](https://pypi.org/project/pip/) to be installed ..."

* contributing.md:53

"then the test suite can be ran for MkDocs but running ..." -> "then the test suite can be run for MkDocs by running  ..."