### PR TITLE
Pass builder to on_serve event.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,6 +23,8 @@ The current and past members of the MkDocs team.
 
 ## Version 1.1.1 (in development)
 
+* Bugfix: Pass `builder` to the `on_serve` event so that it can be passed to
+  `server.watch` by plugins (#1952).
 * Bugfix: Use `lunr[languages]==0.5.8` to avoid `nltk` incompatibilities (#2062).
 * Bugfix: Ensure wheel is Python 3 only (#2021).
 * Bugfix: Clean up `dev_addr` validation and disallow `0.0.0.0` (#2022).

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -155,6 +155,7 @@ entire site.
     Parameters:
     : __server:__ `livereload.Server` instance
     : __config:__ global configuration object
+    : __builder:__ a callable which gets passed to each call to `server.watch`
 
     Returns:
     : `livereload.Server` instance

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -73,7 +73,7 @@ def _livereload(host, port, config, builder, site_dir):
         server.watch(d, builder)
 
     # Run `serve` plugin events.
-    server = config['plugins'].run_event('serve', server, config=config)
+    server = config['plugins'].run_event('serve', server, config=config, builder=builder)
 
     server.serve(root=site_dir, host=host, port=port, restart_delay=0)
 


### PR DESCRIPTION
Every call to `server.watch` requires `builder` to be passed in. If
users are to add their own watched files, then they need access to
`builder`. Fixes #1952.