### PR TITLE
Cleanup MarkdownLint issue in docs.

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -510,7 +510,7 @@ blocks without indentation.
 The first line should contain 3 or more backtick (`` ` ``) characters, and the
 last line should contain the same number of backtick characters (`` ` ``):
 
-~~~no-highlight
+````no-highlight
 ```
 Fenced code blocks are like Standard
 Markdown’s regular code blocks, except that
@@ -518,17 +518,17 @@ they’re not indented and instead rely on
 start and end fence lines to delimit the
 code block.
 ```
-~~~
+````
 
 With this approach, the language can optionally be specified on the first line
 after the backticks which informs any syntax highlighters of the language used:
 
-~~~no-highlight
+````no-highlight
 ```python
 def fn():
     pass
 ```
-~~~
+````
 
 Note that fenced code blocks can not be indented. Therefore, they cannot be
 nested inside list items, blockquotes, etc.


### PR DESCRIPTION
You can see the failing test this is supposed to address here: https://travis-ci.org/mkdocs/mkdocs/jobs/627731199#L525

I'm assuming this started to fail due to a recent update to the linter. I believe the old ruby linter we used to use complained that we used a different number of backticks, which is why we previously used tildes to wrap backticks within a code block. The JS linter properly recognizes that you need a different number of backticks to wrap backticks within the code block.