### PR TITLE
Fix relative links

### DIFF
--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -764,7 +764,7 @@ class RelativePathExtensionTests(unittest.TestCase):
 
         with mock.patch(
             'mkdocs.structure.pages.open',
-            mock.mock_open(read_data='[link](../{}/non-index.md)'.format(docs_rel_dir))
+            mock.mock_open(read_data='[link](../docs/non-index.md)')
         ):
             self.assertEqual(
                 self.get_rendered_result(['index.md', 'non-index.md']),

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -750,6 +750,27 @@ class RelativePathExtensionTests(unittest.TestCase):
             '<p><a href="../..">link</a></p>'
         )
 
+    def test_project_relative_html_link_parent_index(self):
+        docs_rel_dir = self.DOCS_DIR.replace(os.getcwd(), '').lstrip(os.sep)
+
+        with mock.patch(
+            'mkdocs.structure.pages.open',
+            mock.mock_open(read_data='[link]({}/non-index.md)'.format(docs_rel_dir))
+        ):
+            self.assertEqual(
+                self.get_rendered_result(['index.md', 'non-index.md']),
+                '<p><a href="non-index/">link</a></p>'
+            )
+
+        with mock.patch(
+            'mkdocs.structure.pages.open',
+            mock.mock_open(read_data='[link](../{}/non-index.md)'.format(docs_rel_dir))
+        ):
+            self.assertEqual(
+                self.get_rendered_result(['index.md', 'non-index.md']),
+                '<p><a href="non-index/">link</a></p>'
+            )
+
     @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](non-index.md#hash)'))
     def test_relative_html_link_hash(self):
         self.assertEqual(


### PR DESCRIPTION
It solves cases when the path starts from the project root. The file still must be in `docs_dir`, but links like `[image](../docs/image.png)` and `[image](docs/image.png)` now works. It makes it possible to use README.md files with relative links.