### PR TITLE
Correct the block name of the search box in the doc

### DIFF
--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -299,7 +299,7 @@ following blocks:
 * `extrahead`: An empty block in the `<head>` to insert custom tags/scripts/etc.
 * `site_name`: Contains the site name in the navigation bar.
 * `site_nav`: Contains the site navigation in the navigation bar.
-* `search_box`: Contains the search box in the navigation bar.
+* `search_button`: Contains the search box in the navigation bar.
 * `next_prev`: Contains the next and previous buttons in the navigation bar.
 * `repo`: Contains the repository link in the navigation bar.
 * `content`: Contains the page content and table of contents for the page.


### PR DESCRIPTION
As mentionned here: https://github.com/mkdocs/mkdocs/issues/1142#issuecomment-282899537
I just correct the name in the documentation