### PR TITLE
Ensure bdist_wheel no longer creates a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
MkDocs no longer supports Python 2. Therefore, a universal wheel would be
inappropriate as it results in `py2.py3`.

See Python-Markdown/markdown#919.