### PR TITLE
 Disallow 0.0.0.0 dev_addr.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,11 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Version 1.1.1 (in development)
+
+Bugfix: Ensure wheel is Python 3 only.
+Bugfix: Clean up `dev_addr` validation and disallow `0.0.0.0`.
+
 ## Version 1.1 (2020-02-22)
 
 ### Major Additions to Version 1.1

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1,6 +1,7 @@
 import os
 from collections import Sequence, namedtuple
 from urllib.parse import urlparse
+import ipaddress
 import markdown
 
 from mkdocs import utils, theme, plugins
@@ -232,6 +233,11 @@ class IpAddress(OptionallyRequired):
             host, port = value.rsplit(':', 1)
         except Exception:
             raise ValidationError("Must be a string of format 'IP:PORT'")
+
+        try:
+            ipaddress.ip_address(host)
+        except ValueError as e:
+            raise ValidationError(e)
 
         try:
             port = int(port)

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -244,6 +244,15 @@ class IpAddress(OptionallyRequired):
 
         return Address(host, port)
 
+    def post_validation(self, config, key_name):
+        host = config[key_name].host
+        if key_name == 'dev_addr' and host == '0.0.0.0':
+            raise ValidationError(
+                ("The MkDocs' server is intended for development purposes only. "
+                "Therefore, '{}' is not a supported IP address. Please use a "
+                "third party production-ready server instead.").format(host)
+            )
+
 
 class URL(OptionallyRequired):
     """

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -234,10 +234,12 @@ class IpAddress(OptionallyRequired):
         except Exception:
             raise ValidationError("Must be a string of format 'IP:PORT'")
 
-        try:
-            ipaddress.ip_address(host)
-        except ValueError as e:
-            raise ValidationError(e)
+
+        if host != 'localhost':
+            try:
+                ipaddress.ip_address(host)
+            except ValueError as e:
+                raise ValidationError(e)
 
         try:
             port = int(port)
@@ -252,11 +254,11 @@ class IpAddress(OptionallyRequired):
 
     def post_validation(self, config, key_name):
         host = config[key_name].host
-        if key_name == 'dev_addr' and host == '0.0.0.0':
+        if key_name == 'dev_addr' and host in ('0.0.0.0', '::'):
             raise ValidationError(
                 ("The MkDocs' server is intended for development purposes only. "
-                "Therefore, '{}' is not a supported IP address. Please use a "
-                "third party production-ready server instead.").format(host)
+                 "Therefore, '{}' is not a supported IP address. Please use a "
+                 "third party production-ready server instead.").format(host)
             )
 
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -234,7 +234,6 @@ class IpAddress(OptionallyRequired):
         except Exception:
             raise ValidationError("Must be a string of format 'IP:PORT'")
 
-
         if host != 'localhost':
             try:
                 ipaddress.ip_address(host)
@@ -254,7 +253,7 @@ class IpAddress(OptionallyRequired):
 
     def post_validation(self, config, key_name):
         host = config[key_name].host
-        if key_name == 'dev_addr' and host in ('0.0.0.0', '::'):
+        if key_name == 'dev_addr' and host in ['0.0.0.0', '::']:
             raise ValidationError(
                 ("The MkDocs' server is intended for development purposes only. "
                  "Therefore, '{}' is not a supported IP address. Please use a "

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -131,6 +131,13 @@ class IpAddressTest(unittest.TestCase):
         self.assertEqual(value.host, '127.0.0.1')
         self.assertEqual(value.port, 8000)
 
+    def test_invalid_address_range(self):
+        option = config_options.IpAddress()
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, '227.0.0.1:8000'
+        )
+
     def test_invalid_address_format(self):
         option = config_options.IpAddress()
         self.assertRaises(
@@ -157,6 +164,20 @@ class IpAddressTest(unittest.TestCase):
         self.assertRaises(
             config_options.ValidationError,
             option.validate, '127.0.0.1'
+        )
+
+    def test_disallowed_address(self):
+        option = config_options.IpAddress()
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, '0.0.0.0:8000'
+        )
+
+    def test_disallowed_IPv6_address(self):
+        option = config_options.IpAddress()
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, '[::]:8000'
         )
 
 

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -105,12 +105,12 @@ class IpAddressTest(unittest.TestCase):
         self.assertEqual(value.port, 8000)
 
     def test_valid_IPv6_address(self):
-        addr = '[::1]:8000'
+        addr = '::1:8000'
 
         option = config_options.IpAddress()
         value = option.validate(addr)
         self.assertEqual(str(value), addr)
-        self.assertEqual(value.host, '[::1]')
+        self.assertEqual(value.host, '::1')
         self.assertEqual(value.port, 8000)
 
     def test_named_address(self):
@@ -135,7 +135,7 @@ class IpAddressTest(unittest.TestCase):
         option = config_options.IpAddress()
         self.assertRaises(
             config_options.ValidationError,
-            option.validate, '227.0.0.1:8000'
+            option.validate, '277.0.0.1:8000'
         )
 
     def test_invalid_address_format(self):
@@ -168,16 +168,30 @@ class IpAddressTest(unittest.TestCase):
 
     def test_disallowed_address(self):
         option = config_options.IpAddress()
+        value = option.validate('0.0.0.0:8000')
         self.assertRaises(
             config_options.ValidationError,
-            option.validate, '0.0.0.0:8000'
+            option.post_validation,
+            {'dev_addr': value},
+            'dev_addr'
         )
 
     def test_disallowed_IPv6_address(self):
         option = config_options.IpAddress()
+        value = option.validate(':::8000')
         self.assertRaises(
             config_options.ValidationError,
-            option.validate, '[::]:8000'
+            option.post_validation,
+            {'dev_addr': value},
+            'dev_addr'
+        )
+
+    def test_invalid_IPv6_address(self):
+        # The server will error out with this so we treat it as invalid.
+        option = config_options.IpAddress()
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, '[::1]:8000'
         )
 
 

--- a/mkdocs/tests/integration/complicated_config/mkdocs.yml
+++ b/mkdocs/tests/integration/complicated_config/mkdocs.yml
@@ -21,7 +21,7 @@ theme:
 
 copyright: "Dougal Matthews"
 google_analytics: ["1", "2"]
-dev_addr: 0.0.0.0:8000
+dev_addr: ::1:8000
 use_directory_urls: false
 
 repo_url: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/tests/integration


### PR DESCRIPTION
MkDocs has never supported using the included server for production.
However, some users have been using it that way. This would prevent that.

Still needs proper tests. However, a quick test on the command line produces these results:

```
λ mkdocs serve -a 0.0.0.0:8000
INFO    -  Building documentation...
ERROR   -  Config value: 'dev_addr'. Error: The MkDocs' server is intended for 
development purposes only. Therefore, '0.0.0.0' is not a supported IP address.
Please use a third party production-ready server instead.

Aborted with 1 Configuration Errors!
λ mkdocs serve -a 277.0.0.0:8000
INFO    -  Building documentation...
ERROR   -  Config value: 'dev_addr'. Error: '277.0.0.0' does not appear to be an
IPv4 or IPv6 address

Aborted with 1 Configuration Errors!
```