### PR TITLE
Correct error message

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -370,8 +370,8 @@ class Dir(FilesystemObject):
         # Validate that the dir is not the parent dir of the config file.
         if os.path.dirname(config.config_file_path) == config[key_name]:
             raise ValidationError(
-                ("The '{}' should not be the parent directory of the config "
-                 "file. Use a child directory instead so that the config file "
+                ("The '{0}' should not be the parent directory of the config "
+                 "file. Use a child directory instead so that the '{0}' "
                  "is a sibling of the config file.").format(key_name))
 
 


### PR DESCRIPTION
If the config file was inside the docs dir, mkdocs would give a
confusing error:

    config value: 'docs_dir'. Error: The 'docs_dir' should not be the parent directory of the config file. Use a child directory instead so that the config file is a sibling of the config file.

The last part of that message now reads:

    Use a child directory instead so that the 'docs_dir' is a sibling of the config file.

Fixes https://github.com/mkdocs/mkdocs/issues/2009