### PR TITLE
Properly handle the scroll offset for anchors in the mkdocs theme; resolves #1931

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -1,3 +1,9 @@
+html {
+    /* csslint ignore:start */
+    scroll-padding-top: 70px;
+    /* csslint ignore:end */
+}
+
 body {
     padding-top: 70px;
 }
@@ -38,19 +44,6 @@ ul.nav .main {
     border: 1px solid #ddd;
     border-radius: 4px;
     margin: 20px auto 30px auto;
-}
-
-/*
- * The code below adds some padding to the top of the current anchor target so
- * that, when navigating to it, the header isn't hidden by the navbar at the
- * top.
- */
-:target::before {
-    content: "";
-    display: block;
-    margin-top: -75px;
-    height: 75px;
-    pointer-events: none;
 }
 
 h1 {


### PR DESCRIPTION
This patch uses `scroll-padding-top` to indicate that when the user clicks on an anchor and the browser scrolls to it, the anchor should have that amount of padding on the top, thus neatly accommodating the fixed nav header without any gross hacks!

Note: I used a padding of 70px to match the body's padding, rather than 75px as the old CSS hack used. Probably doesn't matter too much either way, but this seems more consistent...