### PR TITLE
Unpin lunr.py dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'click>=3.3',
         'Jinja2>=2.10.1',
         'livereload>=2.5.1',
-        'lunr[languages]==0.5.8',  # must support lunr.js version included in search
+        'lunr[languages]>=0.5.8',  # must support lunr.js version included in search
         'Markdown>=3.2.1',
         'PyYAML>=3.10',
         'tornado>=5.0',


### PR DESCRIPTION
Hi all, I was about to release a new version of lunr.py and started to get errors while building the docs, this is because mkdocs is pinning it to 0.5.8 which raises a version conflict error.

I've read through https://github.com/mkdocs/mkdocs/issues/2062 and decided to [restrict lunr.py to nltk<3.5](https://github.com/yeraydiazdiaz/lunr.py/pull/89/commits/b648c9206b5f0d113ab8725fda3a95d1a944ad91) to avoid these installation issues. However mkdocs does need to loosen the restrictions on lunr for us to build the docs moving forward.

This does introduce a slight problem though, when we release a new version of lunr.py users of mkdocs will get a version that may be out of sync with the version of lunr.js mkdocs ships with. In practice this is not a big problem because there's usually very minor differences between lunr.js versions. The solution is to make sure things are in sync before releasing so I'm happy to make a PR to mkdocs after each release of lunr.py to make sure things are sync.