### PR TITLE
Ensure lunr.py version matches lunr.js

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'click>=3.3',
         'Jinja2>=2.10.1',
         'livereload>=2.5.1',
-        'lunr[languages]>=0.5.2',
+        'lunr[languages]==0.5.6',  # must match lunr.js version included in search
         'Markdown>=3.2.1',
         'PyYAML>=3.10',
         'tornado>=5.0'


### PR DESCRIPTION
Each version of lunr.py only works with a specific version of lunr.js.
Therefore we must hardcode the specific version of lunr.py in our
requirements. As we recently updated to lunr.js version 2.3.8 (#1995),
that coincides with lunr.py version 0.5.6. See the lunr.py CHANGELOG for
coinciding versions: https://github.com/yeraydiazdiaz/lunr.py/blob/master/CHANGELOG.md