### PR TITLE
docs: fix markdown hyperlink

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -76,8 +76,7 @@ nested URLs, like so:
 
 Any files which are not identified as Markdown files (by their file extension)
 within the [documentation directory](configuration.md#docs_dir) are copied by
-MkDocs to the built site unaltered. See [how to link to images and media]
-(#linking_to_images_and_media) below for details.
+MkDocs to the built site unaltered. See [how to link to images and media](#linking_to_images_and_media) below for details.
 
 ### Index pages
 

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -76,7 +76,7 @@ nested URLs, like so:
 
 Any files which are not identified as Markdown files (by their file extension)
 within the [documentation directory](configuration.md#docs_dir) are copied by
-MkDocs to the built site unaltered. See [how to link to images and media](#linking_to_images_and_media) below for details.
+MkDocs to the built site unaltered. See [how to link to images and media](#linking-to-images-and-media) below for details.
 
 ### Index pages
 


### PR DESCRIPTION
Fixes a broken Markdown hyperlink in mkdocs.org/user-guide/writing-your-docs