### PR TITLE
Adds --page-type option when deploying using gh-deploy

### DIFF
--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -43,34 +43,23 @@ files locally.
 
 ### Organization and User Pages
 
-User and Organization Pages sites are not tied to a specific project, and the
-site files are deployed to the `master` branch in a dedicated repository named
-with the GitHub account name. Therefore, you need working copies of two
-repositories on our local system. For example, consider the following file
-structure:
+GitHub Pages also allows users to create [User and Organization Pages sites](https://help.github.com/en/github/working-with-github-pages/about-github-pages#types-of-github-pages-sites)
+that are not tied to a specific project. Rather, the site files are deployed to the
+`master` branch in a dedicated repository named with the GitHub account name,
+i.e. `<user>.github.io` or `<org>.github.io`.
 
-```no-highlight
-my-project/
-    mkdocs.yml
-    docs/
-orgname.github.io/
-```
-
-After making and verifying updates to your project you need to change
-directories to the `orgname.github.io` repository and call the
-`mkdocs gh-deploy` command from there:
+After making and verifying updates to a dedicated user or organization repository on
+its `master` branch, call `mkdocs gh-deploy` in the command line and specify the site
+type with the `--page-type` option. Inputs for this option include 'user', 'org', or
+'project'. For example, to create a user-specific site enter:
 
 ```sh
-cd ../orgname.github.io/
-mkdocs gh-deploy --config-file ../my-project/mkdocs.yml --remote-branch master
+mkdocs gh-deploy --remote-branch master --page-type user
 ```
 
-Note that you need to explicitly point to the `mkdocs.yml` configuration file as
-it is no longer in the current working directory. You also need to inform the
-deploy script to commit to the `master` branch. You may override the default
-with the [remote_branch] configuration setting, but if you forget to change
-directories before running the deploy script, it will commit to the `master`
-branch of your project, which you probably don't want.
+Note that you need to inform the deploy script to commit to the `master` branch rather
+than the default `gh-pages` branch. The command above should result in your docs being
+deployed to `https://<user.github.io>`.
 
 Be aware that you will not be able to review the built site before it is pushed
 to GitHub. Therefore, you may want to verify any changes you make to the docs

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -43,23 +43,24 @@ files locally.
 
 ### Organization and User Pages
 
-GitHub Pages also allows users to create [User and Organization Pages sites](https://help.github.com/en/github/working-with-github-pages/about-github-pages#types-of-github-pages-sites)
-that are not tied to a specific project. Rather, the site files are deployed to the
-`master` branch in a dedicated repository named with the GitHub account name,
-i.e. `<user>.github.io` or `<org>.github.io`.
+GitHub Pages also allows users to create User and Organization Pages sites
+that are not tied to a specific project. Rather, the site files are deployed to
+the `master` branch in a dedicated repository named with the GitHub account
+name, i.e. `<user>.github.io` or `<org>.github.io`.
 
-After making and verifying updates to a dedicated user or organization repository on
-its `master` branch, call `mkdocs gh-deploy` in the command line and specify the site
-type with the `--page-type` option. Inputs for this option include 'user', 'org', or
-'project'. For example, to create a user-specific site enter:
+After making and verifying updates to a dedicated user or organization
+repository on its `master` branch, call `mkdocs gh-deploy` in the
+command line and specify the site type with the `--page-type` option.
+Inputs for this option include 'user', 'org', or'project'. For example,
+to create a user-specific site enter:
 
 ```sh
 mkdocs gh-deploy --remote-branch master --page-type user
 ```
 
-Note that you need to inform the deploy script to commit to the `master` branch rather
-than the default `gh-pages` branch. The command above should result in your docs being
-deployed to `https://<user.github.io>`.
+Note that you need to inform the deploy script to commit to the `master` branch
+rather than the default `gh-pages` branch. The command above should result in
+your docs being deployed to `https://<user.github.io>`.
 
 Be aware that you will not be able to review the built site before it is pushed
 to GitHub. Therefore, you may want to verify any changes you make to the docs

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -55,7 +55,7 @@ Markdown files with HTML files, you need *two* working repositories
 installed locally. For example, consider the following file
 structure:
 
-```
+```no-highlight
 my-project/
     mkdocs.yml
     docs/

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -43,24 +43,50 @@ files locally.
 
 ### Organization and User Pages
 
-GitHub Pages also allows users to create User and Organization Pages sites
-that are not tied to a specific project. Rather, the site files are deployed to
-the `master` branch in a dedicated repository named with the GitHub account
-name, i.e. `<user>.github.io` or `<org>.github.io`.
+GitHub also allows users to create User and Organization Pages sites
+that are not tied to a specific project. Rather, the site files are deployed 
+from the `master` branch in a dedicated repository named with the GitHub
+account name, i.e. `<user>.github.io` or `<org>.github.io`.
 
-After making and verifying updates to a dedicated user or organization
-repository on its `master` branch, call `mkdocs gh-deploy` in the
-command line and specify the site type with the `--page-type` option.
-Inputs for this option include 'user', 'org', or'project'. For example,
-to create a user-specific site enter:
+However, because Github requires user and organization pages to be
+deployed from the `master` branch of the `<user>.github.io` repo
+and deploying from this same `master` branch would overwrite all
+Markdown files with HTML files, you need *two* working repositories
+installed locally. For example, consider the following file 
+structure:
 
-```sh
-mkdocs gh-deploy --remote-branch master --page-type user
+```
+my-project/
+    mkdocs.yml
+    docs/
+orgname.github.io/
 ```
 
-Note that you need to inform the deploy script to commit to the `master` branch
-rather than the default `gh-pages` branch. The command above should result in
-your docs being deployed to `https://<user.github.io>`.
+The first repository, `my-project`, is for developing your Markdown
+documents and adding to your `mkdocs.yml` file. The second
+repository, `orgname.github.io`, is exclusively for deployment of
+your organization or user site and contains all of the HTML files
+that make up your static site.
+
+After making and verifying updates to the `my-project` repository
+on its `master` branch, change directories to the `orgname.github.io`
+and call the following in the command line:
+
+```sh
+cd ../orgname.github.io/
+mkdocs gh-deploy --config-file ../my-project/mkdocs.yml --page-type org
+```
+Note that you need to explicitly point to the mkdocs.yml configuration 
+file as it is no longer in the current working directory. 
+Additionally, note that you should specify the site type with the 
+`--page-type` option. Inputs for this option include 'user', 'org', or 
+'project', with the default being the latter.
+
+Lastly, be aware that mkdocs automatically deploys from the `master`
+branch when `--page-type` is `user` or `org`. This is different from
+the default `gh-pages` branch that is deployed when using the
+`project` option. The command above should result inyour docs being 
+deployed to `https://<org>.github.io`.
 
 Be aware that you will not be able to review the built site before it is pushed
 to GitHub. Therefore, you may want to verify any changes you make to the docs

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -76,6 +76,7 @@ and call the following in the command line:
 cd ../orgname.github.io/
 mkdocs gh-deploy --config-file ../my-project/mkdocs.yml --page-type org
 ```
+
 Note that you need to explicitly point to the mkdocs.yml configuration
 file as it is no longer in the current working directory.
 Additionally, note that you should specify the site type with the

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -43,17 +43,17 @@ files locally.
 
 ### Organization and User Pages
 
-GitHub also allows users to create User and Organization Pages sites
+GitHub also allows users to create User and Organization Pages sites 
 that are not tied to a specific project. Rather, the site files are deployed 
-from the `master` branch in a dedicated repository named with the GitHub
-account name, i.e. `<user>.github.io` or `<org>.github.io`.
+from the `master` branch in a dedicated repository named with the GitHub 
+account name, i.e. `<user>.github.io` or `<org>.github.io`. 
 
-However, because Github requires user and organization pages to be
-deployed from the `master` branch of the `<user>.github.io` repo
-and deploying from this same `master` branch would overwrite all
-Markdown files with HTML files, you need *two* working repositories
+However, because Github requires user and organization pages to be 
+deployed from the `master` branch of the `<user>.github.io` repo 
+and deploying from this same `master` branch would overwrite all 
+Markdown files with HTML files, you need *two* working repositories 
 installed locally. For example, consider the following file 
-structure:
+structure: 
 
 ```
 my-project/
@@ -62,15 +62,15 @@ my-project/
 orgname.github.io/
 ```
 
-The first repository, `my-project`, is for developing your Markdown
-documents and adding to your `mkdocs.yml` file. The second
-repository, `orgname.github.io`, is exclusively for deployment of
-your organization or user site and contains all of the HTML files
-that make up your static site.
+The first repository, `my-project`, is for developing your Markdown 
+documents and adding to your `mkdocs.yml` file. The second 
+repository, `orgname.github.io`, is exclusively for deployment of 
+your organization or user site and contains all of the HTML files 
+that make up your static site. 
 
-After making and verifying updates to the `my-project` repository
-on its `master` branch, change directories to the `orgname.github.io`
-and call the following in the command line:
+After making and verifying updates to the `my-project` repository 
+on its `master` branch, change directories to the `orgname.github.io` 
+and call the following in the command line: 
 
 ```sh
 cd ../orgname.github.io/
@@ -80,18 +80,18 @@ Note that you need to explicitly point to the mkdocs.yml configuration
 file as it is no longer in the current working directory. 
 Additionally, note that you should specify the site type with the 
 `--page-type` option. Inputs for this option include 'user', 'org', or 
-'project', with the default being the latter.
+'project', with the default being the latter. 
 
-Lastly, be aware that mkdocs automatically deploys from the `master`
-branch when `--page-type` is `user` or `org`. This is different from
-the default `gh-pages` branch that is deployed when using the
+Lastly, be aware that mkdocs automatically deploys from the `master` 
+branch when `--page-type` is `user` or `org`. This is different from 
+the default `gh-pages` branch that is deployed when using the 
 `project` option. The command above should result inyour docs being 
-deployed to `https://<org>.github.io`.
+deployed to `https://<org>.github.io`. 
 
-Be aware that you will not be able to review the built site before it is pushed
-to GitHub. Therefore, you may want to verify any changes you make to the docs
-beforehand by using the `build` or `serve` commands and reviewing the built
-files locally.
+Be aware that you will not be able to review the built site before it is pushed 
+to GitHub. Therefore, you may want to verify any changes you make to the docs 
+beforehand by using the `build` or `serve` commands and reviewing the built 
+files locally. 
 
 !!! warning
 

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -43,17 +43,17 @@ files locally.
 
 ### Organization and User Pages
 
-GitHub also allows users to create User and Organization Pages sites 
-that are not tied to a specific project. Rather, the site files are deployed 
-from the `master` branch in a dedicated repository named with the GitHub 
-account name, i.e. `<user>.github.io` or `<org>.github.io`. 
+GitHub also allows users to create User and Organization Pages sites
+that are not tied to a specific project. Rather, the site files are deployed
+from the `master` branch in a dedicated repository named with the GitHub
+account name, i.e. `<user>.github.io` or `<org>.github.io`.
 
-However, because Github requires user and organization pages to be 
-deployed from the `master` branch of the `<user>.github.io` repo 
-and deploying from this same `master` branch would overwrite all 
-Markdown files with HTML files, you need *two* working repositories 
-installed locally. For example, consider the following file 
-structure: 
+However, because Github requires user and organization pages to be
+deployed from the `master` branch of the `<user>.github.io` repo
+and deploying from this same `master` branch would overwrite all
+Markdown files with HTML files, you need *two* working repositories
+installed locally. For example, consider the following file
+structure:
 
 ```
 my-project/
@@ -62,36 +62,36 @@ my-project/
 orgname.github.io/
 ```
 
-The first repository, `my-project`, is for developing your Markdown 
-documents and adding to your `mkdocs.yml` file. The second 
-repository, `orgname.github.io`, is exclusively for deployment of 
-your organization or user site and contains all of the HTML files 
-that make up your static site. 
+The first repository, `my-project`, is for developing your Markdown
+documents and adding to your `mkdocs.yml` file. The second
+repository, `orgname.github.io`, is exclusively for deployment of
+your organization or user site and contains all of the HTML files
+that make up your static site.
 
-After making and verifying updates to the `my-project` repository 
-on its `master` branch, change directories to the `orgname.github.io` 
-and call the following in the command line: 
+After making and verifying updates to the `my-project` repository
+on its `master` branch, change directories to the `orgname.github.io`
+and call the following in the command line:
 
 ```sh
 cd ../orgname.github.io/
 mkdocs gh-deploy --config-file ../my-project/mkdocs.yml --page-type org
 ```
-Note that you need to explicitly point to the mkdocs.yml configuration 
-file as it is no longer in the current working directory. 
-Additionally, note that you should specify the site type with the 
-`--page-type` option. Inputs for this option include 'user', 'org', or 
-'project', with the default being the latter. 
+Note that you need to explicitly point to the mkdocs.yml configuration
+file as it is no longer in the current working directory.
+Additionally, note that you should specify the site type with the
+`--page-type` option. Inputs for this option include 'user', 'org', or
+'project', with the default being the latter.
 
-Lastly, be aware that mkdocs automatically deploys from the `master` 
-branch when `--page-type` is `user` or `org`. This is different from 
-the default `gh-pages` branch that is deployed when using the 
-`project` option. The command above should result inyour docs being 
-deployed to `https://<org>.github.io`. 
+Lastly, be aware that mkdocs automatically deploys from the `master`
+branch when `--page-type` is `user` or `org`. This is different from
+the default `gh-pages` branch that is deployed when using the
+`project` option. The command above should result in your docs being
+deployed to `https://<org>.github.io`.
 
-Be aware that you will not be able to review the built site before it is pushed 
-to GitHub. Therefore, you may want to verify any changes you make to the docs 
-beforehand by using the `build` or `serve` commands and reviewing the built 
-files locally. 
+Be aware that you will not be able to review the built site before it is pushed
+to GitHub. Therefore, you may want to verify any changes you make to the docs
+beforehand by using the `build` or `serve` commands and reviewing the built
+files locally.
 
 !!! warning
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -18,11 +18,6 @@ from mkdocs.commands import build, gh_deploy, new, serve  # noqa: E402
 
 log = logging.getLogger(__name__)
 
-# Disable the warning that Click displays (as of Click version 5.0) when users
-# use unicode_literals in Python 2.
-# See http://click.pocoo.org/dev/python3/#unicode-literals for more details.
-click.disable_unicode_literals_warning = True
-
 
 class State:
     ''' Maintain logging level.'''
@@ -60,7 +55,7 @@ remote_branch_help = ("The remote branch to commit to for Github Pages. This "
                       "overrides the value specified in config")
 remote_name_help = ("The remote name to commit to for Github Pages. This "
                     "overrides the value specified in config")
-page_type_help = ("The page type to be created, either 'user', 'org', or 'project'.")
+page_type_help = "The page type to be created, either 'user', 'org', or 'project'."
 force_help = "Force the push to the repository."
 ignore_version_help = "Ignore check that build is not being deployed with an older version of MkDocs."
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -18,6 +18,11 @@ from mkdocs.commands import build, gh_deploy, new, serve  # noqa: E402
 
 log = logging.getLogger(__name__)
 
+# Disable the warning that Click displays (as of Click version 5.0) when users
+# use unicode_literals in Python 2.
+# See http://click.pocoo.org/dev/python3/#unicode-literals for more details.
+click.disable_unicode_literals_warning = True
+
 
 class State:
     ''' Maintain logging level.'''
@@ -55,6 +60,7 @@ remote_branch_help = ("The remote branch to commit to for Github Pages. This "
                       "overrides the value specified in config")
 remote_name_help = ("The remote name to commit to for Github Pages. This "
                     "overrides the value specified in config")
+page_type_help = ("The page type to be created, either 'user', 'org', or 'project'.")
 force_help = "Force the push to the repository."
 ignore_version_help = "Ignore check that build is not being deployed with an older version of MkDocs."
 
@@ -162,17 +168,21 @@ def build_command(clean, **kwargs):
 @click.option('-m', '--message', help=commit_message_help)
 @click.option('-b', '--remote-branch', help=remote_branch_help)
 @click.option('-r', '--remote-name', help=remote_name_help)
+@click.option('--page-type',
+              type=click.Choice(['user', 'org', 'project'], case_sensitive=False),
+              help=page_type_help)
 @click.option('--force', is_flag=True, help=force_help)
 @click.option('--ignore-version', is_flag=True, help=ignore_version_help)
 @common_config_options
 @click.option('-d', '--site-dir', type=click.Path(), help=site_dir_help)
 @common_options
-def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_version, **kwargs):
+def gh_deploy_command(clean, message, remote_branch, remote_name, page_type, force, ignore_version, **kwargs):
     """Deploy your documentation to GitHub Pages"""
     try:
         cfg = config.load_config(
             remote_branch=remote_branch,
             remote_name=remote_name,
+            page_type=page_type,
             **kwargs
         )
         build.build(cfg, dirty=not clean)

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -164,8 +164,7 @@ def build_command(clean, **kwargs):
 @click.option('-b', '--remote-branch', help=remote_branch_help)
 @click.option('-r', '--remote-name', help=remote_name_help)
 @click.option('--page-type',
-              type=click.Choice(['user', 'org', 'project'], case_sensitive=False),
-              help=page_type_help)
+              type=click.Choice(['user', 'org', 'project']), help=page_type_help)
 @click.option('--force', is_flag=True, help=force_help)
 @click.option('--ignore-version', is_flag=True, help=ignore_version_help)
 @common_config_options

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -139,4 +139,3 @@ def gh_deploy(config, message=None, force=False, ignore_version=False):
                 repo = repo[:-len('.git')]
             url = 'https://{}.github.io/{}/'.format(username, repo)
             log.info('Your documentation should shortly be available at: ' + url)
