### PR TITLE
Use README.md as index.html also if use_directory_urls is false

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,6 +23,7 @@ The current and past members of the MkDocs team.
 
 ## Version 1.1.1 (in development)
 
+* Bugfix: Use README.md as index.html even if use_directory_urls is false.
 * Bugfix: Ignore links which start with a backslash (#1680).
 * Bugfix: Pass `builder` to the `on_serve` event so that it can be passed to
   `server.watch` by plugins (#1952).

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,7 +23,7 @@ The current and past members of the MkDocs team.
 
 ## Version 1.1.1 (in development)
 
-* Bugfix: Use README.md as index.html even if use_directory_urls is false.
+* Bugfix: Use README.md as index.html even if use_directory_urls is false (#2081).
 * Bugfix: Ignore links which start with a backslash (#1680).
 * Bugfix: Pass `builder` to the `on_serve` event so that it can be passed to
   `server.watch` by plugins (#1952).

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -143,18 +143,14 @@ class File:
     def _get_dest_path(self, use_directory_urls):
         """ Return destination path based on source path. """
         if self.is_documentation_page():
-            if use_directory_urls:
-                parent, filename = os.path.split(self.src_path)
-                if self.name == 'index':
-                    # index.md or README.md => index.html
-                    return os.path.join(parent, 'index.html')
-                else:
-                    # foo.md => foo/index.html
-                    return os.path.join(parent, self.name, 'index.html')
-            else:
+            parent, filename = os.path.split(self.src_path)
+            if not use_directory_urls or self.name == 'index':
+                # index.md or README.md => index.html
                 # foo.md => foo.html
-                root, ext = os.path.splitext(self.src_path)
-                return root + '.html'
+                return os.path.join(parent, self.name + '.html')
+            else:
+                # foo.md => foo/index.html
+                return os.path.join(parent, self.name, 'index.html')
         return self.src_path
 
     def _get_url(self, use_directory_urls):

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -122,10 +122,38 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         self.assertFalse(f.is_javascript())
         self.assertFalse(f.is_css())
 
+    def test_md_readme_index_file(self):
+        f = File('README.md', '/path/to/docs', '/path/to/site', use_directory_urls=False)
+        self.assertPathsEqual(f.src_path, 'README.md')
+        self.assertPathsEqual(f.abs_src_path, '/path/to/docs/README.md')
+        self.assertPathsEqual(f.dest_path, 'index.html')
+        self.assertPathsEqual(f.abs_dest_path, '/path/to/site/index.html')
+        self.assertEqual(f.url, 'index.html')
+        self.assertEqual(f.name, 'index')
+        self.assertTrue(f.is_documentation_page())
+        self.assertFalse(f.is_static_page())
+        self.assertFalse(f.is_media_file())
+        self.assertFalse(f.is_javascript())
+        self.assertFalse(f.is_css())
+
     def test_md_index_file_use_directory_urls(self):
         f = File('index.md', '/path/to/docs', '/path/to/site', use_directory_urls=True)
         self.assertPathsEqual(f.src_path, 'index.md')
         self.assertPathsEqual(f.abs_src_path, '/path/to/docs/index.md')
+        self.assertPathsEqual(f.dest_path, 'index.html')
+        self.assertPathsEqual(f.abs_dest_path, '/path/to/site/index.html')
+        self.assertEqual(f.url, '.')
+        self.assertEqual(f.name, 'index')
+        self.assertTrue(f.is_documentation_page())
+        self.assertFalse(f.is_static_page())
+        self.assertFalse(f.is_media_file())
+        self.assertFalse(f.is_javascript())
+        self.assertFalse(f.is_css())
+
+    def test_md_readme_index_file_use_directory_urls(self):
+        f = File('README.md', '/path/to/docs', '/path/to/site', use_directory_urls=True)
+        self.assertPathsEqual(f.src_path, 'README.md')
+        self.assertPathsEqual(f.abs_src_path, '/path/to/docs/README.md')
         self.assertPathsEqual(f.dest_path, 'index.html')
         self.assertPathsEqual(f.abs_dest_path, '/path/to/site/index.html')
         self.assertEqual(f.url, '.')


### PR DESCRIPTION
Right now, just like any *foo/index.md*, any *foo/README.md* becomes *foo/index.html*, but that works only if `use_directory_urls` is on.
But the `use_directory_urls` feature is for changing *foo/bar.md* into *foo/bar/index.html* and should not prevent the former from working.

I'm hoping that this is more of an oversight (due to the source code for the two things being very related) than an intentional exclusion.
So I'm sending a small pull request to fix that and also unify the code paths. But feel free to discuss this as an issue in case it's not as agreeable as I thought.