### PR TITLE
Skip duplicated error message when omitting the traceback

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -179,7 +179,11 @@ def _populate_page(page, config, files, dirty=False):
             'page_content', page.content, page=page, config=config, files=files
         )
     except Exception as e:
-        log.error("Error reading page '{}': {}".format(page.file.src_path, e))
+        message = f"Error reading page '{page.file.src_path}':"
+        # Prevent duplicated the error message because it will be printed immediately afterwards.
+        if not isinstance(e, BuildError):
+            message += f" {e}"
+        log.error(message)
         raise
 
 
@@ -227,7 +231,11 @@ def _build_page(page, config, doc_files, nav, env, dirty=False):
         # Deactivate page
         page.active = False
     except Exception as e:
-        log.error("Error building page '{}': {}".format(page.file.src_path, e))
+        message = f"Error building page '{page.file.src_path}':"
+        # Prevent duplicated the error message because it will be printed immediately afterwards.
+        if not isinstance(e, BuildError):
+            message += f" {e}"
+        log.error(message)
         raise
 
 


### PR DESCRIPTION
[The new BuildError exception](https://github.com/mkdocs/mkdocs/pull/2103) is good for skipping the traceback, but now that it's skipped, the two copies of the error mesage (one from logging, one from reaching `SystemExit`) end up immediately following each other, which looks strange.
So, skip logging the exception's message when encountering a `BuildError` in `_populate_page` and `_build_page`.

<details><summary>Error output for other uncaught exception (no change here)</summary>

```
INFO    -  Cleaning site directory 
ERROR   -  Error reading page 'some/page.md': Some error message
Traceback (most recent call last):
  File "", line , in
    zzz
  File "", line , in
    zzz
  File "", line , in
    zzz
  File "", line , in
    zzz
  File "", line , in
    zzz
some_module.SomeException: Some error message
```

</details>

<details><summary>Error output for PluginError exception, currently</summary>

```
INFO    -  Cleaning site directory 
ERROR   -  Error reading page 'some/page.md': Some error message 

Some error message
```

</details>

<details><summary>Error output for PluginError exception, with this change</summary>

```
INFO    -  Cleaning site directory 
ERROR   -  Error reading page 'some/page.md':

Some error message
```

</details>