### PR TITLE
Add error when the GitHub Pages custom domain does not match local CNAME file

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -51,6 +51,7 @@ remote_name_help = ("The remote name to commit to for Github Pages. This "
                     "overrides the value specified in config")
 force_help = "Force the push to the repository."
 ignore_version_help = "Ignore check that build is not being deployed with an older version of MkDocs."
+ignore_cname_help = "Ignore check that deploying will remove an existing CNAME file."
 watch_theme_help = ("Include the theme in list of files to watch for live reloading. "
                     "Ignored when live reload is not used.")
 wait_help = "Wait the specified number of seconds before reloading (default 0)."
@@ -168,10 +169,12 @@ def build_command(clean, **kwargs):
 @click.option('--force', is_flag=True, help=force_help)
 @click.option('--ignore-version', is_flag=True, help=ignore_version_help)
 @click.option('--shell', is_flag=True, help=shell_help)
+@click.option('--ignore-cname', is_flag=True, help=ignore_cname_help)
 @common_config_options
 @click.option('-d', '--site-dir', type=click.Path(), help=site_dir_help)
 @common_options
-def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_version, shell, **kwargs):
+def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_version, shell,
+                      ignore_cname, **kwargs):
     """Deploy your documentation to GitHub Pages"""
     try:
         cfg = config.load_config(
@@ -180,7 +183,8 @@ def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_
             **kwargs
         )
         build.build(cfg, dirty=not clean)
-        gh_deploy.gh_deploy(cfg, message=message, force=force, ignore_version=ignore_version, shell=shell)
+        gh_deploy.gh_deploy(cfg, message=message, force=force, ignore_version=ignore_version,
+                            shell=shell, ignore_cname=ignore_cname)
     except exceptions.ConfigurationError as e:  # pragma: no cover
         # Avoid ugly, unhelpful traceback
         raise SystemExit('\n' + str(e))

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -51,7 +51,6 @@ remote_name_help = ("The remote name to commit to for Github Pages. This "
                     "overrides the value specified in config")
 force_help = "Force the push to the repository."
 ignore_version_help = "Ignore check that build is not being deployed with an older version of MkDocs."
-ignore_cname_help = "Ignore check that deploying will remove an existing CNAME file."
 watch_theme_help = ("Include the theme in list of files to watch for live reloading. "
                     "Ignored when live reload is not used.")
 wait_help = "Wait the specified number of seconds before reloading (default 0)."
@@ -169,12 +168,10 @@ def build_command(clean, **kwargs):
 @click.option('--force', is_flag=True, help=force_help)
 @click.option('--ignore-version', is_flag=True, help=ignore_version_help)
 @click.option('--shell', is_flag=True, help=shell_help)
-@click.option('--ignore-cname', is_flag=True, help=ignore_cname_help)
 @common_config_options
 @click.option('-d', '--site-dir', type=click.Path(), help=site_dir_help)
 @common_options
-def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_version, shell,
-                      ignore_cname, **kwargs):
+def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_version, shell, **kwargs):
     """Deploy your documentation to GitHub Pages"""
     try:
         cfg = config.load_config(
@@ -183,8 +180,7 @@ def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_
             **kwargs
         )
         build.build(cfg, dirty=not clean)
-        gh_deploy.gh_deploy(cfg, message=message, force=force, ignore_version=ignore_version,
-                            shell=shell, ignore_cname=ignore_cname)
+        gh_deploy.gh_deploy(cfg, message=message, force=force, ignore_version=ignore_version, shell=shell)
     except exceptions.ConfigurationError as e:  # pragma: no cover
         # Avoid ugly, unhelpful traceback
         raise SystemExit('\n' + str(e))

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -84,6 +84,19 @@ def _check_version(branch):
 
 
 def _check_cname(remote_name, branch, current_cname, site_dir):
