### PR TITLE
Provide sensible error message when git not found

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -62,6 +62,7 @@ your global navigation uses more than one level, things will likely be broken.
 * Bugfix: Do not normalize URL fragments (#1655).
 * Bugfix: Skip external URLs in sitemap.xml (#1742).
 * Add canonical tag to `readthedocs` theme (#1669).
+* Improved error message for when `git` is not available.
 
 ## Version 1.0.4 (2018-09-07)
 

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -14,8 +14,12 @@ default_message = """Deployed {sha} with MkDocs version: {version}"""
 
 
 def _is_cwd_git_repo():
-    proc = subprocess.Popen(['git', 'rev-parse', '--is-inside-work-tree'],
+    try:
+        proc = subprocess.Popen(['git', 'rev-parse', '--is-inside-work-tree'],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        log.error("Could not find git - is it installed / on path?")
+        raise SystemExit(1)
     proc.communicate()
     return proc.wait() == 0
 

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -18,7 +18,7 @@ def _is_cwd_git_repo():
         proc = subprocess.Popen(['git', 'rev-parse', '--is-inside-work-tree'],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except FileNotFoundError:
-        log.error("Could not find git - is it installed / on path?")
+        log.error("Could not find git - is it installed and on your path?")
         raise SystemExit(1)
     proc.communicate()
     return proc.wait() == 0

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -17,7 +17,7 @@ def _is_cwd_git_repo():
     try:
         proc = subprocess.Popen(
             ['git', 'rev-parse', '--is-inside-work-tree'],
-            stdout=subprocess.PIPE, 
+            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
     except FileNotFoundError:

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -15,8 +15,11 @@ default_message = """Deployed {sha} with MkDocs version: {version}"""
 
 def _is_cwd_git_repo():
     try:
-        proc = subprocess.Popen(['git', 'rev-parse', '--is-inside-work-tree'],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            ['git', 'rev-parse', '--is-inside-work-tree'],
+            stdout=subprocess.PIPE, 
+            stderr=subprocess.PIPE
+        )
     except FileNotFoundError:
         log.error("Could not find git - is it installed and on your path?")
         raise SystemExit(1)


### PR DESCRIPTION
Currently if you try to run `gh-deploy` without git installed you get a fairly unhelpful backtrace, that will lead you to the thread for #722 if you google it.  This adds a more helpful error message.