### PR TITLE
Fix a minimum dependency description of Markdown at the release note

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -80,7 +80,7 @@ may be removed in a future version of MkDocs.
 ### Other Changes and Additions to Version 1.1
 
 * Bugfix: Ensure nested dot files in themes are ignored and document behavior (#1981).
-* Update minimum dependancy to Markdown 3.0.1.
+* Update minimum dependancy to Markdown 3.2.1.
 * Updated minimum dependancy to Jinja 2.10.1 to address security
   concerns (#1780).
 * Update to lunr.js 2.3.8 (#1989).


### PR DESCRIPTION
The release note describes:

>* Update minimum dependancy to Markdown 3.0.1.

However, the actual minimum dependency of Markdown package at mkdocs 1.1 is 3.2.1.

https://github.com/mkdocs/mkdocs/blob/eddeeab066cb071dbe426878a85de715df1b93e7/requirements/project.txt#L4

