### PR TITLE
Put the mobile menu button for the mkdocs theme on the right

### DIFF
--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -62,19 +62,16 @@
         <div class="navbar fixed-top navbar-expand-lg navbar-{% if config.theme.nav_style == "light" %}light{% else %}dark{% endif %} bg-{{ config.theme.nav_style }}">
             <div class="container">
 
-                <!-- Collapsed navigation -->
-                <div class="navbar-header">
-                    {%- if nav|length>1 or (page and (page.next_page or page.previous_page)) or config.repo_url %}
-                    <!-- Expander button -->
-                    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar-collapse">
-                        <span class="navbar-toggler-icon"></span>
-                    </button>
-                    {%- endif %}
+                {%- block site_name %}
+                <a class="navbar-brand" href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
+                {%- endblock %}
 
-                  {%- block site_name %}
-                    <a class="navbar-brand" href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
-                  {%- endblock %}
-                </div>
+                {%- if nav|length>1 or (page and (page.next_page or page.previous_page)) or config.repo_url %}
+                <!-- Expander button -->
+                <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar-collapse">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                {%- endif %}
 
                 <!-- Expanded navigation -->
                 <div id="navbar-collapse" class="navbar-collapse collapse">


### PR DESCRIPTION
This behavior matches MkDocs 1.0 as well as the examples on the Bootswatch site. The HTML just needed a bit of re-arranging to match how Bootswatch expects things to be. I tested this with the base `mkdocs` theme as well as the `mkdocs-bootswatch` themes.

(The white background for the dropdowns is a bit ugly in my opinion, but it's how things look in the Bootswatch demos...)

Before:
![left](https://user-images.githubusercontent.com/826865/75082788-33f45900-54ca-11ea-8694-1f892252cd2f.png)

After:
![right](https://user-images.githubusercontent.com/826865/75082799-3f478480-54ca-11ea-8ddc-03d5f16a8bcc.png)

