### PR TITLE
Add theme localization

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.md
 include LICENSE
-recursive-include mkdocs *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff *.woff2 *.xml *.mustache *mkdocs_theme.yml
+recursive-include mkdocs *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff *.woff2 *.xml *.mustache *mkdocs_theme.yml *.mo
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -14,6 +14,7 @@ import jinja2
 from mkdocs import utils
 from mkdocs.structure.files import get_files
 from mkdocs.structure.nav import get_navigation
+from mkdocs.localization import install_translations
 import mkdocs
 
 
@@ -262,6 +263,9 @@ def build(config, live_server=False, dirty=False):
     files = get_files(config)
     env = config['theme'].get_env()
     files.add_files_from_theme(env, config)
+
+    if 'locale' in config['theme']:
+        install_translations(env, config)
 
     # Run `files` plugin events.
     files = config['plugins'].run_event('files', files, config=config)

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -415,6 +415,7 @@ class Theme(BaseConfigOption):
 
     Validate that the theme exists and build Theme instance.
     """
+    name = 'theme'
 
     def __init__(self, default=None):
         super(Theme, self).__init__()
@@ -447,7 +448,8 @@ class Theme(BaseConfigOption):
         theme_config = config[key_name]
 
         if not theme_config['name'] and 'custom_dir' not in theme_config:
-            raise ValidationError("At least one of 'theme.name' or 'theme.custom_dir' must be defined.")
+            raise ValidationError("At least one of '{name}.name' or '{name}.custom_dir' must be defined."
+                                  .format(name=self.name))
 
         # Ensure custom_dir is an absolute path
         if 'custom_dir' in theme_config and not os.path.isabs(theme_config['custom_dir']):
@@ -455,8 +457,11 @@ class Theme(BaseConfigOption):
             theme_config['custom_dir'] = os.path.join(config_dir, theme_config['custom_dir'])
 
         if 'custom_dir' in theme_config and not os.path.isdir(theme_config['custom_dir']):
-            raise ValidationError("The path set in {name}.custom_dir ('{path}') does not exist.".
-                                  format(path=theme_config['custom_dir'], name=self.name))
+            raise ValidationError("The path set in '{name}.custom_dir' ('{path}') does not exist."
+                                  .format(path=theme_config['custom_dir'], name=self.name))
+
+        if 'locale' in theme_config and not isinstance(theme_config['locale'], utils.string_types):
+            raise ValidationError("'{name}.locale' must be a string.".format(name=self.name))
 
         config[key_name] = theme.Theme(**theme_config)
 

--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -37,7 +37,11 @@ function displayResults (results) {
       search_results.insertAdjacentHTML('beforeend', html);
     }
   } else {
-    search_results.insertAdjacentHTML('beforeend', "<p>No results found</p>");
+    var noResultsText = search_results.getAttribute('data-no-results-text');
+    if (!noResultsText) {
+      noResultsText = "No results found";
+    }
+    search_results.insertAdjacentHTML('beforeend', '<p>' + noResultsText + '</p>');
   }
 }
 

--- a/mkdocs/localization.py
+++ b/mkdocs/localization.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+
+from __future__ import absolute_import, unicode_literals
+
+import os
+import logging
+from babel.core import Locale
+from babel.support import Translations, NullTranslations
+
+log = logging.getLogger(__name__)
+base_path = os.path.dirname(os.path.abspath(__file__))
+
+
+def install_translations(env, config):
+    locale = Locale.parse(config['theme']['locale'], sep='_')
+
+    env.add_extension('jinja2.ext.i18n')
+    translations = _get_merged_translations(config['theme'].dirs, 'locales', locale)
+    if translations is not None:
+        env.install_gettext_translations(translations)
+    else:
+        env.install_null_translations()
+
+
+def _get_merged_translations(theme_dirs, locales_dir, locale):
+    merged_translations = None
+
+    log.debug("Looking for translations for locale '%s'", locale)
+    for theme_dir in reversed(theme_dirs):
+        dirname = os.path.join(theme_dir, locales_dir)
+        translations = Translations.load(dirname, [locale])
+
+        if type(translations) is NullTranslations:
+            log.debug("No translations found here: '%s'", dirname)
+            continue
+
+        log.debug("Translations found here: '%s'", dirname)
+        if merged_translations is None:
+            merged_translations = translations
+        else:
+            merged_translations.merge(translations)
+
+    return merged_translations

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -67,6 +67,8 @@ class Files(object):
         """ Retrieve static files from Jinja environment and add to collection. """
         def filter(name):
             patterns = ['.*', '*.py', '*.pyc', '*.html', '*readme*', 'mkdocs_theme.yml']
+            # Exclude translation files
+            patterns.append('locales/*')
             patterns.extend('*{0}'.format(x) for x in utils.markdown_extensions)
             patterns.extend(config['theme'].static_templates)
             for pattern in patterns:

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -11,6 +11,7 @@ import mkdocs
 from mkdocs import utils
 from mkdocs.config import config_options
 from mkdocs.config.base import Config
+from mkdocs.tests.base import tempdir
 
 
 class OptionallyRequiredTest(unittest.TestCase):
@@ -542,6 +543,66 @@ class ThemeTest(unittest.TestCase):
         option = config_options.Theme()
         self.assertRaises(config_options.ValidationError,
                           option.validate, config)
+
+    def test_post_validation_none_theme_name_and_missing_custom_dir(self):
+
+        config = {
+            'theme': {
+                'name': None
+            }
+        }
+        option = config_options.Theme()
+        self.assertRaises(config_options.ValidationError,
+                          option.post_validation, config, 'theme')
+
+    @tempdir()
+    def test_post_validation_inexisting_custom_dir(self, abs_base_path):
+
+        config = {
+            'theme': {
+                'name': None,
+                'custom_dir': abs_base_path + '/inexisting_custom_dir',
+            }
+        }
+        option = config_options.Theme()
+        self.assertRaises(config_options.ValidationError,
+                          option.post_validation, config, 'theme')
+
+    def test_post_validation_locale_none(self):
+
+        config = {
+            'theme': {
+                'name': 'mkdocs',
+                'locale': None
+            }
+        }
+        option = config_options.Theme()
+        self.assertRaises(config_options.ValidationError,
+                          option.post_validation, config, 'theme')
+
+    def test_post_validation_locale_invalid_type(self):
+
+        config = {
+            'theme': {
+                'name': 'mkdocs',
+                'locale': 0
+            }
+        }
+        option = config_options.Theme()
+        self.assertRaises(config_options.ValidationError,
+                          option.post_validation, config, 'theme')
+
+    def test_post_validation_locale(self):
+
+        config = {
+            'theme': {
+                'name': 'mkdocs',
+                'locale': 'fr'
+            }
+        }
+        option = config_options.Theme()
+        option.post_validation(config, 'theme')
+        self.assertEqual('fr', config['theme']['locale'])
 
 
 class NavTest(unittest.TestCase):

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -111,6 +111,7 @@ class ConfigTests(unittest.TestCase):
                 {  # user defined variables
                     'theme': {
                         'name': 'mkdocs',
+                        'locale': 'fr',
                         'static_templates': ['foo.html'],
                         'show_sidebar': False,
                         'some_var': 'bar'
@@ -127,6 +128,7 @@ class ConfigTests(unittest.TestCase):
                     'dirs': [os.path.join(theme_dir, 'mkdocs'), mkdocs_templates_dir],
                     'static_templates': ['404.html', 'sitemap.xml'],
                     'vars': {
+                        'locale': 'en',
                         'include_search_page': False,
                         'search_index_only': False,
                         'highlightjs': True,
@@ -187,6 +189,7 @@ class ConfigTests(unittest.TestCase):
                     'dirs': [os.path.join(theme_dir, 'mkdocs'), mkdocs_templates_dir],
                     'static_templates': ['404.html', 'sitemap.xml', 'foo.html'],
                     'vars': {
+                        'locale': 'fr',
                         'show_sidebar': False,
                         'some_var': 'bar',
                         'include_search_page': False,

--- a/mkdocs/tests/localization_tests.py
+++ b/mkdocs/tests/localization_tests.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+import unittest
+import mock
+
+from mkdocs.localization import install_translations
+from mkdocs.tests.base import load_config, tempdir
+
+
+class LocalizationTests(unittest.TestCase):
+
+    def setUp(self):
+        self.env = mock.Mock()
+
+    def test_jinja_extension_installed(self):
+        config = load_config()
+        install_translations(self.env, config)
+        self.env.add_extension.assert_called_once_with('jinja2.ext.i18n')
+
+    @tempdir()
+    def test_no_translations_found(self, dir_without_translations):
+        config = load_config()
+        config['theme']['locale'] = 'fr_CA'
+        config['theme'].dirs = [dir_without_translations]
+
+        install_translations(self.env, config)
+
+        self.env.install_null_translations.assert_called_once()
+
+    def test_translations_found(self):
+        config = load_config()
+        config['theme']['locale'] = 'en'
+        translations = mock.Mock()
+
+        with mock.patch('mkdocs.localization.Translations.load', return_value=translations):
+            install_translations(self.env, config)
+
+        self.env.install_gettext_translations.assert_called_once_with(translations)
+
+    @tempdir()
+    @tempdir()
+    def test_merge_translations(self, custom_dir, theme_dir):
+        config = load_config()
+        custom_dir_translations = mock.Mock()
+        theme_dir_translations = mock.Mock()
+        config['theme'].dirs = [custom_dir, theme_dir]
+
+        def side_effet(*args, **kwargs):
+            dirname = args[0]
+            if dirname.startswith(custom_dir):
+                return custom_dir_translations
+            elif dirname.startswith(theme_dir):
+                return theme_dir_translations
+            else:
+                self.fail()
+
+        with mock.patch('mkdocs.localization.Translations.load', side_effect=side_effet):
+            install_translations(self.env, config)
+
+        theme_dir_translations.merge.assert_called_once_with(custom_dir_translations)

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -29,6 +29,7 @@ class ThemeTests(unittest.TestCase):
         )
         self.assertEqual(theme.static_templates, set(['404.html', 'sitemap.xml']))
         self.assertEqual(get_vars(theme), {
+            'locale': 'en',
             'include_search_page': False,
             'search_index_only': False,
             'highlightjs': True,

--- a/mkdocs/themes/mkdocs/404.html
+++ b/mkdocs/themes/mkdocs/404.html
@@ -5,7 +5,7 @@
     <div class="row-fluid">
       <div id="main-content" class="span12">
         <h1 id="404-page-not-found" style="text-align: center">404</h1>
-        <p style="text-align: center"><strong>Page not found</strong></p>
+        <p style="text-align: center"><strong>{% trans %}Page not found{% endtrans %}</strong></p>
       </div>
     </div>
 

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -113,7 +113,7 @@
                         {%- if 'search' in config['plugins'] %}
                         <li class="nav-item">
                             <a href="#" class="nav-link" data-toggle="modal" data-target="#mkdocs_search_modal">
-                                <i class="fa fa-search"></i> Search
+                                <i class="fa fa-search"></i> {% trans %}Search{% endtrans %}
                             </a>
                         </li>
                         {%- endif %}
@@ -123,12 +123,12 @@
                         {%- if page and (page.next_page or page.previous_page) %}
                             <li class="nav-item">
                                 <a rel="prev" {% if page.previous_page %}href="{{ page.previous_page.url|url }}" class="nav-link"{% else %}class="nav-link disabled"{% endif %}>
-                                    <i class="fa fa-arrow-left"></i> Previous
+                                    <i class="fa fa-arrow-left"></i> {% trans %}Previous{% endtrans %}
                                 </a>
                             </li>
                             <li class="nav-item">
                                 <a rel="next" {% if page.next_page %}href="{{ page.next_page.url|url }}" class="nav-link"{% else %}class="nav-link disabled"{% endif %}>
-                                    Next <i class="fa fa-arrow-right"></i>
+                                    {% trans %}Next{% endtrans %} <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>
                         {%- endif %}
@@ -139,13 +139,13 @@
                             <li class="nav-item">
                                 <a href="{{ page.edit_url }}" class="nav-link">
                                     {%- if config.repo_name == 'GitHub' -%}
-                                        <i class="fa fa-github"></i> Edit on {{ config.repo_name }}
+                                        <i class="fa fa-github"></i> {% trans repo_name=config.repo_name %}Edit on {{ repo_name }}{% endtrans %}
                                     {%- elif config.repo_name == 'Bitbucket' -%}
-                                        <i class="fa fa-bitbucket"></i> Edit on {{ config.repo_name }}
+                                        <i class="fa fa-bitbucket"></i> {% trans repo_name=config.repo_name %}Edit on {{ repo_name }}{% endtrans %}
                                     {%- elif config.repo_name == 'GitLab' -%}
-                                        <i class="fa fa-gitlab"></i> Edit on {{ config.repo_name }}
+                                        <i class="fa fa-gitlab"></i> {% trans repo_name=config.repo_name %}Edit on {{ repo_name }}{% endtrans %}
                                     {%- else -%}
-                                    Edit on {{ config.repo_name }}
+                                    {% trans repo_name=config.repo_name %}Edit on {{ repo_name }}{% endtrans %}
                                     {%- endif -%}
                                 </a>
                             </li>
@@ -185,7 +185,7 @@
             {%- if config.copyright %}
                 <p>{{ config.copyright }}</p>
             {%- endif %}
-            <p>Documentation built with <a href="https://www.mkdocs.org/">MkDocs</a>.</p>
+            <p>{% trans mkdocs_link='<a href="https://www.mkdocs.org/">MkDocs</a>' %}Documentation built with {{ mkdocs_link }}.{% endtrans %}</p>
           {%- endblock %}
         </footer>
 

--- a/mkdocs/themes/mkdocs/keyboard-modal.html
+++ b/mkdocs/themes/mkdocs/keyboard-modal.html
@@ -2,33 +2,33 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" id="keyboardModalLabel">Keyboard Shortcuts</h4>
-                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title" id="keyboardModalLabel">{% trans %}Keyboard Shortcuts{% endtrans %}</h4>
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans %}Close{% endtrans %}</span></button>
             </div>
             <div class="modal-body">
               <table class="table">
                 <thead>
                   <tr>
-                    <th style="width: 20%;">Keys</th>
-                    <th>Action</th>
+                    <th style="width: 20%;">{% trans %}Key{% endtrans %}</th>
+                    <th>{% trans %}Action{% endtrans %}</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
                     <td class="help shortcut"><kbd>?</kbd></td>
-                    <td>Open this help</td>
+                    <td>{% trans %}Open this help{% endtrans %}</td>
                   </tr>
                   <tr>
                     <td class="next shortcut"><kbd>n</kbd></td>
-                    <td>Next page</td>
+                    <td>{% trans %}Next page{% endtrans %}</td>
                   </tr>
                   <tr>
                     <td class="prev shortcut"><kbd>p</kbd></td>
-                    <td>Previous page</td>
+                    <td>{% trans %}Previous page{% endtrans %}</td>
                   </tr>
                   <tr>
                     <td class="search shortcut"><kbd>s</kbd></td>
-                    <td>Search</td>
+                    <td>{% trans %}Search{% endtrans %}</td>
                   </tr>
                 </tbody>
               </table>

--- a/mkdocs/themes/mkdocs/locales/en/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/en/LC_MESSAGES/messages.po
@@ -1,0 +1,94 @@
+# English translations for PROJECT.
+# Copyright (C) 2019 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2019-04-14 22:51-0400\n"
+"PO-Revision-Date: 2019-04-14 22:51-0400\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+#: 404.html:8
+msgid "Page not found"
+msgstr ""
+
+#: base.html:116 keyboard-modal.html:31 search-modal.html:5
+msgid "Search"
+msgstr ""
+
+#: base.html:126
+msgid "Previous"
+msgstr ""
+
+#: base.html:131
+msgid "Next"
+msgstr ""
+
+#: base.html:142 base.html:144 base.html:146 base.html:148
+#, python-format
+msgid "Edit on %(repo_name)s"
+msgstr ""
+
+#: base.html:188
+#, python-format
+msgid "Documentation built with %(mkdocs_link)s."
+msgstr ""
+
+#: keyboard-modal.html:5
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: keyboard-modal.html:6 search-modal.html:6
+msgid "Close"
+msgstr ""
+
+#: keyboard-modal.html:12
+msgid "Key"
+msgstr ""
+
+#: keyboard-modal.html:13
+msgid "Action"
+msgstr ""
+
+#: keyboard-modal.html:19
+msgid "Open this help"
+msgstr ""
+
+#: keyboard-modal.html:23
+msgid "Next page"
+msgstr ""
+
+#: keyboard-modal.html:27
+msgid "Previous page"
+msgstr ""
+
+#: search-modal.html:9
+msgid "From here you can search these documents. Enter your search below."
+msgstr ""
+
+#: search-modal.html:12
+msgid "Search..."
+msgstr ""
+
+#: search-modal.html:12
+msgid "Type search term here"
+msgstr ""
+
+#: search-modal.html:15
+msgid "No results found"
+msgstr ""
+
+#: toc.html:3
+msgid "Table of Contents"
+msgstr ""
+

--- a/mkdocs/themes/mkdocs/mkdocs_theme.yml
+++ b/mkdocs/themes/mkdocs/mkdocs_theme.yml
@@ -3,6 +3,8 @@
 static_templates:
     - 404.html
 
+locale: en
+
 include_search_page: false
 search_index_only: false
 

--- a/mkdocs/themes/mkdocs/search-modal.html
+++ b/mkdocs/themes/mkdocs/search-modal.html
@@ -2,20 +2,17 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" id="searchModalLabel">Search</h4>
-                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title" id="searchModalLabel">{% trans %}Search{% endtrans %}</h4>
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans %}Close{% endtrans %}</span></button>
             </div>
             <div class="modal-body">
-                <p>
-                    From here you can search these documents. Enter
-                    your search terms below.
-                </p>
+                <p>{% trans %}From here you can search these documents. Enter your search below.{% endtrans %}</p>
                 <form>
                     <div class="form-group">
-                        <input type="text" class="form-control" placeholder="Search..." id="mkdocs-search-query" title="Type search term here">
+                        <input type="text" class="form-control" placeholder="{% trans %}Search...{% endtrans %}" id="mkdocs-search-query" title="{% trans %}Type search term here{% endtrans %}">
                     </div>
                 </form>
-                <div id="mkdocs-search-results"></div>
+                <div id="mkdocs-search-results" data-no-results-text="{% trans %}No results found{% endtrans %}"></div>
             </div>
             <div class="modal-footer">
             </div>

--- a/mkdocs/themes/mkdocs/toc.html
+++ b/mkdocs/themes/mkdocs/toc.html
@@ -1,6 +1,6 @@
 <div class="navbar-light navbar-expand-md bs-sidebar hidden-print affix" role="complementary">
     <div class="navbar-header">
-        <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#toc-collapse" title="Table of Contents">
+        <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#toc-collapse" title="{% trans %}Table of Contents{% endtrans %}">
             <span class="fa fa-angle-down"></span>
         </button>
     </div>

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     packages=get_packages("mkdocs"),
     include_package_data=True,
     install_requires=[
+        'babel>=2.6.0',
         'click>=3.3',
         'Jinja2>=2.7.1',
         'livereload>=2.5.1',


### PR DESCRIPTION
_&lt;edit&gt;_

### Note from project maintainers:

There are multiple aspects to supporting multiple languages in MkDocs, each of which is linked to from #211, which is the primary issue and ties all of the various aspects together. However, it is best to discuss each aspect in its related issue. 

This issue/PR addresses theme localization (l10n). The templates need to be updated to support translations of the next/previous navigation, page footer, etc.  Volunteers are needed to complete the work as outlined [below](#issuecomment-559211318).

_&lt;/edit&gt;_

Goal: be able to use translations from PyBabel to localize a theme when built.

Before moving forward, I would like some feedback. There's a bit more work to do (mostly add tests). Second commit will be removed/or bonified (note: .mo files need to be generated with `pybabel compile -d locales`). I think translations could be done in a separate PR.

Related with [this comment](https://github.com/mkdocs/mkdocs/issues/211#issuecomment-466420384).