### PR TITLE
Reintroduce pypy to CI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, pypy3]
         include:
           - python-version: 3.5
             tox-env: py35
@@ -29,10 +29,6 @@ jobs:
             tox-env: py38
           - python-version: pypy3
             tox-env: pypy3
-            os: ubuntu-latest
-          - python-version: pypy3
-            tox-env: pypy3
-            os: macos-latest
     env:
       TOXENV: ${{ matrix.tox-env }}-{unittests,min-req,integration}
     runs-on: ${{ matrix.os }}
@@ -47,7 +43,8 @@ jobs:
           python -m pip install --upgrade pip tox coverage codecov
       - name: Run tox
         run: |
-          python -m tox
+          python -m tox --discover $(which python)
+        shell: bash
       - name: Upload Codecov Results
         if: success()
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Hi, I noticed from the tox issue that you disabled pypy for Windows. I found a simple workaround that seems like a good enough solution at least until the new pypy is released on GitHub Actions.