### PR TITLE
Optimize getting relative page URLs

### DIFF
--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -60,6 +60,60 @@ class UtilsTests(unittest.TestCase):
             is_html = utils.is_html_file(path)
             self.assertEqual(is_html, expected_result)
 
+    def test_get_relative_url(self):
+        expected_results = {
+            ('foo/bar', 'foo'): 'bar',
+            ('foo/bar.txt', 'foo'): 'bar.txt',
+            ('foo', 'foo/bar'): '..',
+            ('foo', 'foo/bar.txt'): '.',
+            ('foo/../../bar', '.'): 'bar',
+            ('foo/../../bar', 'foo'): '../bar',
+            ('foo//./bar/baz', 'foo/bar/baz'): '.',
+            ('a/b/.././../c', '.'): 'c',
+            ('a/b/c/d/ee', 'a/b/c/d/e'): '../ee',
+            ('a/b/c/d/ee', 'a/b/z/d/e'): '../../../c/d/ee',
+            ('foo', 'bar.'): 'foo',
+            ('foo', 'bar./'): '../foo',
+            ('foo', 'foo/bar./'): '..',
+            ('foo', 'foo/bar./.'): '..',
+            ('foo', 'foo/bar././'): '..',
+            ('foo/', 'foo/bar././'): '../',
+            ('foo', 'foo'): '.',
+            ('.foo', '.foo'): '.foo',
+            ('.foo/', '.foo'): '.foo/',
+            ('.foo', '.foo/'): '.',
+            ('.foo/', '.foo/'): './',
+            ('///', ''): './',
+            ('a///', ''): 'a/',
+            ('a///', 'a'): './',
+            ('.', 'here'): '..',
+            ('..', 'here'): '..',
+            ('../..', 'here'): '..',
+            ('../../a', 'here'): '../a',
+            ('..', 'here.txt'): '.',
+            ('a', ''): 'a',
+            ('a', '..'): 'a',
+            ('a', 'b'): '../a',
+            ('a', 'b/..'): '../a',  # The dots are considered a file. Documenting a long-standing bug.
+            ('a', 'b/../..'): 'a',
+            ('', ''): '.',
+            ('.', ''): '.',
+            ('', '.'): '.',
+            ('.', '.'): '.',
+            ('a/..../b', 'a/../b'): '../a/..../b',
+            ('a/я/b', 'a/я/c'): '../b',
+            ('a/я/b', 'a/яя/c'): '../../я/b',
+        }
+        # Leading slash intentionally ignored
+        for url_slash in ('', '/'):
+            for other_slash in ('', '/'):
+                for (url, other), expected_result in expected_results.items():
+                    # Acknowledge the only difference that a leading slash can cause:
+                    if url_slash + url == '/':
+                        expected_result += '/'
+                    relurl = utils.get_relative_url(url_slash + url, other_slash + other)
+                    self.assertEqual(relurl, expected_result)
+
     def test_create_media_urls(self):
 
         expected_results = {

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -255,13 +255,13 @@ def get_relative_url(url, other):
     """
     Return given url relative to other.
     """
-    other_parts = [p for p in other.split('/') if p not in ('.', '')]
-    dest_parts = [p for p in url.split('/') if p not in ('.', '')]
-
+    other_parts = other.split('/')
     # Remove filename from other url if it has one.
     if other_parts and '.' in other_parts[-1]:
         other_parts.pop()
 
+    other_parts = [p for p in other_parts if p not in ('.', '')]
+    dest_parts = [p for p in url.split('/') if p not in ('.', '')]
     common = 0
     for a, b in zip(other_parts, dest_parts):
         if a != b:
@@ -270,7 +270,6 @@ def get_relative_url(url, other):
 
     rel_parts = ['..'] * (len(other_parts) - common) + dest_parts[common:]
     relurl = '/'.join(rel_parts) or '.'
-
     return relurl + '/' if url.endswith('/') else relurl
 
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -251,9 +251,10 @@ def is_error_template(path):
     return bool(_ERROR_TEMPLATE_RE.match(path))
 
 
+@functools.lru_cache(maxsize=None)
 def _norm_parts(parts):
     dest_parts = []
-    for p in parts:
+    for p in parts.split('/'):
         if p not in ('.', ''):
             if p == '..':
                 if dest_parts:
@@ -267,14 +268,13 @@ def get_relative_url(url, other):
     """
     Return given url relative to other.
     """
-    other_parts = other.split('/')
     # Remove filename from other url if it has one.
-    if other_parts and '.' in other_parts[-1]:
-        other_parts.pop()
+    dirname, _, basename = other.rpartition('/')
+    if '.' in basename:
+        other = dirname
 
-    other_parts = _norm_parts(other_parts)
-    dest_parts = _norm_parts(url.split('/'))
-
+    other_parts = _norm_parts(other)
+    dest_parts = _norm_parts(url)
     common = 0
     for a, b in zip(other_parts, dest_parts):
         if a != b:

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -251,6 +251,18 @@ def is_error_template(path):
     return bool(_ERROR_TEMPLATE_RE.match(path))
 
 
+def _norm_parts(parts):
+    dest_parts = []
+    for p in parts:
+        if p not in ('.', ''):
+            if p == '..':
+                if dest_parts:
+                    dest_parts.pop()
+            else:
+                dest_parts.append(p)
+    return dest_parts
+
+
 def get_relative_url(url, other):
     """
     Return given url relative to other.
@@ -260,8 +272,9 @@ def get_relative_url(url, other):
     if other_parts and '.' in other_parts[-1]:
         other_parts.pop()
 
-    other_parts = [p for p in other_parts if p not in ('.', '')]
-    dest_parts = [p for p in url.split('/') if p not in ('.', '')]
+    other_parts = _norm_parts(other_parts)
+    dest_parts = _norm_parts(url.split('/'))
+
     common = 0
     for a, b in zip(other_parts, dest_parts):
         if a != b:

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -252,21 +252,27 @@ def is_error_template(path):
 
 
 @functools.lru_cache(maxsize=None)
-def _norm_parts(parts):
-    dest_parts = []
-    for p in parts.split('/'):
+def _norm_parts(path):
+    parts = []
+    for p in path.split('/'):
         if p not in ('.', ''):
             if p == '..':
-                if dest_parts:
-                    dest_parts.pop()
+                if parts:
+                    parts.pop()
             else:
-                dest_parts.append(p)
-    return dest_parts
+                parts.append(p)
+    return parts
 
 
 def get_relative_url(url, other):
     """
     Return given url relative to other.
+
+    Both are operated as slash-separated paths, similarly to the 'path' part of a URL.
+    The last component of `other` is skipped if it contains a dot (considered a file).
+    Actual URLs (with schemas etc.) aren't supported. The leading slash is ignored.
+    Paths are normalized ('..' works as parent directory), but going higher than the
+    root has no effect ('foo/../../bar' ends up just as 'bar').
     """
     # Remove filename from other url if it has one.
     dirname, _, basename = other.rpartition('/')


### PR DESCRIPTION
This is a custom implementation that's ~5 times faster. That's important because calls to `normalize_url` on a site with ~300 pages currently take up ~20% of the total run time due to the sheer number of them. The number of calls is at least the number of pages squared.

The old implementation relied on `posixpath.relpath`, which (among other unnecessary parts) first expands every path with `abspath` for whatever reason, so actually it becomes even slower if you happen to be building under a deeply nested path.

### Profile before/after

![profile](https://user-images.githubusercontent.com/371383/103169437-da705f80-483b-11eb-986c-4700b86eb111.gif)

#### In context

![profile](https://user-images.githubusercontent.com/371383/103169440-e52af480-483b-11eb-81ae-83d72d7a478d.gif)
