### PR TITLE
Fix #2062 nltk dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Jinja2>=2.10.1',
         'livereload>=2.5.1',
         'lunr[languages]==0.5.6',  # must match lunr.js version included in search
+        'nltk<=3.4.5' # must be lower than 3.5.0 which breaks install. See issue 2062 on Github
         'Markdown>=3.2.1',
         'PyYAML>=3.10',
         'tornado>=5.0'

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'Jinja2>=2.10.1',
         'livereload>=2.5.1',
         'lunr[languages]==0.5.6',  # must match lunr.js version included in search
-        'nltk<=3.4.5' # must be lower than 3.5.0 which breaks install. See issue 2062 on Github
+        'nltk<3.5.0' # must be lower than 3.5.0 which breaks install. See issue 2062 on Github
         'Markdown>=3.2.1',
         'PyYAML>=3.10',
         'tornado>=5.0'


### PR DESCRIPTION
Based on reports in #2062 I created this MR which makes sure `nltk` version `3.5.0` is not installed