### PR TITLE
Don't needlessly encode a string, that's a holdover from Py2 compat

### DIFF
--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -35,15 +35,14 @@ class SearchIndex:
 
     def _add_entry(self, title, text, loc):
         """
-        A simple wrapper to add an entry and ensure the contents
-        is UTF8 encoded.
+        A simple wrapper to add an entry, dropping bad characters.
         """
         text = text.replace('\u00a0', ' ')
         text = re.sub(r'[ \t\n\r\f\v]+', ' ', text.strip())
 
         self._entries.append({
             'title': title,
-            'text': str(text.encode('utf-8'), encoding='utf-8'),
+            'text': text,
             'location': loc
         })
 


### PR DESCRIPTION
As far as I can tell, a Python `str` type can never be not encodable as UTF-8, so this doesn't check anything. And if it was `bytes` instead, well, it just doesn't have an `encode` method.

Last code change was here: https://github.com/mkdocs/mkdocs/commit/c9032bd6bfde09ead2f4f879e85590d7cd6e68a6#diff-c415bde0ad17e1a44da9e86aabf2f6ee0c21fd38ae9c459bea6589bcc61d0efbR46
