### PR TITLE
Initial implementation of local search fix

### DIFF
--- a/docs/shims/fetch_shim.js
+++ b/docs/shims/fetch_shim.js
@@ -1,0 +1,39 @@
+// Simple decorator shim for fetch, which makes the search_index.json file fetchable (ONLY if you enable search:local_search_shim in mkdocs.yml)
+fetch_native = fetch
+fetch = function(url, options){
+
+    // Simple helper to resolve relative url (./search/search_index.json) to absolute (file://C:/Users...)
+    var absolutePath = function(href) {
+        var link = document.createElement("a");
+        link.href = href;
+        absolute = link.href;
+        link.remove();
+        return absolute;
+    }
+
+    // Check if this fetch call is one we need to "intercept"
+    if (absolutePath(url).startsWith("file:") && absolutePath(url).endsWith("search_index.json")) {
+        // If we detect that this IS a call trying to fetch the search index, then...
+        console.log("LOCAL SEARCH SHIM: Detected search_index fetch attempt! Using search index shim for " + url)
+
+        // Return a "forged" object that mimics a normal fetch call's output
+        // This looks messy, but it essentially just slips in the search index wrapped in
+        // all the formatting that normally results from the fetch() call
+        return new Promise(
+            function(resolve, reject){
+              var shimResponse = {
+                  json: function(){
+                  // This should return the search index
+                  return shim_localSearchIndex;
+                }
+              }
+              resolve( shimResponse ) 
+            }
+        )
+    }
+    // In all other cases, behave normally
+    else {
+        console.log("LOCAL SEARCH SHIM: Using native fetch code for " + url)
+        return fetch_native(url, options);
+    }
+}

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -41,6 +41,7 @@ class SearchPlugin(BasePlugin):
         ('lang', LangOption(default=['en'])),
         ('separator', config_options.Type(utils.string_types, default=r'[\s\-]+')),
         ('prebuild_index', config_options.Choice((False, True, 'node', 'python'), default=False)),
+        ('local_search_shim', config_options.Type(bool, default=False))
     )
 
     def on_config(self, config, **kwargs):
@@ -65,9 +66,25 @@ class SearchPlugin(BasePlugin):
     def on_post_build(self, config, **kwargs):
         "Build search index."
         output_base_path = os.path.join(config['site_dir'], 'search')
-        search_index = self.search_index.generate_search_index()
-        json_output_path = os.path.join(output_base_path, 'search_index.json')
-        utils.write_file(search_index.encode('utf-8'), json_output_path)
+
+        if self.config['local_search_shim']:
+            print("INFO    -   local_search_shim Enabled! Make sure you've added shims/fetch_shim.js to your docs folder.")
+            # Change the search_index from being pure JSON to being JavaScript containing a global searchIndex variable with the JSON object we want
+            # Also write it in the traditional format, so that either way works
+            search_index = self.search_index.generate_search_index()
+            search_index_shimmed = "shim_localSearchIndex = " + search_index
+            json_output_path = os.path.join(output_base_path, 'search_index.json')
+            json_output_path_shimmed = os.path.join(output_base_path, 'search_index.js')
+            utils.write_file(search_index.encode('utf-8'), json_output_path)
+            utils.write_file(search_index_shimmed.encode('utf-8'), json_output_path_shimmed)
+        else:
+            # Write the search index only in the traditional way
+            print("INFO    -   local_search_shim disabled. Generating only traditional JSON search index...")
+            search_index = self.search_index.generate_search_index()
+            json_output_path = os.path.join(output_base_path, 'search_index.json')
+            utils.write_file(search_index.encode('utf-8'), json_output_path)
+        
+        
 
         if not ('search_index_only' in config['theme'] and config['theme']['search_index_only']):
             # Include language support files in output. Copy them directly


### PR DESCRIPTION
I use mkdocs at work, and we generally just view the site using file:/// urls, so we have been missing the search function since browser security tightened up. This is a simple fix for that (fixes #871). Here is the summary:

