### PR TITLE
Don't check the filesystem for edits to template files during a build

### DIFF
--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -107,7 +107,8 @@ class Theme:
         """ Return a Jinja environment for the theme. """
 
         loader = jinja2.FileSystemLoader(self.dirs)
-        env = jinja2.Environment(loader=loader)
+        # No autoreload because editing a template in the middle of a build is not useful.
+        env = jinja2.Environment(loader=loader, auto_reload=False)
         env.filters['tojson'] = filters.tojson
         env.filters['url'] = filters.url_filter
         return env


### PR DESCRIPTION
MkDocs templates are quite heavily split into files and [can even be nested][1] (particularly for navs, which also repeat on every page).
    
Any time a template is referenced, even though it's cached in memory, Jinja ends up doing a filesystem access, to check whether the template file has been modified and so would need to be recompiled.
But it's not even useful to be able to modify a template file on disk in the middle of a mkdocs build.
    
So, by disabling autoreload, we eliminate all these filesystem accesses (on the order of thousands), other than the initial one per template.

The lifetime of the Jinja environment is the lifetime of a `mkdocs build`, and a `mkdocs serve` creates a new one each time anyway, so that is not affected.

---

For my site of 134 pages with a heavily nested nav (w/ material theme), this changes from

ncalls | tottime | percall | cumtime | percall | filename:lineno(function)
-- | -- | -- | -- | -- | --
**24735** | 0.01567 | 6.335e-07 | 0.1135 | 4.587e-06 | [loaders.py:190(uptodate)](https://github.com/pallets/jinja/blob/27c65757b26bb5012df1a5ccab1340cd7d52f139/src/jinja2/loaders.py#L188)

-- to (considered negligible by the profiler). Overall that site's build time goes from 3.02s to 2.91s

And that's on an SSD; maybe some people have a worse disk where the effect would be greater.

Code references:

* https://github.com/pallets/jinja/blob/27c65757b26bb5012df1a5ccab1340cd7d52f139/src/jinja2/loaders.py#L188
* https://github.com/pallets/jinja/blob/27c65757b26bb5012df1a5ccab1340cd7d52f139/src/jinja2/environment.py#L1177
* https://github.com/pallets/jinja/blob/27c65757b26bb5012df1a5ccab1340cd7d52f139/src/jinja2/environment.py#L812





[1]: https://github.com/mkdocs/mkdocs/blob/master/mkdocs/themes/mkdocs/nav-sub.html