### PR TITLE
Deprecate google_analytics config option.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -36,6 +36,23 @@ mkdocs serve --wait 60
 
 ### Backward Incompatible Changes in 1.2
 
+The `google_analytics` configuration option is deprecated as Google appears to
+be fazing it out in favor of its new Google Analytics 4 property. See the
+documentation for your theme for alternatives which can be configured as part
+of your theme configuration. For exmaple, the [mkdocs][mkdocs-theme] and
+[readthedocs][rtd-theme] themes have each added a new `theme.analytics.gtag`
+configuration option which uses the new Google Analytics 4 property. See
+Google's documentation on how to [Upgrade to a Google Analytics 4
+property][ga4]. Then set  `theme.analytics.gtag` to the "G-" ID and delete the
+`google_analytics` configuration option which contains a "UA-" ID. So long
+as the old "UA-" ID and new "G-" ID are properly linked in your Google account,
+and you are using the "G-" ID, the data will be made available in both the old
+and new formats by Google Analytics. See #2252.
+
+[mkdocs-theme]: ../user-guide/styling-your-docs.md#mkdocs
+[rtd-theme]: ../user-guide/styling-your-docs.md#readthedocs
+[ga4]: https://support.google.com/analytics/answer/9744165?hl=en 
+
 A theme's files are now excluded from the list of watched files by default
 when using the `--livereload` server. This new default behavior is what most
 users need and provides better performance when editing site content.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -136,16 +136,6 @@ Set the copyright information to be included in the documentation by the theme.
 
 **default**: `null`
 
-### google_analytics
-
-Set the Google analytics tracking configuration.
-
-```yaml
-google_analytics: ['UA-36723568-3', 'mkdocs.org']
-```
-
-**default**: `null`
-
 ### remote_branch
 
 Set the remote branch to commit to when using `gh-deploy` to deploy to Github

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -49,6 +49,21 @@ supports the following options:
                 - yaml
                 - rust
 
+* __`analytics`__: Defines configuration options for an analytics service.
+  Currently, only Google Analytics v4 is supported via the `gtag` option.
+
+    *   __`gtag`__: To enable Google Analytics, set to a Google Analytics v4 tracking ID, which uses the `G-` format. See Google's documentation to
+    [Set up Analytics for a website and/or app (GA4)][setup-GA4] or to
+    [Upgrade to a Google Analytics 4 property][upgrade-GA4].
+
+            theme:
+                name: mkdocs
+                analytics:
+                    gtag: G-ABC123
+
+        When set to the default (`null`) Google Analytics is disabled for the
+        site.
+
 * __`shortcuts`__: Defines keyboard shortcut keys.
 
         theme:
@@ -84,6 +99,8 @@ supports the following options:
             nav_style: dark
 
 [styles]: https://highlightjs.org/static/demo/
+[setup-GA4]: https://support.google.com/analytics/answer/9304153?hl=en&ref_topic=9303319
+[upgrade-GA4]: https://support.google.com/analytics/answer/9744165?hl=en&ref_topic=9303319
 
 ### readthedocs
 
@@ -108,6 +125,21 @@ theme supports the following options:
             hljs_languages:
                 - yaml
                 - rust
+
+* __`analytics`__: Defines configuration options for an analytics service.
+  Currently, only Google Analytics v4 is supported via the `gtag` option.
+
+    *   __`gtag`__: To enable Google Analytics, set to a Google Analytics v4 tracking ID, which uses the `G-` format. See Google's documentation to
+    [Set up Analytics for a website and/or app (GA4)][setup-GA4] or to
+    [Upgrade to a Google Analytics 4 property][upgrade-GA4].
+
+            theme:
+                name: readthedocs
+                analytics:
+                    gtag: G-ABC123
+
+        When set to the default (`null`) Google Analytics is disabled for the
+        site.
 
 * __`include_homepage_in_sidebar`__: Lists the homepage in the sidebar menu. As
   MkDocs requires that the homepage be listed in the `nav` configuration

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -187,37 +187,58 @@ class Choice(OptionallyRequired):
 
 
 class Deprecated(BaseConfigOption):
+    """
+    Deprecated Config Option
 
-    def __init__(self, moved_to=None):
+    Raises a warning the the option is deprecated. Uses `message` for the
+    warning. If `move_to` is set to the name of a new config option, the value
+    is moved to the new option on pre_validation. If `option_type` is set to a 
+    ConfigOption instance, then the value is validated against that type.
+    """
+
+    def __init__(self, moved_to=None, message='', option_type=None):
         super().__init__()
         self.default = None
         self.moved_to = moved_to
