### PR TITLE
Normalize IP addresses and change error to warning

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,10 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Version 1.1.2 (Under development)
+
+* Bugfix: Normalize IP addresses and change error to warning (#2108).
+
 ## Version 1.1.1 (2020-05-12)
 
 * Bugfix: Allow compressed sitemap to be deterministic by supporting the

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -236,7 +236,8 @@ class IpAddress(OptionallyRequired):
 
         if host != 'localhost':
             try:
-                ipaddress.ip_address(host)
+                # Validate and normalize IP Address
+                host = str(ipaddress.ip_address(host))
             except ValueError as e:
                 raise ValidationError(e)
 
@@ -254,10 +255,11 @@ class IpAddress(OptionallyRequired):
     def post_validation(self, config, key_name):
         host = config[key_name].host
         if key_name == 'dev_addr' and host in ['0.0.0.0', '::']:
-            raise ValidationError(
-                ("The MkDocs' server is intended for development purposes only. "
-                 "Therefore, '{}' is not a supported IP address. Please use a "
-                 "third party production-ready server instead.").format(host)
+            self.warnings.append(
+                ("The use of the IP address '{}' suggests a production environment "
+                 "or the use of a proxy to connect to the MkDocs server. However, "
+                 "the MkDocs' server is intended for local development purposes only. "
+                 "Please use a third party production-ready server instead.").format(host)
             )
 
 


### PR DESCRIPTION
All IP addresses passed to `dev_addr` are now normalized.
`127.000.000.001` is normalized to `127.0.0.1`.

With apologies to docker container users, the address `0.0.0.0`
no longer raises an error but a warning instead. Apparently,
docker containers need to use that address, even in dev environments.

Closes #2108.