### PR TITLE
Change 'search.html' in the Read the Docs theme to extend 'main.html'

### DIFF
--- a/mkdocs/themes/readthedocs/search.html
+++ b/mkdocs/themes/readthedocs/search.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "main.html" %}
 
 {% block content %}
 


### PR DESCRIPTION
Simple change to 'search.html' template.

Closes #1791 