### PR TITLE
Add support for customizing navigation bar styles in the MkDocs theme

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -68,6 +68,7 @@ your global navigation uses more than one level, things will likely be broken.
 * Bugfix: Ensure theme files do not override docs_dir files on Windows (#1876)
 * Add canonical tag to `readthedocs` theme (#1669).
 * Improved error message for when `git` is not available.
+* Add support for `nav_style` theme option for the `mkdocs` theme (#1930).
 
 ## Version 1.0.4 (2018-09-07)
 

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -73,6 +73,14 @@ supports the following options:
 
     * __`search`__: Display the search modal. Default: `83` (s)
 
+* __`nav_style`__: This adjusts the visual style for the top navigation bar; by
+  default, this is set to `primary` (the default), but it can also be set to
+  `dark` or `light`.
+
+        theme:
+            name: mkdocs
+            nav_style: dark
+
 [styles]: https://highlightjs.org/static/demo/
 
 ### readthedocs

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -132,7 +132,8 @@ class ConfigTests(unittest.TestCase):
                         'highlightjs': True,
                         'hljs_style': 'github',
                         'hljs_languages': [],
-                        'shortcuts': {'help': 191, 'next': 78, 'previous': 80, 'search': 83}
+                        'shortcuts': {'help': 191, 'next': 78, 'previous': 80, 'search': 83},
+                        'nav_style': 'primary'
                     }
                 }, {
                     'dirs': [os.path.join(theme_dir, 'readthedocs'), mkdocs_templates_dir],
@@ -194,7 +195,8 @@ class ConfigTests(unittest.TestCase):
                         'highlightjs': True,
                         'hljs_style': 'github',
                         'hljs_languages': [],
-                        'shortcuts': {'help': 191, 'next': 78, 'previous': 80, 'search': 83}
+                        'shortcuts': {'help': 191, 'next': 78, 'previous': 80, 'search': 83},
+                        'nav_style': 'primary'
                     }
                 }
             )

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -34,7 +34,8 @@ class ThemeTests(unittest.TestCase):
             'highlightjs': True,
             'hljs_style': 'github',
             'hljs_languages': [],
-            'shortcuts': {'help': 191, 'next': 78, 'previous': 80, 'search': 83}
+            'shortcuts': {'help': 191, 'next': 78, 'previous': 80, 'search': 83},
+            'nav_style': 'primary'
         })
 
     def test_custom_dir(self):

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -59,8 +59,7 @@
     </head>
 
     <body{% if page and page.is_homepage %} class="homepage"{% endif %}>
-
-        <div class="navbar fixed-top navbar-expand-lg navbar-dark bg-primary">
+        <div class="navbar fixed-top navbar-expand-lg navbar-{% if config.theme.nav_style == "light" %}light{% else %}dark{% endif %} bg-{{ config.theme.nav_style }}">
             <div class="container">
 
                 <!-- Collapsed navigation -->

--- a/mkdocs/themes/mkdocs/mkdocs_theme.yml
+++ b/mkdocs/themes/mkdocs/mkdocs_theme.yml
@@ -9,6 +9,7 @@ search_index_only: false
 highlightjs: true
 hljs_languages: []
 hljs_style: github
+nav_style: primary
 
 shortcuts:
     help: 191    # ?


### PR DESCRIPTION
See also: https://github.com/mkdocs/mkdocs-bootswatch/issues/56

This patch allows documentation authors to configure the color of the navigation bar with one of three options (defined by the Bootswatch theme): `primary` (the default), `dark`, and `light`. This is primarily here to restore support for (what used to be called) inverse nav headers in mkdocs-bootswatch. Without this patch, mkdocs-bootswatch would have to redefine all of `base.html` for each theme to include the changes made here. Since this feature is relevant for the `mkdocs` theme, I figured it made more sense to add it in the base theme.

The Jinja template change is a bit hairy here, but I'm not sure if there's a better way to do it...

Here are some examples of what it looks like with the `mkdocs` theme:

`primary`
![Primary theme](https://user-images.githubusercontent.com/826865/70870246-af271500-1f45-11ea-8278-decdf2b0a211.png)

`dark`
![Dark theme](https://user-images.githubusercontent.com/826865/70870250-ba7a4080-1f45-11ea-89be-3a977c5774d0.png)

`light`
![light](https://user-images.githubusercontent.com/826865/70870255-ca922000-1f45-11ea-87a1-97edbabedfbd.png)