-

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -127,10 +127,8 @@ def gh_deploy(config, message=None, force=False, ignore_version=False):
         if host is None:
             # This could be a GitHub Enterprise deployment.
             log.info('Your documentation should be available shortly.')
-        if page_type == 'user' or page_type == "org":
+        elif page_type == 'user' or page_type == 'org':
             username, repo = path.split('/', 1)
-            if repo.endswith('.git'):
-                repo = repo[:-len('.git')]
             url = 'https://{}.github.io/'.format(username)
             log.info('Your documentation should shortly be available at: ' + url)
         else:

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -91,6 +91,7 @@ def gh_deploy(config, message=None, force=False, ignore_version=False):
 
     remote_branch = config['remote_branch']
     remote_name = config['remote_name']
+    page_type = config['page_type']
 
     if not ignore_version:
         _check_version(remote_branch)
@@ -126,9 +127,16 @@ def gh_deploy(config, message=None, force=False, ignore_version=False):
         if host is None:
             # This could be a GitHub Enterprise deployment.
             log.info('Your documentation should be available shortly.')
+        if page_type == 'user' or page_type == "org":
+            username, repo = path.split('/', 1)
+            if repo.endswith('.git'):
+                repo = repo[:-len('.git')]
+            url = 'https://{}.github.io/'.format(username)
+            log.info('Your documentation should shortly be available at: ' + url)
         else:
             username, repo = path.split('/', 1)
             if repo.endswith('.git'):
                 repo = repo[:-len('.git')]
             url = 'https://{}.github.io/{}/'.format(username, repo)
             log.info('Your documentation should shortly be available at: ' + url)
