### PR TITLE
Allow mkdocs.yaml when '--config' is not passed

### DIFF
--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -143,7 +143,12 @@ def _open_config_file(config_file):
 
     # Default to the standard config filename.
     if config_file is None:
-        config_file = os.path.abspath('mkdocs.yml')
+        for possible_file_ending in ('yml', 'yaml'):
+            config_file = os.path.abspath('mkdocs.{}'.format(possible_file_ending))
+            if os.path.exists(config_file):
+                break
+        else:
+            config_file = os.path.abspath('mkdocs.yml')
 
     # If closed file descriptor, get file path to reopen later.
     if hasattr(config_file, 'closed') and config_file.closed:

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -131,7 +131,6 @@ class ConfigBaseTests(unittest.TestCase):
             temp_dir.cleanup()
             os.chdir(old_dir)
 
-
     def test_load_from_missing_file(self):
 
         self.assertRaises(exceptions.ConfigurationError,

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -57,6 +57,81 @@ class ConfigBaseTests(unittest.TestCase):
             os.remove(config_file.name)
             temp_dir.cleanup()
 
+    def test_load_default_file(self):
+        """
+        test that `mkdocs.yml` will be loaded when '--config' is not set.
+        """
+
+        temp_dir = TemporaryDirectory()
+        config_file = open(os.path.join(temp_dir.name, 'mkdocs.yml'), 'w')
+        os.mkdir(os.path.join(temp_dir.name, 'docs'))
+        old_dir = os.getcwd()
+        try:
+            os.chdir(temp_dir.name)
+            config_file.write("site_name: MkDocs Test\n")
+            config_file.flush()
+            config_file.close()
+
+            cfg = base.load_config(config_file=None)
+            self.assertTrue(isinstance(cfg, base.Config))
+            self.assertEqual(cfg['site_name'], 'MkDocs Test')
+        finally:
+            os.remove(config_file.name)
+            temp_dir.cleanup()
+            os.chdir(old_dir)
+
+    def test_load_default_file_with_yaml(self):
+        """
+        test that `mkdocs.yml` will be loaded when '--config' is not set.
+        """
+
+        temp_dir = TemporaryDirectory()
+        config_file = open(os.path.join(temp_dir.name, 'mkdocs.yaml'), 'w')
+        os.mkdir(os.path.join(temp_dir.name, 'docs'))
+        old_dir = os.getcwd()
+        try:
+            os.chdir(temp_dir.name)
+            config_file.write("site_name: MkDocs Test\n")
+            config_file.flush()
+            config_file.close()
+
+            cfg = base.load_config(config_file=None)
+            self.assertTrue(isinstance(cfg, base.Config))
+            self.assertEqual(cfg['site_name'], 'MkDocs Test')
+        finally:
+            os.remove(config_file.name)
+            temp_dir.cleanup()
+            os.chdir(old_dir)
+
+    def test_load_default_file_prefer_yml(self):
+        """
+        test that `mkdocs.yml` will be loaded when '--config' is not set.
+        """
+
+        temp_dir = TemporaryDirectory()
+        config_file1 = open(os.path.join(temp_dir.name, 'mkdocs.yml'), 'w')
+        config_file2 = open(os.path.join(temp_dir.name, 'mkdocs.yaml'), 'w')
+        os.mkdir(os.path.join(temp_dir.name, 'docs'))
+        old_dir = os.getcwd()
+        try:
+            os.chdir(temp_dir.name)
+            config_file1.write("site_name: MkDocs Test1\n")
+            config_file1.flush()
+            config_file1.close()
+            config_file2.write("site_name: MkDocs Test2\n")
+            config_file2.flush()
+            config_file2.close()
+
+            cfg = base.load_config(config_file=None)
+            self.assertTrue(isinstance(cfg, base.Config))
+            self.assertEqual(cfg['site_name'], 'MkDocs Test1')
+        finally:
+            os.remove(config_file1.name)
+            os.remove(config_file2.name)
+            temp_dir.cleanup()
+            os.chdir(old_dir)
+
+
     def test_load_from_missing_file(self):
 
         self.assertRaises(exceptions.ConfigurationError,


### PR DESCRIPTION
We wanted to give our colleagues to possibility to build docs automatically when they put a `mkdocs.yml` in the docs folder of their repository. But it happened often, that they used `.yaml` instead the `.yml`.

When this PR is accepted, it will look first look for `mkdocs.yml` when `--config` is not provided. If this file is not present, it will try to find `mkdocs.yaml`.
When both are not present, it behaves like before.
When both are present, it behaves like before.
If only the `.yaml` version it present, this one will be used as the config file.