### PR TITLE
Remove unneeded IE8 polyfills

### DIFF
--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -29,11 +29,6 @@
       {%- endblock %}
 
       {%- block libs %}
-        <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-        <!--[if lt IE 9]>
-            <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-            <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-        <![endif]-->
 
         <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
         <script src="{{ 'js/bootstrap.min.js'|url }}" defer></script>


### PR DESCRIPTION
Bootstrap 4.x doesn't work with IE8 at all.
IE8 marketshare is now just 0.1% anyway (https://caniuse.com/usage-table)