### PR TITLE
Remove links to specific hosts from Getting Started Guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -333,9 +333,8 @@ mkdocs build --help
 ## Deploying
 
 The documentation site that you just built only uses static files so you'll be
-able to host it from pretty much anywhere. [GitHub project pages] and [Amazon
-S3] may be good hosting options, depending upon your needs. Upload the contents
-of the entire `site` directory to wherever you're hosting your website from and
+able to host it from pretty much anywhere. Simply upload the contents of the
+entire `site` directory to wherever you're hosting your website from and
 you're done. For specific instructions on a number of common hosts, see the
 [Deploying your Docs][deploy] page.
 
@@ -352,12 +351,10 @@ the MkDocs IRC channel `#mkdocs` on freenode.
 [plugins]: user-guide/plugins/
 [MkDocs Themes]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
 [build your own]: user-guide/custom-themes/
-[Amazon S3]: https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html
 [get-pip.py]: https://bootstrap.pypa.io/get-pip.py
 [nav]: user-guide/configuration/#nav
 [discussion group]: https://groups.google.com/forum/#!forum/mkdocs
 [GitHub issues]: https://github.com/mkdocs/mkdocs/issues
-[GitHub project pages]: https://help.github.com/articles/creating-project-pages-manually/
 [pip]: https://pip.readthedocs.io/en/stable/installing/
 [Python]: https://www.python.org/
 [site_name]: user-guide/configuration/#site_name


### PR DESCRIPTION
We already link to the Deploying for Docs page which includes specific
instructions for various hosts. There is no need to also link to those
hosts in the Getting Started guide.

Closes #2210, closes #2104, closes <del>#1494</del> <ins>#1890</ins>.