---
By slightly modifying the search plugin in ``mkdocs`` and adding a small JS file to your ``docs`` directory, it's possible to get the search function working in all browsers, even if you open the HTML files directly (a situation which would previously cause cross-site-scripting errors).

### The Problem:

``mkdocs`` search feature relies on a client-side JavaScript search library called ``lunr.js``. Out of the box, the JavaScript that powers the docs site tries to fetch ``search_index.json`` using the HTML5 ``fetch`` API. When viewing the docs site locally (i.e. not via a web server), modern browsers block this fetch request because they think it's cross site scripting.

### The Workaround:

The browser still allows ``.js`` files to be embedded in HTML (via ``<script>`` tags) when viewing the site from your filesystem. It just doesn't allow JavaScript to fetch files from your filesystem programmatically (for security reasons). However, if we change the ``search_index.json`` file to ``search_index.js``, we can turn the JSON file into an executable JavaScript file which sets the search index JSON object as a global variable. See the pseudo-code below:

**Original ``search_index.json``**

```javascript
// Nothing but a big JSON object
{key:value, key:value}
```

**Modified ``search_index.js``**

```javascript
// Just store the big JSON object in a global variable
search_index_shimmed = {key:value, key:value}
```

With these modifications, ``search_index.js`` can be embedded in mkdocs HTML pages just like any other JavaScript, making the search index accessible from the browser (via a global variable instead of via an HTML5 ``fetch`` call).

These modifications can be automated by adjusting the ``mkdocs`` search plugin. The modifications I've made allow you to enable/disable this "shim" from within ``mkdocs.yml``, and it still generates the regular ``search_index.json`` file as well.

```yaml
plugins:
  - search:
      local_search_shim: true # setting this to true tells the search plugin to generate both search_index.json (unmodified) and search_index.js (modified as shown above)
```

### The Last of the Fix

The modifications above solve the problem _almost_ completely. However, the theme (in our case, mkdocs-material) is unaware of these changes, so it's still trying to grab the search index by calling the ``fetch`` function.

The solution is to add another short JavaScript to the site which decorates/wraps the ``fetch`` function. It behaves just like the normal native ``fetch`` code, UNLESS it detects a ``file://`` URL that ends in ``search_index.json``, in which case it "fakes" the expected output of the ``fetch`` command. So no modification to the theme is necessary, because the theme has no idea it's not dealing with the normal ``fetch`` API.

This file looks messy, particularly the return statement, but it only modifies ``fetch``'s behavior in one very specific situation (the only situation that fetch gets used, in our case).

```javascript
// Simple decorator shim for fetch, which makes the search_index.json file fetchable (ONLY if you enable search:local_search_shim in mkdocs.yml)
fetch_native = fetch
fetch = function(url, options){

    // Simple helper to resolve relative url (./search/search_index.json) to absolute (file://C:/Users...)
    var absolutePath = function(href) {
        var link = document.createElement("a");
        link.href = href;
        absolute = link.href;
        link.remove();
        return absolute;
    }

    // Check if this fetch call is one we need to "intercept"
    if (absolutePath(url).startsWith("file:") && absolutePath(url).endsWith("search_index.json")) {
        // If we detect that this IS a call trying to fetch the search index, then...
        console.log("LOCAL SEARCH SHIM: Detected search_index fetch attempt! Using search index shim for " + url)

        // Return a "forged" object that mimics a normal fetch call's output
        // This looks messy, but it essentially just slips in the search index wrapped in
        // all the formatting that normally results from the fetch() call
        return new Promise(
            function(resolve, reject){
              var shimResponse = {
                  json: function(){
                  // This should return the search index
                  return shim_localSearchIndex;
                }
              }
              resolve( shimResponse ) 
            }
        )
    }
    // In all other cases, behave normally
    else {
        console.log("LOCAL SEARCH SHIM: Using native fetch code for " + url)
        return fetch(url, options);
    }
}
```

---

I didn't update the documentation yet because **I have a feeling that using the ``extra_javascript`` directive to add ``search_index.js`` and ``fetch_shim.js`` is unnecessary, but I couldn't find a programmatic way to do that. Please advise.** After that's addressed, I'll be happy to write proper documentation for this modification.