### PR TITLE
(1.0 only) Fix padding/background color issues with hljs code blocks after #1556

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -111,12 +111,14 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
     white-space: pre;
     word-wrap: normal;
     font-family: monospace,serif;
     font-size: 12px;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {


### PR DESCRIPTION
This is the mkdocs version of https://github.com/mkdocs/mkdocs-bootswatch/pull/55. I noticed this was an issue with the default theme too...

(This doesn't matter for 1.1, since the upgrade to Bootswatch 4 avoids this issue as far as I can tell.)