### PR TITLE
Fix quotes in TOC not being escaped properly

### DIFF
--- a/mkdocs/structure/toc.py
+++ b/mkdocs/structure/toc.py
@@ -108,7 +108,7 @@ def _parse_html_table_of_contents(html):
                 href = parser.attrs['href']
             except KeyError:
                 continue
-            title = parser.title
+            title = parser.title.replace('"', '&#34;').replace("'", '&#39;')
             nav = AnchorLink(title, href, level)
             # Add the item to its parent if required.  If it is a topmost
             # item then instead append it to our return value.


### PR DESCRIPTION
I was making a site using mkdocs-material, and discovered that invalid HTML was being generated for the title tags used in the Table of Contents. I made a PR (https://github.com/squidfunk/mkdocs-material/pull/1100) to fix this by escaping the variable in the theme, but @squidfunk pointed out that it causes other characters to be double-escaped.

As far as I understand, MkDocs gets data for the TOC by generating one using the Table of Contents extension for Python-Markdown, then parsing the produced HTML to get title and href data to supply to the templates. The issue is that Python-Markdown (in the TOC extension) only escapes the characters `&`, `<`, and `>`, and not quotes `"` and `'` that Jinja normally escapes. For the generated TOC in Python-Markdown this is fine as the title is never put into attributes, but for MkDocs templates the title variable is not fully escaped.

This is only problematic if a theme uses the title variable in an attribute, which is the case for mkdocs-material, but does not occur in the built-in themes.
This may be an issue to submit to Python-Markdown rather than MkDocs, however for Python-Markdown's use case there is no need to escape quotes (as the title is never put into attributes) so it is not a problem there. I think the best way to fix this would be to replace `"` and `'` in the title, as is done in this PR.