### PR TITLE
Fix to allow an empty `repo_url` when still specifying a `edit_uri`

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -286,7 +286,7 @@ class RepoURL(URL):
         edit_uri = config.get('edit_uri')
 
         # derive repo_name from repo_url if unset
-        if config['repo_url'] is not None and config.get('repo_name') is None:
+        if config['repo_url'] is not '' and config.get('repo_name') is None:
             if repo_host == 'github.com':
                 config['repo_name'] = 'GitHub'
             elif repo_host == 'bitbucket.org':
@@ -297,7 +297,7 @@ class RepoURL(URL):
                 config['repo_name'] = repo_host.split('.')[0].title()
 
         # derive edit_uri from repo_name if unset
-        if config['repo_url'] is not None and edit_uri is None:
+        if config['repo_url'] is not '' and edit_uri is None:
             if repo_host == 'github.com' or repo_host == 'gitlab.com':
                 edit_uri = 'edit/master/docs/'
             elif repo_host == 'bitbucket.org':
@@ -308,6 +308,7 @@ class RepoURL(URL):
         # ensure a well-formed edit_uri
         if edit_uri:
             if not edit_uri.startswith(('?', '#')) \
+                    and config['repo_url'] is not '' \
                     and not config['repo_url'].endswith('/'):
                 config['repo_url'] += '/'
             if not edit_uri.endswith('/'):

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -286,7 +286,7 @@ class RepoURL(URL):
         edit_uri = config.get('edit_uri')
 
         # derive repo_name from repo_url if unset
-        if config['repo_url'] is not '' and config.get('repo_name') is None:
+        if config['repo_url'] != '' and config.get('repo_name') is None:
             if repo_host == 'github.com':
                 config['repo_name'] = 'GitHub'
             elif repo_host == 'bitbucket.org':
@@ -297,7 +297,7 @@ class RepoURL(URL):
                 config['repo_name'] = repo_host.split('.')[0].title()
 
         # derive edit_uri from repo_name if unset
-        if config['repo_url'] is not '' and edit_uri is None:
+        if config['repo_url'] != '' and edit_uri is None:
             if repo_host == 'github.com' or repo_host == 'gitlab.com':
                 edit_uri = 'edit/master/docs/'
             elif repo_host == 'bitbucket.org':
@@ -308,7 +308,7 @@ class RepoURL(URL):
         # ensure a well-formed edit_uri
         if edit_uri:
             if not edit_uri.startswith(('?', '#')) \
-                    and config['repo_url'] is not '' \
+                    and config['repo_url'] != '' \
                     and not config['repo_url'].endswith('/'):
                 config['repo_url'] += '/'
             if not edit_uri.endswith('/'):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -254,6 +254,15 @@ class RepoURLTest(unittest.TestCase):
         option.post_validation(config, 'repo_url')
         self.assertEqual(config.get('edit_uri'), 'edit/master/docs/')
 
+    def test_empty_repo_url_and_edit_url(self):
+
+        option = config_options.RepoURL()
+        config = {'repo_url': '',
+                  'edit_uri': "https://github.com/mkdocs/mkdocs"}
+        option.post_validation(config, 'repo_url')
+        self.assertEqual(config.get('edit_uri'), "https://github.com/mkdocs/mkdocs/")
+        self.assertEqual(config.get('repo_url'), '')
+
 
 class DirTest(unittest.TestCase):
 


### PR DESCRIPTION
Generally with mkdocs you can exclude the link to the code repository by omitting the `repo_url` from the `mkdocs.yml` file.

This does work in most cases. One exception to this is if you also have a `edit_uri` config value.

We have a MKDoc page where we don't specifically want to point a user to a specific repo, but we do want to encourage contributions to the docs.

If we provide an explicit `edit_uri` like `edit_uri: https://github.com/mkdocs/mkdocs/blob/master/docs/` this works as expected even without a `repo_url`.

But, because of some logic in `config_options.py` and with this configuration, `repo_url` ends up being `"/"` which causes our theme to include empty whitespace where the repo link should be (see screenshots).

![Screen Shot 2019-10-02 at 4 50 31 PM](https://user-images.githubusercontent.com/568079/66080778-c6548a00-e534-11e9-9c08-40935490269e.png)

![66017065-3288ac80-e4a7-11e9-8887-d1987d0332e6](https://user-images.githubusercontent.com/568079/66078679-74116a00-e530-11e9-845b-f04f5c731f55.png)

`RepoURL` extends from `URL` which has a default value of `""`. Because of this, it's impossible for `repo_url` to ever be `None`. At most it will be the empty string `""`.

This change modifies `RepoURL` to check for this empty string state instead of `None`, it also adds a test-case for a config with a `edit_uri` and empty `repo_url`.

After the change, the template works as expected:
![Screen Shot 2019-10-02 at 4 51 32 PM](https://user-images.githubusercontent.com/568079/66080879-f2700b00-e534-11e9-8a2f-15801b143735.png)
