### PR TITLE
Optimize/simplify __eq__ implementations

### DIFF
--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -168,11 +168,11 @@ class ContentSection:
         self.title = title
 
     def __eq__(self, other):
-        return all([
-            self.text == other.text,
-            self.id == other.id,
+        return (
+            self.text == other.text and
+            self.id == other.id and
             self.title == other.title
-        ])
+        )
 
 
 class ContentParser(HTMLParser):

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -125,11 +125,12 @@ class File:
         self.url = self._get_url(use_directory_urls)
 
     def __eq__(self, other):
-
-        def sub_dict(d):
-            return {key: value for key, value in d.items() if key in ['src_path', 'abs_src_path', 'url']}
-
-        return (isinstance(other, self.__class__) and sub_dict(self.__dict__) == sub_dict(other.__dict__))
+        return (
+            isinstance(other, self.__class__) and
+            self.src_path == other.src_path and
+            self.abs_src_path == other.abs_src_path and
+            self.url == other.url
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -44,11 +44,11 @@ class Page:
         self.meta = {}
 
     def __eq__(self, other):
-
-        def sub_dict(d):
-            return {key: value for key, value in d.items() if key in ['title', 'file']}
-
-        return (isinstance(other, self.__class__) and sub_dict(self.__dict__) == sub_dict(other.__dict__))
+        return (
+            isinstance(other, self.__class__) and
+            self.title == other.title and
+            self.file == other.file
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)


### PR DESCRIPTION
This has proven to be very significant in profiling:

Before:

|ncalls|tottime |percall  |**cumtime** |percall  |filename:lineno(function)|
|------|--------|---------|--------|---------|-------------------------|
|128695|0.1908  |1.483e-06|**1.169**   |9.082e-06|pages.py:46(`__eq__`)      |
|**119617**|0.12    |1.003e-06|**0.4357**  |3.643e-06|files.py:127(`__eq__`)     |

After:

|ncalls|tottime |percall  |**cumtime** |percall  |filename:lineno(function)|
|------|--------|---------|--------|---------|-------------------------|
|128695|0.06688 |5.197e-07|**0.08264** |6.421e-07|pages.py:46(`__eq__`)      |
|**1842**  |0.001276|6.926e-07|**0.001434**|7.787e-07|files.py:127(`__eq__`)     |
