### PR TITLE
Add link to README to contributing.md

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -10,6 +10,10 @@ ways, a few examples are:
 - Documentation improvements
 - Bug reports and patch reviews
 
+For information about available communication channels please refer to the
+[README](https://github.com/mkdocs/mkdocs/blob/master/README.md) file in our
+GitHub repository.
+
 ## Code of Conduct
 
 Everyone interacting in the MkDocs project's codebases, issue trackers, chat


### PR DESCRIPTION
In https://github.com/mkdocs/mkdocs/issues/1972#issuecomment-582952604
I was pointed to the README, but I hadn't looked for contact information there.
I think looking on the website is a reasonable way, and pointing to the README
from the "Contributing" page looks like a good help to me.