### PR TITLE
Update min Markdown version to 3.0.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -72,6 +72,7 @@ do, adding `--strict`, `--theme`, `--theme-dir`, and `--site-dir`.
 
 ### Other Changes and Additions to Version 1.1
 
+* Update minimum dependancy to Markdown 3.0.1.
 * Updated minimum dependancy to Jinja 2.10.1 to address security
   concerns (#1780).
 * Add support for Python 3.8.

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -247,6 +247,6 @@ class _RelativePathExtension(Extension):
         self.file = file
         self.files = files
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         relpath = _RelativePathTreeprocessor(self.file, self.files)
-        md.treeprocessors.add("relpath", relpath, "_end")
+        md.treeprocessors.register(relpath, "relpath", 0)

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -1,7 +1,7 @@
 click==3.3
 Jinja2==2.10.1
 livereload==2.5.1
-Markdown==2.5
+Markdown==3.0.1
 PyYAML==3.13
 tornado==4.1
 mdx_gh_links>=0.2

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,7 +1,7 @@
 click>=7.0
 Jinja2>=2.10.3
 livereload>=2.6.1
-Markdown>=3.0.1
+Markdown>=3.1.1
 PyYAML>=5.2
 tornado>=5.1.1
 mdx_gh_links>=0.2

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'Jinja2>=2.10.1',
         'livereload>=2.5.1',
         'lunr[languages]>=0.5.2',
-        'Markdown>=2.3.1',
+        'Markdown>=3.0.1',
         'PyYAML>=3.10',
         'tornado>=5.0'
     ],


### PR DESCRIPTION
This cleans up the last two warnings issued when tests are run from #1434.