### PR TITLE
Docs: Clarify supported header style

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -365,10 +365,13 @@ specific page. The following keys are supported:
     1. A title defined in the [nav] configuration setting for a document.
     2. A title defined in the `title` meta-data key of a document.
     3. A level 1 Markdown header on the first line of the document body.
+       Please note that [Setext-style] headers are not supported.
     4. The filename of a document.
 
     Upon finding a title for a page, MkDoc does not continue checking any
     additional sources in the above list.
+
+[Setext-style]: https://daringfireball.net/projects/markdown/syntax#header
 
 #### YAML Style Meta-Data
 


### PR DESCRIPTION
Only atx-style headers are supported for page titles, not Setext styles.

Refs #1837