### PR TITLE
page.is_homepage evaluates to True only for index.md at route of docs_dir

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -93,7 +93,7 @@ class Page(object):
 
     @property
     def is_homepage(self):
-        return self.is_top_level and self.is_index
+        return self.is_top_level and self.is_index and self.file.url == '.'
 
     @property
     def url(self):


### PR DESCRIPTION
Fixes: https://github.com/mkdocs/mkdocs/issues/1919

Note to reviewers/maintainers: I ran the tests (my version of Python is 3.7) and it looked like they passed, and I tried it on the site where I saw the original issue, and it looked like it fixed it. But I am not a Python dev (or really a developer at all), so I apologize in advance if this isn't a good solution - bit of a learning exercise for me here!