+

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -89,9 +89,14 @@ def gh_deploy(config, message=None, force=False, ignore_version=False):
         log.error('Cannot deploy - this directory does not appear to be a git '
                   'repository')
 
-    remote_branch = config['remote_branch']
-    remote_name = config['remote_name']
     page_type = config['page_type']
+
+    if page_type == 'user' or page_type == 'org':
+        remote_branch = 'master'
+    else:
+        remote_branch = config['remote_branch']
+
+    remote_name = config['remote_name']
 
     if not ignore_version:
         _check_version(remote_branch)

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -100,6 +100,10 @@ DEFAULT_SCHEMA = (
     # the remote name to push to when using gh-deploy
     ('remote_name', config_options.Type(str, default='origin')),
 
+    # the type of page being deployed, i.e. 'user', 'org',
+    # or 'project' when using gh-deploy
+    ('page_type', config_options.Type(str, default='project')),
+
     # extra is a mapping/dictionary of data that is passed to the template.
     # This allows template authors to require extra configuration that not
     # relevant to all themes and doesn't need to be explicitly supported by

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -624,6 +624,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=None,
             theme=None,

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -28,7 +28,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None
         )
 
@@ -58,7 +57,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None
         )
 
@@ -75,7 +73,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=True,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None
         )
 
@@ -92,24 +89,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme='readthedocs',
-            theme_dir=None,
-            use_directory_urls=None
-        )
-
-    @mock.patch('mkdocs.commands.serve.serve', autospec=True)
-    def test_serve_theme_dir(self, mock_serve):
-
-        result = self.runner.invoke(
-            cli.cli, ["serve", '--theme-dir', 'custom'], catch_exceptions=False)
-
-        self.assertEqual(result.exit_code, 0)
-        mock_serve.assert_called_once_with(
-            dev_addr=None,
-            livereload='livereload',
-            config_file=None,
-            strict=None,
-            theme=None,
-            theme_dir='custom',
             use_directory_urls=None
         )
 
