### PR TITLE
Release a public docker image on docker hub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.8.2-alpine3.11
+
+ARG BUILD_DATE
+ARG SOURCE_BRANCH
+ARG SOURCE_COMMIT
+
+RUN pip install mkdocs=="${SOURCE_BRANCH}"
+
+# Default exposed port by 'mkdocs serve' command
+EXPOSE 8000
+
+ENTRYPOINT [ "/usr/local/bin/mkdocs" ]
+CMD [ "--help" ]
+
+LABEL \
+    org.label-schema.build-date="${BUILD_DATE}" \
+    org.label-schema.name="mkdocs" \
+    org.label-schema.description="Project documentation with Markdown." \
+    org.label-schema.vcs-url="https://github.com/mkdocs/mkdocs" \
+    org.label-schema.vcs-ref="${SOURCE_COMMIT}" \
+    org.label-schema.version="${SOURCE_BRANCH}" \
+    org.label-schema.schema-version="1.0"

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+docker build \
+	--build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+	--build-arg SOURCE_BRANCH="${SOURCE_BRANCH}" \
+	--build-arg SOURCE_COMMIT="${SOURCE_COMMIT}" \
+	--file "${DOCKERFILE_PATH}" \
+	--tag "${IMAGE_NAME}" \
+	.


### PR DESCRIPTION
I saw few non-official mkdocs docker image and I think that it can be a good idea to have one.

For the moment, I have made a simple start :
- Automatically built image on Docker Hub's infrastructure
- Image built on each git tag
- [label schema](http://label-schema.org/) compliant

I used my personal account to produce a poc :
https://hub.docker.com/r/lvjp/mkdocs

The only setting I have done is to add this building rule :

 Name | Value 
------ | ---------
Source type | Tag
Source | /^[0-9.]+.*$/
Docker tag | {sourceref}
Build context | /docker
Autobuild | On
Build Caching | Off