### PR TITLE
Add link to Jinja environment class

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -211,7 +211,7 @@ entire site.
 ##### on_env
 
 :   The `env` event is called after the Jinja template environment is created
-    and can be used to alter the Jinja environment.
+    and can be used to alter the [Jinja environment](https://jinja.palletsprojects.com/en/master/api/#jinja2.Environment).
 
     Parameters:
     : __env:__ global Jinja environment


### PR DESCRIPTION
Add helpful link for plugin developers. I used the 'master' branch of jinja so link will not break on future versions of `jinja2`