@@ -126,7 +105,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=True
         )
 
@@ -143,7 +121,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=False
         )
 
@@ -160,7 +137,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None
         )
 
@@ -177,7 +153,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None
         )
 
@@ -194,7 +169,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None
         )
 
@@ -214,7 +188,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -275,7 +248,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=True,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -293,25 +265,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme='readthedocs',
-            theme_dir=None,
-            use_directory_urls=None,
-            site_dir=None
-        )
-
-    @mock.patch('mkdocs.config.load_config', autospec=True)
-    @mock.patch('mkdocs.commands.build.build', autospec=True)
-    def test_build_theme_dir(self, mock_build, mock_load_config):
-
-        result = self.runner.invoke(
-            cli.cli, ['build', '--theme-dir', 'custom'], catch_exceptions=False)
-
-        self.assertEqual(result.exit_code, 0)
-        self.assertEqual(mock_build.call_count, 1)
-        mock_load_config.assert_called_once_with(
-            config_file=None,
-            strict=None,
-            theme=None,
-            theme_dir='custom',
             use_directory_urls=None,
             site_dir=None
         )
@@ -329,7 +282,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=True,
             site_dir=None
         )
@@ -347,7 +299,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=False,
             site_dir=None
         )
@@ -365,7 +316,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir='custom',
         )
