### PR TITLE
Don't neglect to register our Markdown extension

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -240,5 +240,6 @@ class _RelativePathExtension(Extension):
         self.files = files
 
     def extendMarkdown(self, md):
+        md.registerExtension(self)
         relpath = _RelativePathTreeprocessor(self.file, self.files)
         md.treeprocessors.register(relpath, "relpath", 0)


### PR DESCRIPTION
(all other "normal" extensions do this)

---

My use case for this is that I am rendering a Markdown sub-document that is to be re-integrated into the root document, and I want to inherit all the Markdown extensions.

I create a markdown instance like `new_md = Markdown(extensions=old_md.registeredExtensions)` but this `_RelativePathExtension` extension is skipped from that because it never registered itself.

I see that this extension is not public on purpose, and I'm trying not to instantiate it directly, but I think copying it like this should not be prevented.