### PR TITLE
Fix fallout from #1967

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -242,9 +242,11 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     text-align: left;
 }
 
-.navbar-collapse.show { /* csslint allow: adjoining-classes */
-    overflow-y: auto;
-    max-height: calc(100vh - 3.5rem);
+@media (max-width: 991.98px) {
+    .navbar-collapse.show { /* csslint allow: adjoining-classes */
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
 }
 
 .dropdown-item.open { /* csslint allow: adjoining-classes */


### PR DESCRIPTION
Previously, opening a dropdown from the mobile-sized nav header would break things if the user resized the window to be desktop-sized again. This was due to an attempted fix to allow the mobile-sized nav header to scroll when it had many elements.

This patch now only does that when the header is in mobile mode.