### PR TITLE
Set dependency to `lunr[languages]==0.5.8`.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,10 +23,11 @@ The current and past members of the MkDocs team.
 
 ## Version 1.1.1 (in development)
 
-Bugfix: Ensure wheel is Python 3 only.
-Bugfix: Clean up `dev_addr` validation and disallow `0.0.0.0`.
-Add support for `min_search_length` parameter for search plugin (#2014).
-Bugfix: `readthedocs` theme `code` colors (#2027).
+* Bugfix: Use `lunr[languages]==0.5.8` to avoid `nltk` incompatibilities (#2062).
+* Bugfix: Ensure wheel is Python 3 only (#2021).
+* Bugfix: Clean up `dev_addr` validation and disallow `0.0.0.0` (#2022).
+* Add support for `min_search_length` parameter for search plugin (#2014).
+* Bugfix: `readthedocs` theme `code` colors (#2027).
 
 ## Version 1.1 (2020-02-22)
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'click>=3.3',
         'Jinja2>=2.10.1',
         'livereload>=2.5.1',
-        'lunr[languages]==0.5.6',  # must match lunr.js version included in search
+        'lunr[languages]==0.5.8',  # must support lunr.js version included in search
         'Markdown>=3.2.1',
         'PyYAML>=3.10',
         'tornado>=5.0'


### PR DESCRIPTION
Lunr.py version 0.5.8 maintains compatability with Lunr.js 2.3.8, but
restricts its dependnecy to `nltk>=3.2.5,<3.5`, which avoids installation
issues on some Docker images. Fixes #2062.