@@ -431,7 +381,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -517,7 +466,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -540,7 +488,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -562,7 +509,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -584,7 +530,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -639,7 +584,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=True,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir=None
         )
@@ -662,30 +606,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme='readthedocs',
-            theme_dir=None,
-            use_directory_urls=None,
-            site_dir=None
-        )
-
-    @mock.patch('mkdocs.config.load_config', autospec=True)
-    @mock.patch('mkdocs.commands.build.build', autospec=True)
-    @mock.patch('mkdocs.commands.gh_deploy.gh_deploy', autospec=True)
-    def test_gh_deploy_theme_dir(self, mock_gh_deploy, mock_build, mock_load_config):
-
-        result = self.runner.invoke(
-            cli.cli, ['gh-deploy', '--theme-dir', 'custom'], catch_exceptions=False)
-
-        self.assertEqual(result.exit_code, 0)
-        self.assertEqual(mock_gh_deploy.call_count, 1)
-        self.assertEqual(mock_build.call_count, 1)
-        mock_load_config.assert_called_once_with(
-            remote_branch=None,
-            remote_name=None,
-            page_type=None,
-            config_file=None,
-            strict=None,
-            theme=None,
-            theme_dir='custom',
             use_directory_urls=None,
             site_dir=None
         )
@@ -707,7 +627,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=True,
             site_dir=None
         )
