### PR TITLE
Support for minimum search length configuration parameter.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -25,6 +25,7 @@ The current and past members of the MkDocs team.
 
 Bugfix: Ensure wheel is Python 3 only.
 Bugfix: Clean up `dev_addr` validation and disallow `0.0.0.0`.
+Add support for `min_search_length` parameter for search plugin (#2014).
 
 ## Version 1.1 (2020-02-22)
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -506,8 +506,9 @@ plugins:
 
 An integer value that defines the minimum length for a search query. By default
 searches shorter than 3 chars in length are ignored as search result quality with
-short search terms is poor. However, for some use cases (e.g. searching for 'MQ') 
-it may be preferable to set a shorter limit.
+short search terms is poor. However, for some use cases (such as documentation
+about Message Queues which might generate searches for 'MQ') it may be preferable
+to set a shorter limit.
 
 ```yaml
 plugins:

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -502,6 +502,21 @@ plugins:
 
   **default**: `'[\s\-]+'`
 
+##### **min_search_length**
+
+An integer value that defines the minimum length for a search query. By default
+searches shorter than 3 chars in length are ignored as search result quality with
+short search terms is poor. However, for some use cases (e.g. searching for 'MQ') 
+it may be preferable to set a shorter limit.
+
+```yaml
+plugins:
+    - search:
+        min_search_length: 2
+```
+
+  **default**: 3
+
 ##### **lang**
 
 A list of languages to use when building the search index as identified by their

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -36,6 +36,7 @@ class SearchPlugin(BasePlugin):
     config_scheme = (
         ('lang', LangOption(default=['en'])),
         ('separator', config_options.Type(str, default=r'[\s\-]+')),
+        ('min_search_length', config_options.Type(int, default=3)),
         ('prebuild_index', config_options.Choice((False, True, 'node', 'python'), default=False)),
     )
 

--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -43,7 +43,7 @@ function displayResults (results) {
 
 function doSearch () {
   var query = document.getElementById('mkdocs-search-query').value;
-  if (query.length > 2) {
+  if (query.length > min_search_length) {
     if (!window.Worker) {
       displayResults(search(query));
     } else {
@@ -73,6 +73,9 @@ function onWorkerMessage (e) {
   } else if (e.data.results) {
     var results = e.data.results;
     displayResults(results);
+  } else if (e.data.config) {
+    min_search_length = e.data.config.min_search_length-1
+    console.log(min_search_length)
   }
 }
 

--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -74,8 +74,7 @@ function onWorkerMessage (e) {
     var results = e.data.results;
     displayResults(results);
   } else if (e.data.config) {
-    min_search_length = e.data.config.min_search_length-1
-    console.log(min_search_length)
+    min_search_length = e.data.config.min_search_length-1;
   }
 }
 

--- a/mkdocs/contrib/search/templates/search/worker.js
+++ b/mkdocs/contrib/search/templates/search/worker.js
@@ -58,6 +58,7 @@ function onScriptsLoaded () {
   if (data.config && data.config.separator && data.config.separator.length) {
     lunr.tokenizer.separator = new RegExp(data.config.separator);
   }
+
   if (data.index) {
     index = lunr.Index.load(data.index);
     data.docs.forEach(function (doc) {
@@ -84,6 +85,7 @@ function onScriptsLoaded () {
     console.log('Lunr index built, search ready');
   }
   allowSearch = true;
+  postMessage({config: data.config});
   postMessage({allowSearch: allowSearch});
 }
 

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -58,6 +58,7 @@ class SearchPluginTests(unittest.TestCase):
         expected = {
             'lang': ['en'],
             'separator': r'[\s\-]+',
+            'min_search_length': 3,
             'prebuild_index': False
         }
         plugin = search.SearchPlugin()
@@ -70,6 +71,7 @@ class SearchPluginTests(unittest.TestCase):
         expected = {
             'lang': ['es'],
             'separator': r'[\s\-]+',
+            'min_search_length': 3,
             'prebuild_index': False
         }
         plugin = search.SearchPlugin()
@@ -82,6 +84,7 @@ class SearchPluginTests(unittest.TestCase):
         expected = {
             'lang': ['en'],
             'separator': r'[\s\-\.]+',
+            'min_search_length': 3,
             'prebuild_index': False
         }
         plugin = search.SearchPlugin()
@@ -90,10 +93,24 @@ class SearchPluginTests(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertEqual(warnings, [])
 
+    def test_plugin_config_min_search_length(self):
+        expected = {
+            'lang': ['en'],
+            'separator': r'[\s\-]+',
+            'min_search_length': 2,
+            'prebuild_index': False
+        }
+        plugin = search.SearchPlugin()
+        errors, warnings = plugin.load_config({'min_search_length': 2})
+        self.assertEqual(plugin.config, expected)
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
     def test_plugin_config_prebuild_index(self):
         expected = {
             'lang': ['en'],
             'separator': r'[\s\-]+',
+            'min_search_length': 3,
             'prebuild_index': True
         }
         plugin = search.SearchPlugin()


### PR DESCRIPTION
As mentioned in [issue 2014](https://github.com/mkdocs/mkdocs/issues/2014), searching for any term of less than 3 characters will give the user back a message saying 'No results found' - This is misleading as results may have been present, but due to a hardcoded limit on minimum search length the search was not actually performed.

This PR implements an additional config parameter `min_search_length` for the search plugin.
