### PR TITLE
Fix search function for large documents

### DIFF
--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -95,4 +95,5 @@ if (!window.Worker) {
   var searchWorker = new Worker(joinUrl(base_url, "search/worker.js"));
   searchWorker.postMessage({init: true});
   searchWorker.onmessage = onWorkerMessage;
+  doSearch()
 }


### PR DESCRIPTION
The search function does not function for documents of a certain size and above, this will fix that.
Hopefully it is not a controversial change.