+    # Fetch the gh-pages branch so that we can check the latest CNAME file.
+    # It's also possible that the gh-pages branch has never been fetched at
+    # all.
+    proc = subprocess.Popen(["git", "fetch", "--no-write-fetch-head", remote_name, branch],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    _, _ = proc.communicate()
+    if(proc.returncode != 0):
+        # Couldn't fetch the branch so it doesn't exist and there's no way
+        # an existing CNAME could be configured.
+        return
+
+    # Get the contents of the CNAME file on the gh-pages branch.
     object_name = "%s/%s:CNAME" % (remote_name, branch)
     proc = subprocess.Popen(["git", "show", object_name],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -114,14 +114,15 @@ def _check_cname(remote_name, branch, current_cname, site_dir):
 
     if current_cname != cname:
         log.error(
-            'Deployment terminated: gh-pages is configured with CNAME {} but '
-            'there isn\'t a matching CNAME file at {}/CNAME. Either create the '
-            'CNAME file or use --ignore-cname to deploy anyway.'.format(cname, site_dir)
+            'Deployment terminated: gh-pages is configured with a custom '
+            'domain ({}) but there isn\'t a matching CNAME file at {}/CNAME. '
+            'Create or update docs/CNAME file with the custom domain.'.format(
+                cname, site_dir)
         )
         raise SystemExit(1)
 
 
-def gh_deploy(config, message=None, force=False, ignore_version=False, shell=False, ignore_cname=False):
+def gh_deploy(config, message=None, force=False, ignore_version=False, shell=False):
 
     if not _is_cwd_git_repo():
         log.error('Cannot deploy - this directory does not appear to be a git '
@@ -142,8 +143,7 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
     else:
         cname_host = None
 
-    if not ignore_cname:
-        _check_cname(remote_name, remote_branch, cname_host, config['site_dir'])
+    _check_cname(remote_name, remote_branch, cname_host, config['site_dir'])
 
     if message is None:
         message = default_message

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -80,7 +80,7 @@ class TestGitHubDeploy(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_check_cname_non_existent(self, mock_popeno):
         mock_popeno().communicate.return_value = (b'', b'Not found')
-        mock_popeno().returncode = 128
+        type(mock_popeno).returncode = mock.PropertyMock(side_effect=[0, 128])
 
         try:
             gh_deploy._check_cname('origin', 'gh-pages', 'not-docs.example.com', 'docs')
@@ -240,7 +240,7 @@ class TestGitHubDeployLogs(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_check_cname_differ(self, mock_popeno):
 
-        mock_popeno().communicate.return_value = (b'docs.example.com\n', b'')
+        mock_popeno().communicate.side_effect = [(b'', b''), (b'docs.example.com\n', b'')]
         mock_popeno().returncode = 0
 
         with self.assertLogs('mkdocs', level='ERROR') as cm:

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -167,20 +167,6 @@ class TestGitHubDeploy(unittest.TestCase):
 
     @mock.patch('mkdocs.commands.gh_deploy._is_cwd_git_repo', return_value=True)
     @mock.patch('mkdocs.commands.gh_deploy._get_current_sha', return_value='shashas')
-    @mock.patch('mkdocs.commands.gh_deploy._get_remote_url', return_value=(None, None))
-    @mock.patch('mkdocs.commands.gh_deploy._check_version')
-    @mock.patch('mkdocs.commands.gh_deploy._check_cname')
-    @mock.patch('ghp_import.ghp_import')
-    def test_deploy_ignore_cname(self, mock_import, check_cname, check_version, get_remote, get_sha, is_repo):
-
-        config = load_config(
-            remote_branch='test',
-        )
-        gh_deploy.gh_deploy(config, ignore_cname=True)
-        check_cname.assert_not_called()
-
-    @mock.patch('mkdocs.commands.gh_deploy._is_cwd_git_repo', return_value=True)
-    @mock.patch('mkdocs.commands.gh_deploy._get_current_sha', return_value='shashas')
     @mock.patch('mkdocs.commands.gh_deploy._check_version')
     @mock.patch('ghp_import.ghp_import')
     @mock.patch('mkdocs.commands.gh_deploy.log')
@@ -248,7 +234,7 @@ class TestGitHubDeployLogs(unittest.TestCase):
 
         self.assertEqual(
             cm.output,
-            ['ERROR:mkdocs.commands.gh_deploy:Deployment terminated: gh-pages is configured with CNAME '
-             'docs.example.com but there isn\'t a matching CNAME file at docs/CNAME. Either create the CNAME file or '
-             'use --ignore-cname to deploy anyway.']
+            ['ERROR:mkdocs.commands.gh_deploy:Deployment terminated: gh-pages is configured with a custom domain '
+             '(docs.example.com) but there isn\'t a matching CNAME file at docs/CNAME. Create or update docs/CNAME '
+             'file with the custom domain.']
         )


### PR DESCRIPTION
Although documentation was added in #1496 around needing to place the CNAME file for custom domains in your docs_dir, GitHub's default behavior of adding the CNAME directly to the gh-pages branch means that lots of folks will get bitten. This has the unfortunate and severe side effect of taking their site down and it's not immediately obvious what went wrong. This PR adds a new check: if there's a CNAME file in the gh-pages branch and it doesn't match the CNAME file in docs_dir (or the CNAME file in docs_dir doesn't exist) it will terminate the deployment. It adds a flag called "--ignore-cname" to bypass this check.

This is my first time contributing to mkdocs, so I hope I did everything as expected. Please let me know if there's any extra steps or stylistic changes needed.