### PR TITLE
Fix reversed breadcrumbs in rtd theme

### DIFF
--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -2,7 +2,7 @@
   <ul class="wy-breadcrumbs">
     <li><a href="{{ nav.homepage.url|url }}">Docs</a> &raquo;</li>
     {% if page %}
-      {% for doc in page.ancestors %}
+      {% for doc in page.ancestors[::-1] %}
         {% if doc.link %}
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
         {% else %}


### PR DESCRIPTION
`pages.py` and `nav.py` generate the `ancestors` property in the following way:
```
[self.parent] + self.parent.ancestors
```
This causes the parent to be first and the root to be last in the list, which is opposite to the order expected in breadcrumbs. This patch fixes it by reversing them before creating the breadcrumbs html.

Fixes #2143