@@ -730,7 +649,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=False,
             site_dir=None
         )
@@ -753,7 +671,6 @@ class CLITests(unittest.TestCase):
             config_file=None,
             strict=None,
             theme=None,
-            theme_dir=None,
             use_directory_urls=None,
             site_dir='custom'
         )

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -427,6 +427,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -512,6 +513,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch='foo',
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -534,6 +536,51 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name='foo',
+            page_type=None,
+            config_file=None,
+            strict=None,
+            theme=None,
+            theme_dir=None,
+            use_directory_urls=None,
+            site_dir=None
+        )
+
+    @mock.patch('mkdocs.config.load_config', autospec=True)
+    @mock.patch('mkdocs.commands.build.build', autospec=True)
+    @mock.patch('mkdocs.commands.gh_deploy.gh_deploy', autospec=True)
+    def test_gh_deploy_page_type_user(self, mock_gh_deploy, mock_build, mock_load_config):
+        result = self.runner.invoke(
+            cli.cli, ['gh-deploy', '--page-type', 'user'], catch_exceptions=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(mock_gh_deploy.call_count, 1)
+        self.assertEqual(mock_build.call_count, 1)
+        mock_load_config.assert_called_once_with(
+            remote_branch=None,
+            remote_name=None,
+            page_type='user',
+            config_file=None,
+            strict=None,
+            theme=None,
+            theme_dir=None,
+            use_directory_urls=None,
+            site_dir=None
+        )
+
+    @mock.patch('mkdocs.config.load_config', autospec=True)
+    @mock.patch('mkdocs.commands.build.build', autospec=True)
+    @mock.patch('mkdocs.commands.gh_deploy.gh_deploy', autospec=True)
+    def test_gh_deploy_page_type_org(self, mock_gh_deploy, mock_build, mock_load_config):
+        result = self.runner.invoke(
+            cli.cli, ['gh-deploy', '--page-type', 'org'], catch_exceptions=False)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(mock_gh_deploy.call_count, 1)
+        self.assertEqual(mock_build.call_count, 1)
+        mock_load_config.assert_called_once_with(
+            remote_branch=None,
+            remote_name=None,
+            page_type='org',
             config_file=None,
             strict=None,
             theme=None,
@@ -588,6 +635,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=True,
             theme=None,
@@ -610,6 +658,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=None,
             theme='readthedocs',
@@ -632,6 +681,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -676,6 +726,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -698,6 +749,7 @@ class CLITests(unittest.TestCase):
         mock_load_config.assert_called_once_with(
             remote_branch=None,
             remote_name=None,
+            page_type=None,
             config_file=None,
             strict=None,
             theme=None,


### PR DESCRIPTION
I recently ran into an issue trying to deploy my docs to a personal (i.e. user) site with the `gh-deploy` command where the docs would deploy to the URL `http://<user>.github.io/<user>.github.io`. After looking at the [mkdocs docs](https://www.mkdocs.org/user-guide/deploying-your-docs/#organization-and-user-pages) surrounding deployment I found two things: (1) this was expected behavior because I was essentially following the "project" deployment steps and (2) the docs and UI for deploying user and organization pages was confusing.

As a result, I created a `--page-type` option that can be used in a straightforward fashion during the deployment stage, without having to worry about changing directories or having two local repos. This is accompanied by an update to the "Organization and User Pages" section in the documentation and has been tested using `tox`.

Please let me know if you see any issues with implementing this. And thank you so much for continuing to maintain this great library!