### PR TITLE
Update Travis config for default Python 2.7=>3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - env: TOXENV=markdown-lint
       before_install: npm install -g markdownlint-cli
     - env: TOXENV=linkchecker
+      python: '2.7'
     - env: TOXENV=jshint
       before_install: npm install -g jshint
     - env: TOXENV=csslint

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -48,7 +48,7 @@ class CLITests(unittest.TestCase):
         self.assertTrue('config_file' in kwargs)
         if PY3:
             self.assertIsInstance(kwargs['config_file'], io.BufferedReader)
-        else:
+        else:  # noqa: F821
             self.assertTrue(isinstance(kwargs['config_file'], file))
         self.assertEqual(kwargs['config_file'].name, 'mkdocs.yml')
 
@@ -226,7 +226,7 @@ class CLITests(unittest.TestCase):
         self.assertTrue('config_file' in kwargs)
         if PY3:
             self.assertIsInstance(kwargs['config_file'], io.BufferedReader)
-        else:
+        else:  # noqa: F821
             self.assertTrue(isinstance(kwargs['config_file'], file))
         self.assertEqual(kwargs['config_file'].name, 'mkdocs.yml')
 
@@ -404,7 +404,7 @@ class CLITests(unittest.TestCase):
         self.assertTrue('config_file' in kwargs)
         if PY3:
             self.assertIsInstance(kwargs['config_file'], io.BufferedReader)
-        else:
+        else:  # noqa: F821
             self.assertTrue(isinstance(kwargs['config_file'], file))
         self.assertEqual(kwargs['config_file'].name, 'mkdocs.yml')
 

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -48,8 +48,8 @@ class CLITests(unittest.TestCase):
         self.assertTrue('config_file' in kwargs)
         if PY3:
             self.assertIsInstance(kwargs['config_file'], io.BufferedReader)
-        else:  # noqa: F821
-            self.assertTrue(isinstance(kwargs['config_file'], file))
+        else:
+            self.assertTrue(isinstance(kwargs['config_file'], file))  # noqa: F821
         self.assertEqual(kwargs['config_file'].name, 'mkdocs.yml')
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -226,8 +226,8 @@ class CLITests(unittest.TestCase):
         self.assertTrue('config_file' in kwargs)
         if PY3:
             self.assertIsInstance(kwargs['config_file'], io.BufferedReader)
-        else:  # noqa: F821
-            self.assertTrue(isinstance(kwargs['config_file'], file))
+        else:
+            self.assertTrue(isinstance(kwargs['config_file'], file))  # noqa: F821
         self.assertEqual(kwargs['config_file'].name, 'mkdocs.yml')
 
     @mock.patch('mkdocs.config.load_config', autospec=True)
@@ -404,8 +404,8 @@ class CLITests(unittest.TestCase):
         self.assertTrue('config_file' in kwargs)
         if PY3:
             self.assertIsInstance(kwargs['config_file'], io.BufferedReader)
-        else:  # noqa: F821
-            self.assertTrue(isinstance(kwargs['config_file'], file))
+        else:
+            self.assertTrue(isinstance(kwargs['config_file'], file))  # noqa: F821
         self.assertEqual(kwargs['config_file'].name, 'mkdocs.yml')
 
     @mock.patch('mkdocs.config.load_config', autospec=True)

--- a/mkdocs/utils/ghp_import.py
+++ b/mkdocs/utils/ghp_import.py
@@ -47,12 +47,12 @@ if sys.version_info[0] == 3:
                 raise
 else:
     def enc(text):
-        if isinstance(text, unicode):
+        if isinstance(text, unicode):  # noqa: F821
             return text.encode('utf-8')
         return text
 
     def dec(text):
-        if isinstance(text, unicode):
+        if isinstance(text, unicode):  # noqa: F821
             return text
         return text.decode('utf-8')
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ commands=
     py{27,34,35,36,37,py,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds
 
 [testenv:flake8]
-basepython = python2.7
 deps=-rrequirements/test.txt
 commands={envbindir}/flake8 mkdocs --max-line-length=119
 
@@ -26,7 +25,6 @@ passenv = *
 commands=markdownlint README.md CONTRIBUTING.md docs/
 
 [testenv:linkchecker]
-basepython = python2.7
 passenv=*
 deps=
 	mdx_gh_links

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv = *
 commands=markdownlint README.md CONTRIBUTING.md docs/
 
 [testenv:linkchecker]
+basepython = python2.7
 passenv=*
 deps=
 	mdx_gh_links


### PR DESCRIPTION
Travis has changed their default Python version from 2.7 to 3.6 on April 16, 2019 in anticipation of PY27 support being dropped in 2020. The `basepython` setting isn't nessecary as the tests will run by default in whichever version tox is called from. As we can be sure that version exists on the platform, it is best to use that version and avoids the need for future changes.

This avoids test failures like the [this](https://travis-ci.org/mkdocs/mkdocs/jobs/521064818) and [this](https://travis-ci.org/mkdocs/mkdocs/jobs/521064816).