+        self.message = message or (
+            'The configuration option {} has been deprecated and '
+            'will be removed in a future release of MkDocs.'
+        )
+        self.option = option_type or BaseConfigOption()
+        self.warnings = self.option.warnings
 
     def pre_validation(self, config, key_name):
+        self.option.pre_validation(config, key_name)
 
-        if config.get(key_name) is None or self.moved_to is None:
-            return
+        if config.get(key_name) is not None:
+            self.warnings.append(self.message.format(key_name))
 
-        warning = ('The configuration option {} has been deprecated and '
-                   'will be removed in a future release of MkDocs.'
-                   ''.format(key_name))
-        self.warnings.append(warning)
+            if self.moved_to is not None:
+                if '.' not in self.moved_to:
+                    target = config
+                    target_key = self.moved_to
+                else:
+                    move_to, target_key = self.moved_to.rsplit('.', 1)
 
-        if '.' not in self.moved_to:
-            target = config
-            target_key = self.moved_to
-        else:
-            move_to, target_key = self.moved_to.rsplit('.', 1)
+                    target = config
+                    for key in move_to.split('.'):
+                        target = target.setdefault(key, {})
 
-            target = config
-            for key in move_to.split('.'):
-                target = target.setdefault(key, {})
+                        if not isinstance(target, dict):
+                            # We can't move it for the user
+                            return
 
-                if not isinstance(target, dict):
-                    # We can't move it for the user
-                    return
+                target[target_key] = config.pop(key_name)
 
-        target[target_key] = config.pop(key_name)
+    def run_validation(self, value):
+        return self.option.run_validation(value)
+
+    def post_validation(self, config, key_name):
+        self.option.post_validation(config, key_name)
+
+    def reset_warnings(self):
+        self.option.reset_warnings()
+        self.warnings = self.option.warnings
 
 
 class IpAddress(OptionallyRequired):

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -44,7 +44,12 @@ DEFAULT_SCHEMA = (
 
     # set of values for Google analytics containing the account IO and domain,
     # this should look like, ['UA-27795084-5', 'mkdocs.org']
-    ('google_analytics', config_options.Type(list, length=2)),
+    ('google_analytics', config_options.Deprecated(
+        message = ('The configuration option {} has been deprecated and '
+            'will be removed in a future release of MkDocs. See the '
+            'options available on your theme for an alternative.'),
+        option_type=config_options.Type(list, length=2)
+    )),
 
     # The address on which to serve the live reloading docs server.
     ('dev_addr', config_options.IpAddress(default='127.0.0.1:8000')),

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -42,7 +42,16 @@
       {%- endblock %}
 
       {%- block analytics %}
-        {%- if config.google_analytics %}
+        {%- if config.theme.analytics.gtag %}
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '{{ config.theme.analytics.gtag }}');
+        </script>
+        {%- elif config.google_analytics %}
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/mkdocs/themes/mkdocs/mkdocs_theme.yml
+++ b/mkdocs/themes/mkdocs/mkdocs_theme.yml
@@ -13,6 +13,9 @@ hljs_style: github
 navigation_depth: 2
 nav_style: primary
 
+analytics:
+  gtag: null
+
 shortcuts:
     help: 191    # ?
     next: 78     # n

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -53,7 +53,16 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-  {% if config.google_analytics %}
+  {%- if config.theme.analytics.gtag %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '{{ config.theme.analytics.gtag }}');
+  </script>
+  {%- elif config.google_analytics %}
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/mkdocs/themes/readthedocs/mkdocs_theme.yml
+++ b/mkdocs/themes/readthedocs/mkdocs_theme.yml
@@ -9,6 +9,9 @@ search_index_only: false
 highlightjs: true
 hljs_languages: []
 
+analytics:
+  gtag: null
+
 include_homepage_in_sidebar: true
 prev_next_buttons_location: bottom
 navigation_depth: 4


### PR DESCRIPTION
This implements the plan discussed in #2252.

On the built-in themes I added a new option `theme.analytics.gtag`. See the documentation for details. The idea is that multiple different services could be offered under `theme.analytics`. At this time only support for `gtag` exists, but more could be added in the future.

I made some changes and additions to the Deprecated option validator which still needs tests.

We also need to upgrade the Google Analytics account for https://mkdocs.org to use the new GA4 ID. Until we do, builds will issue a warning:

```text
$ mkdocs build
WARNING -  Config value: 'google_analytics'. Warning: The configuration option 
google_analytics has been deprecated and will be removed in a future release o
f MkDocs. See the options available on your theme for an alternative.
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /Users/waylan/Code/mkdocs/site
INFO    -  Documentation built in 0.99 seconds
```