### PR TITLE
fix #2027 code colors

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -26,6 +26,7 @@ The current and past members of the MkDocs team.
 Bugfix: Ensure wheel is Python 3 only.
 Bugfix: Clean up `dev_addr` validation and disallow `0.0.0.0`.
 Add support for `min_search_length` parameter for search plugin (#2014).
+Bugfix: Code colors (#2027).
 
 ## Version 1.1 (2020-02-22)
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -26,7 +26,7 @@ The current and past members of the MkDocs team.
 Bugfix: Ensure wheel is Python 3 only.
 Bugfix: Clean up `dev_addr` validation and disallow `0.0.0.0`.
 Add support for `min_search_length` parameter for search plugin (#2014).
-Bugfix: Code colors (#2027).
+Bugfix: `readthedocs` theme `code` colors (#2027).
 
 ## Version 1.1 (2020-02-22)
 

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -28,6 +28,20 @@
   font-size: 12px;
 }
 
+/**
+ * Fix code colors
+ *
+ * https://github.com/mkdocs/mkdocs/issues/2027
+ */
+.rst-content code {
+    color: #E74C3C;
+}
+
+.rst-content pre code {
+    color: #000;
+    background: #f8f8f8;
+}
+
 /*
  * Fix link colors when the link text is inline code.
  *


### PR DESCRIPTION
Some CSS overrides. See images for Sphinx, mkdocs 1.0.4 and mkdocs 1.1 (without/with PR) comparison.

## sphinx-2.4.4+rtd-0.4.3

![sphinx-2 4 4+rtd-0 4 3](https://user-images.githubusercontent.com/882353/77235352-31624d80-6bb5-11ea-981a-fa34bc4f62b0.png)

## mkdocs-1.0.4

![mkdocs-1 0 4](https://user-images.githubusercontent.com/882353/77235355-38895b80-6bb5-11ea-9ed1-d3f3455183bb.png)

## mkdocs-1.1

![mkdocs-1 1](https://user-images.githubusercontent.com/882353/77235357-3c1ce280-6bb5-11ea-8ac7-cc1f6c8fe8eb.png)

## mkdocs-1.1+PR

![mkdocs-1 1+PR](https://user-images.githubusercontent.com/882353/77235359-3e7f3c80-6bb5-11ea-9b77-d3ac0e209048.png)
