### PR TITLE
Fix indent width in mkdocs/themes/mkdocs/css/base.css

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -191,7 +191,7 @@ footer {
 }
 
 .bs-sidebar .nav .nav .nav {
-  margin-left: 1em;
+    margin-left: 1em;
 }
 
 .bs-sidebar .nav > li > a {


### PR DESCRIPTION
This is a tiny fix. It's only really here to keep this file somewhat in sync with its counterparts in mkdocs-bootswatch. That way, most changes to base.css can be applied automatically. :)