### PR TITLE
Exclude edge cases where get_relative_url depends on CWD

### DIFF
--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -96,23 +96,26 @@ class UtilsTests(unittest.TestCase):
             ('a', 'b'): '../a',
             ('a', 'b/..'): '../a',  # The dots are considered a file. Documenting a long-standing bug.
             ('a', 'b/../..'): 'a',
-            ('', ''): '.',
-            ('.', ''): '.',
-            ('', '.'): '.',
-            ('.', '.'): '.',
             ('a/..../b', 'a/../b'): '../a/..../b',
             ('a/я/b', 'a/я/c'): '../b',
             ('a/я/b', 'a/яя/c'): '../../я/b',
         }
-        # Leading slash intentionally ignored
-        for url_slash in ('', '/'):
-            for other_slash in ('', '/'):
-                for (url, other), expected_result in expected_results.items():
-                    # Acknowledge the only difference that a leading slash can cause:
-                    if url_slash + url == '/':
-                        expected_result += '/'
-                    relurl = utils.get_relative_url(url_slash + url, other_slash + other)
-                    self.assertEqual(relurl, expected_result)
+        for (url, other), expected_result in expected_results.items():
+            # Leading slash intentionally ignored
+            self.assertEqual(utils.get_relative_url(url, other), expected_result)
+            self.assertEqual(utils.get_relative_url('/' + url, other), expected_result)
+            self.assertEqual(utils.get_relative_url(url, '/' + other), expected_result)
+            self.assertEqual(utils.get_relative_url('/' + url, '/' + other), expected_result)
+
+    def test_get_relative_url_empty(self):
+        for url in ['', '.', '/.']:
+            for other in ['', '.', '/', '/.']:
+                self.assertEqual(utils.get_relative_url(url, other), '.')
+
+        self.assertEqual(utils.get_relative_url('/', ''), './')
+        self.assertEqual(utils.get_relative_url('/', '/'), './')
+        self.assertEqual(utils.get_relative_url('/', '.'), './')
+        self.assertEqual(utils.get_relative_url('/', '/.'), './')
 
     def test_create_media_urls(self):
 

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -60,6 +60,60 @@ class UtilsTests(unittest.TestCase):
             is_html = utils.is_html_file(path)
             self.assertEqual(is_html, expected_result)
 
+    def test_get_relative_url(self):
+        expected_results = {
+            ('foo/bar', 'foo'): 'bar',
+            ('foo/bar.txt', 'foo'): 'bar.txt',
+            ('foo', 'foo/bar'): '..',
+            ('foo', 'foo/bar.txt'): '.',
+            ('foo/../../bar', '.'): 'bar',
+            ('foo/../../bar', 'foo'): '../bar',
+            ('foo//./bar/baz', 'foo/bar/baz'): '.',
+            ('a/b/.././../c', '.'): 'c',
+            ('a/b/c/d/ee', 'a/b/c/d/e'): '../ee',
+            ('a/b/c/d/ee', 'a/b/z/d/e'): '../../../c/d/ee',
+            ('foo', 'bar.'): 'foo',
+            ('foo', 'bar./'): '../foo',
+            ('foo', 'foo/bar./'): '..',
+            ('foo', 'foo/bar./.'): '..',
+            ('foo', 'foo/bar././'): '..',
+            ('foo/', 'foo/bar././'): '../',
+            ('foo', 'foo'): '.',
+            ('.foo', '.foo'): '.foo',
+            ('.foo/', '.foo'): '.foo/',
+            ('.foo', '.foo/'): '.',
+            ('.foo/', '.foo/'): './',
+            ('///', ''): './',
+            ('a///', ''): 'a/',
+            ('a///', 'a'): './',
+            ('.', 'here'): '..',
+            ('..', 'here'): '..',
+            ('../..', 'here'): '..',
+            ('../../a', 'here'): '../a',
+            ('..', 'here.txt'): '.',
+            ('a', ''): 'a',
+            ('a', '..'): 'a',
+            ('a', 'b'): '../a',
+            ('a', 'b/..'): '../a',  # The dots are considered a file. Documenting a long-standing bug.
+            ('a', 'b/../..'): 'a',
+            ('', ''): '.',
+            ('.', ''): '.',
+            ('', '.'): '.',
+            ('.', '.'): '.',
+            ('a/..../b', 'a/../b'): '../a/..../b',
+            ('a/я/b', 'a/я/c'): '../b',
+            ('a/я/b', 'a/яя/c'): '../../я/b',
+        }
+        # Leading slash intentionally ignored
+        for url_slash in ('', '/'):
+            for other_slash in ('', '/'):
+                for (url, other), expected_result in expected_results.items():
+                    # Acknowledge the only difference that a leading slash can cause:
+                    if url_slash + url == '/':
+                        expected_result += '/'
+                    relurl = utils.get_relative_url(url_slash + url, other_slash + other)
+                    self.assertEqual(relurl, expected_result)
+
     def test_create_media_urls(self):
 
         expected_results = {

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -259,7 +259,7 @@ def get_relative_url(url, other):
         # Remove filename from other url if it has one.
         parts = posixpath.split(other)
         other = parts[0] if '.' in parts[1] else other
-    relurl = posixpath.relpath(url, other)
+    relurl = posixpath.relpath('/' + url, '/' + other)
     return relurl + '/' if url.endswith('/') else relurl
 
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -254,6 +254,12 @@ def is_error_template(path):
 def get_relative_url(url, other):
     """
     Return given url relative to other.
+
+    Both are operated as slash-separated paths, similarly to the 'path' part of a URL.
+    The last component of `other` is skipped if it contains a dot (considered a file).
+    Actual URLs (with schemas etc.) aren't supported. The leading slash is ignored.
+    Paths are normalized ('..' works as parent directory), but going higher than the
+    root has no effect ('foo/../../bar' ends up just as 'bar').
     """
     if other != '.':
         # Remove filename from other url if it has one.


### PR DESCRIPTION
When only one of the two passed paths starts with a slash, this function would produce results that depend on (and expose parts of) the actual current working directory.
In a similar manner, it was also possible to "break out" of the "current directory" by starting one of the paths with `../../..` etc.

Additionally, the fact that paths always end up being resolved relative to the current working directory made this function less efficient than it needs to be.
Fun fact: `get_relative_url('path_a', 'path_b')` actually ended up looking up how to get to `/current/working/directory/path_a` from `/current/working/directory/path_b`.

Luckily, none of these behaviors can ever actually come into effect (the function is always called without a leading slash and without paths deliberately trying to escape), but the fix is still good to reduce surprise.

*The actual fix* is that we make the leading slash ignored (or quite the opposite - we always add it).
Now when either of the two arguments try to go up higher than the top level, they just end up at the top level (e.g. `foo/../..` is effectively `.`), only then the "relative" calculation happens.

---

This pull request makes the behavior 100% the same as in https://github.com/mkdocs/mkdocs/pull/2272, but without the disadvantage of being a "custom replacement for the standard lib function". It also brings 35% of the performance advantage.

Build times of a site that has ~350 pages:

* When running from directory `/home/oprypin/repos/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/athena-website`:
  * Before: 11.1 sec
  * After: 8.22 sec
* When running from directory `/home/oprypin/repos/athena-website`:
  * Before: 9.02 sec
  * After: 8.15 sec

(meanwhile, https://github.com/mkdocs/mkdocs/pull/2272 achieves 6.65 sec)