### PR TITLE
Docs: Fix YAML syntax in examples

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -165,14 +165,12 @@ This option can be overridden by a command line option in `gh-deploy`.
 ### nav
 
 This setting is used to determine the format and layout of the global navigation
-for the site. For example, the following would create "Introduction", "User
-Guide" and "About" navigation items.
+for the site. A minimal navigation configuration could look like this:
 
 ```yaml
 nav:
-    - 'Introduction': 'index.md'
-    - 'User Guide': 'user-guide.md'
-    - 'About': 'about.md'
+    - 'index.md'
+    - 'about.md'
 ```
 
 All paths must be relative to the `mkdocs.yml` configuration file. See the
@@ -186,9 +184,9 @@ files is assumed to be an external link.
 
 ```yaml
 nav:
-    - Home: index.md
-    - User Guide: user-guide.md
-    - Bug Tracker: https://example.com/
+    - Introduction: 'index.md'
+    - 'about.md'
+    - 'Issue Tracker': 'https://example.com/'
 ```
 
 In the above example, the first two items point to local files while the third
@@ -202,9 +200,9 @@ the full domain. In that case, you may use and appropriate relative URL.
 site_url: https://example.com/foo/
 
 nav:
-    - Home: ../
-    - User Guide: user-guide.md
-    - Bug Tracker: /bugs/
+    - Home: '../'
+    - 'User Guide': 'user-guide.md'
+    - 'Bug Tracker': '/bugs/'
 ```
 
 In the above example, two different styles of external links are used. First

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -97,12 +97,12 @@ navigation configuration will always be sorted alphanumerically by file name
 will need to manually define your navigation configuration if you would like
 your navigation menu sorted differently.
 
-A simple navigation configuration looks like this:
+A minimal navigation configuration could look like this:
 
 ```no-highlight
 nav:
-- 'index.md'
-- 'about.md'
+    - 'index.md'
+    - 'about.md'
 ```
 
 All paths in the navigation configuration must be relative to the `docs_dir`
@@ -117,8 +117,8 @@ the pages, the title can be added before the filename.
 
 ```no-highlight
 nav:
-- Home: 'index.md'
-- About: 'about.md'
+    - Home: 'index.md'
+    - About: 'about.md'
 ```
 
 Note that if a title is defined for a page in the navigation, that title will be
@@ -130,13 +130,13 @@ section title. For example:
 
 ```no-highlight
 nav:
-- Home: 'index.md'
-- User Guide:
-    - 'Writing your docs': 'writing-your-docs.md'
-    - 'Styling your docs': 'styling-your-docs.md'
-- About:
-    - 'License': 'license.md'
-    - 'Release Notes': 'release-notes.md'
+    - Home: 'index.md'
+    - 'User Guide':
+        - 'Writing your docs': 'writing-your-docs.md'
+        - 'Styling your docs': 'styling-your-docs.md'
+    - About:
+        - 'License': 'license.md'
+        - 'Release Notes': 'release-notes.md'
 ```
 
 With the above configuration we have three top level items: "Home", "User Guide"


### PR DESCRIPTION
The YAML indentation in the examples is wrong.