### PR TITLE
Update min dependency to Jinja 2.10.1.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -56,6 +56,8 @@ your global navigation uses more than one level, things will likely be broken.
 
 ### Other Changes and Additions to Version 1.1
 
+* Updated minimum dependancy to Jinja 2.10.1 to address security
+  concerns (#1780).
 * Add support for Python 3.8.
 * Drop support for Python 3.4.
 * Drop support for Python 2.7. MkDocs is PY3 only now (#1926).

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -1,5 +1,5 @@
 click==3.3
-Jinja2==2.7.1
+Jinja2==2.10.1
 livereload==2.5.1
 Markdown==2.5
 PyYAML==3.13

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'click>=3.3',
-        'Jinja2>=2.7.1',
+        'Jinja2>=2.10.1',
         'livereload>=2.5.1',
         'lunr[languages]>=0.5.2',
         'Markdown>=2.3.1',


### PR DESCRIPTION
Jinja 2.10.1 patched a security valnerability. See the release notes here:
https://github.com/pallets/jinja/blob/master/CHANGES.rst#version-2101

Closes #1780.