### PR TITLE
Expose builder to the 'on_serve' hook

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -53,7 +53,7 @@ def _livereload(host, port, config, builder, site_dir):
         server.watch(d, builder)
 
     # Run `serve` plugin events.
-    server = config['plugins'].run_event('serve', server, config=config)
+    server = config['plugins'].run_event('serve', server, config=config, builder=builder)
 
     server.serve(root=site_dir, host=host, port=port, restart_delay=0)
 


### PR DESCRIPTION
This change allows us to add additional files/folders to the `watch` command - the use case specifically here is for our mkdocs plugin which adds support for building documentation in monorepos with multiple `docs/` folders.

The alternative proposal I have is to expose a lambda called `watch` which wraps in `builder` automatically, but I'm happy to adjust as per your feedback.