### PR TITLE
Fix GitHub project pages link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -353,7 +353,7 @@ the MkDocs IRC channel `#mkdocs` on freenode.
 [nav]: user-guide/configuration/#nav
 [discussion group]: https://groups.google.com/forum/#!forum/mkdocs
 [GitHub issues]: https://github.com/mkdocs/mkdocs/issues
-[GitHub project pages]: https://help.github.com/articles/creating-project-pages-manually/
+[GitHub project pages]: https://help.github.com/articles/creating-a-github-pages-site
 [pip]: https://pip.readthedocs.io/en/stable/installing/
 [Python]: https://www.python.org/
 [site_name]: user-guide/configuration/#site_name


### PR DESCRIPTION
Update the `GitHub project pages` link in the docs to an existing article. The current link takes you to a page that doesn't exit.