### PR TITLE
Import ABC from collections.abc explicitly.

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1,5 +1,6 @@
 import os
-from collections import Sequence, namedtuple
+from collections import namedtuple
+from collections.abc import Sequence
 from urllib.parse import urlparse
 import ipaddress
 import markdown


### PR DESCRIPTION
This fixes below warning for Python 3.10 compatibility. 

```
  /root/py39-venv/lib/python3.9/site-packages/mkdocs/config/config_options.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Sequence, namedtuple
```