### PR TITLE
Modify the syntax of version option and checking python version

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -8,7 +8,7 @@ import click
 PYTHON_VERSION = sys.version[:3]
 # TODO: Remove this check at some point in the future.
 # (also remove flake8's 'ignore E402' comments below)
-if PYTHON_VERSION[0] != '3':  # pragma: no cover
+if PYTHON_VERSION < '3':  # pragma: no cover
     raise ImportError('A recent version of Python 3 is required.')
 
 from mkdocs import __version__                            # noqa: E402
@@ -115,8 +115,7 @@ PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 @click.version_option(
     __version__,
     '-V', '--version',
-    message='%(prog)s, version %(version)s from {} (Python {})'.format(
-        PKG_DIR, PYTHON_VERSION)
+    message=f'(prog)s, version %(version)s from { PKG_DIR } (Python { PYTHON_VERSION })'
 )
 @common_options
 def cli():

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -5,11 +5,11 @@ import sys
 import logging
 import click
 
-from mkdocs import __version__                            # noqa: E402
-from mkdocs import utils                                  # noqa: E402
-from mkdocs import exceptions                             # noqa: E402
-from mkdocs import config                                 # noqa: E402
-from mkdocs.commands import build, gh_deploy, new, serve  # noqa: E402
+from mkdocs import __version__
+from mkdocs import utils
+from mkdocs import exceptions
+from mkdocs import config
+from mkdocs.commands import build, gh_deploy, new, serve
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -110,6 +110,7 @@ common_config_options = add_options([
 
 PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
 @click.version_option(
     __version__,

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -115,7 +115,7 @@ PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 @click.version_option(
     __version__,
     '-V', '--version',
-    message=f'(prog)s, version %(version)s from { PKG_DIR } (Python { PYTHON_VERSION })'
+    message=f'%(prog)s, version %(version)s from { PKG_DIR } (Python { PYTHON_VERSION })'
 )
 @common_options
 def cli():

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -5,9 +5,10 @@ import sys
 import logging
 import click
 
+PYTHON_VERSION = sys.version[:3]
 # TODO: Remove this check at some point in the future.
 # (also remove flake8's 'ignore E402' comments below)
-if sys.version_info[0] < 3:  # pragma: no cover
+if PYTHON_VERSION[0] != '3':  # pragma: no cover
     raise ImportError('A recent version of Python 3 is required.')
 
 from mkdocs import __version__                            # noqa: E402
@@ -107,13 +108,18 @@ common_config_options = add_options([
     click.option('--use-directory-urls/--no-directory-urls', is_flag=True, default=None, help=use_directory_urls_help)
 ])
 
-pgk_dir = os.path.dirname(os.path.abspath(__file__))
-
+PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
+#@click.version_option(
+#    '{} from {} (Python {})'.format(__version__, pgk_dir, sys.version[:3]),
+#    '-V', '--version')
 @click.version_option(
-    '{} from {} (Python {})'.format(__version__, pgk_dir, sys.version[:3]),
-    '-V', '--version')
+    __version__,
+    '-V', '--version',
+    message='%(prog)s, version %(version)s from {} (Python {})'.format(
+        PKG_DIR, PYTHON_VERSION)
+)
 @common_options
 def cli():
     """

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -5,12 +5,6 @@ import sys
 import logging
 import click
 
-PYTHON_VERSION = sys.version[:3]
-# TODO: Remove this check at some point in the future.
-# (also remove flake8's 'ignore E402' comments below)
-if PYTHON_VERSION < '3':  # pragma: no cover
-    raise ImportError('A recent version of Python 3 is required.')
-
 from mkdocs import __version__                            # noqa: E402
 from mkdocs import utils                                  # noqa: E402
 from mkdocs import exceptions                             # noqa: E402
@@ -107,6 +101,8 @@ common_config_options = add_options([
     # override the config file
     click.option('--use-directory-urls/--no-directory-urls', is_flag=True, default=None, help=use_directory_urls_help)
 ])
+
+PYTHON_VERSION = sys.version[:3]
 
 PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -111,9 +111,6 @@ common_config_options = add_options([
 PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
-#@click.version_option(
-#    '{} from {} (Python {})'.format(__version__, pgk_dir, sys.version[:3]),
-#    '-V', '--version')
 @click.version_option(
     __version__,
     '-V', '--version',


### PR DESCRIPTION
- Use message  and  version arguments of click.version_option for better syntax instead string formatting.
- Modify pgk_dir typo.
- FIx pylint: C0103.
- DRY: remove repeated call of python version and add PYTHON_VERSION.