### PR TITLE
Fix relative link to Index Pages in Writing Your Docs help page

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -21,7 +21,7 @@ docs/
 ```
 
 By convention your project homepage should be named `index.md` (see [Index
-pages](#index_pages) below for details). Any of the following file
+pages](#index-pages) below for details). Any of the following file
 extensions may be used for your Markdown source files: `markdown`, `mdown`,
 `mkdn`, `mkd`, `md`. All Markdown files included in your documentation
 directory will be rendered in the built site regardless of any settings.


### PR DESCRIPTION
On the Writing Your Docs page, the link in the text links to `index_pages` with an underscore but the page as currently rendered has that link as `index-pages` with a hyphen.  This corrects that link.