### PR TITLE
Tidy up CSS link formatting

### DIFF
--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -18,15 +18,15 @@
   {%- endblock %}
 
   {%- block styles %}
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700" />
 
-  <link rel="stylesheet" href="{{ 'css/theme.css'|url }}">
-  <link rel="stylesheet" href="{{ 'css/theme_extra.css'|url }}">
+  <link rel="stylesheet" href="{{ 'css/theme.css'|url }}" />
+  <link rel="stylesheet" href="{{ 'css/theme_extra.css'|url }}" />
   {%- if config.theme.highlightjs %}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" />
   {%- endif %}
   {%- for path in config['extra_css'] %}
-  <link href="{{ path|url }}" rel="stylesheet">
+  <link href="{{ path|url }}" rel="stylesheet" />
   {%- endfor %}
   {%- endblock %}
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -18,10 +18,10 @@
   {%- endblock %}
 
   {%- block styles %}
-  <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700">
 
-  <link rel="stylesheet" href="{{ 'css/theme.css'|url }}" type="text/css" />
-  <link rel="stylesheet" href="{{ 'css/theme_extra.css'|url }}" type="text/css" />
+  <link rel="stylesheet" href="{{ 'css/theme.css'|url }}">
+  <link rel="stylesheet" href="{{ 'css/theme_extra.css'|url }}">
   {%- if config.theme.highlightjs %}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">
   {%- endif %}


### PR DESCRIPTION
- no need for `type/css` in HTML5 documents
- having `rel="stylesheet"` first can improve readability/scannability of the code and as it's more consistent aids with gZip compression.
- no need for closing `/` in HTML5 documents

REF:
- http://codeguide.co/  (Bootstrap Styleguide)
- https://google.github.io/styleguide/htmlcssguide.html  (Google Styleguide)