### PR TITLE
Links to the MkDocs Plugins wiki page, a few extra links regarding user guide, themes and plugins

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,9 @@ Amazon S3, or [anywhere][deploy] else you choose.
 
 ### Great themes available
 
-There's a stack of good looking themes available for MkDocs. Choose between
+There's a stack of good looking [themes] available for MkDocs. Choose between
 the built in themes: [mkdocs] and [readthedocs], select one of the 3rd
-party themes in the [MkDocs wiki], or [build your own].
+party themes listed on the [MkDocs Themes] wiki page, or [build your own].
 
 ### Preview your site as you work
 
@@ -31,7 +31,7 @@ your changes.
 ### Easy to customize
 
 Get your project documentation looking just the way you want it by customizing
-the theme.
+the [theme] and/or installing some [plugins].
 
 ---
 
@@ -347,7 +347,10 @@ the MkDocs IRC channel `#mkdocs` on freenode.
 [deploy]: user-guide/deploying-your-docs/
 [mkdocs]: user-guide/styling-your-docs/#mkdocs
 [readthedocs]: user-guide/styling-your-docs/#readthedocs
-[MkDocs wiki]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
+[theme]: user-guide/styling-your-docs/
+[themes]: user-guide/styling-your-docs/
+[plugins]: user-guide/plugins/
+[MkDocs Themes]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
 [build your own]: user-guide/custom-themes/
 [Amazon S3]: https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html
 [get-pip.py]: https://bootstrap.pypa.io/get-pip.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,8 @@ Project documentation with&nbsp;Markdown.
 MkDocs is a **fast**, **simple** and **downright gorgeous** static site
 generator that's geared towards building project documentation. Documentation
 source files are written in Markdown, and configured with a single YAML
-configuration file. See the user [guide] for detailed documentation.
+configuration file. Start by reading the introduction below, then check the User
+Guide for more info.
 
 ### Host anywhere
 
@@ -343,7 +344,6 @@ you're done. For specific instructions on a number of common hosts, see the
 To get help with MkDocs, please use the [discussion group], [GitHub issues] or
 the MkDocs IRC channel `#mkdocs` on freenode.
 
-[guide]: user-guide/
 [deploy]: user-guide/deploying-your-docs/
 [mkdocs]: user-guide/styling-your-docs/#mkdocs
 [readthedocs]: user-guide/styling-your-docs/#readthedocs

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Project documentation with&nbsp;Markdown.
 MkDocs is a **fast**, **simple** and **downright gorgeous** static site
 generator that's geared towards building project documentation. Documentation
 source files are written in Markdown, and configured with a single YAML
-configuration file.
+configuration file. See the user [guide] for detailed documentation.
 
 ### Host anywhere
 
@@ -343,6 +343,7 @@ you're done. For specific instructions on a number of common hosts, see the
 To get help with MkDocs, please use the [discussion group], [GitHub issues] or
 the MkDocs IRC channel `#mkdocs` on freenode.
 
+[guide]: user-guide/
 [deploy]: user-guide/deploying-your-docs/
 [mkdocs]: user-guide/styling-your-docs/#mkdocs
 [readthedocs]: user-guide/styling-your-docs/#readthedocs

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -14,7 +14,8 @@ appropriate package name and install it using `pip`:
     pip install mkdocs-foo-plugin
 
 Once a plugin has been successfully installed, it is ready to use. It just needs
-to be [enabled](#using-plugins) in the configuration file.
+to be [enabled](#using-plugins) in the configuration file. The [MkDocs Plugins] 
+wiki page has a growing list of plugins that you can install and use.
 
 ## Using Plugins
 
@@ -412,3 +413,4 @@ tell MkDocs to use if via the config.
 [post_template]: #on_post_template
 [static_templates]: configuration.md#static_templates
 [Template Events]: #template-events
+[MkDocs Plugins]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -14,7 +14,7 @@ appropriate package name and install it using `pip`:
     pip install mkdocs-foo-plugin
 
 Once a plugin has been successfully installed, it is ready to use. It just needs
-to be [enabled](#using-plugins) in the configuration file. The [MkDocs Plugins] 
+to be [enabled](#using-plugins) in the configuration file. The [MkDocs Plugins]
 wiki page has a growing list of plugins that you can install and use.
 
 ## Using Plugins


### PR DESCRIPTION
Since I’ve refactored and extended the MkDocs Plugins wiki page ( https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins ), I thought it’d be a good idea to improve its visibility by adding a link from the docs. I’m also adding a few more links to better connect the introduction with the user guide.