### PR TITLE
Use f-strings instead of formatting

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -116,7 +116,7 @@ def _build_theme_template(template_name, env, files, config, nav):
         utils.write_file(output.encode('utf-8'), output_path)
 
         if template_name == 'sitemap.xml':
-            log.debug("Gzipping template: %s", template_name)
+            log.debug(f"Gzipping template: {template_name}")
             gz_filename = f'{output_path}.gz'
             with open(gz_filename, 'wb') as f:
                 timestamp = utils.get_build_timestamp()
@@ -261,7 +261,7 @@ def build(config, live_server=False, dirty=False):
                         " links within your site. This option is designed for site development purposes only.")
 
         if not live_server:  # pragma: no cover
-            log.info("Building documentation to directory: %s", config['site_dir'])
+            log.info(f"Building documentation to directory: {config['site_dir']}")
             if dirty and site_directory_contains_stale_files(config['site_dir']):
                 log.info("The directory contains stale files. Use --clean to remove them.")
 
@@ -281,7 +281,7 @@ def build(config, live_server=False, dirty=False):
 
         log.debug("Reading markdown pages.")
         for file in files.documentation_pages():
-            log.debug("Reading: " + file.src_path)
+            log.debug(f"Reading: {file.src_path}")
             _populate_page(file.page, config, files, dirty)
 
         # Run `env` plugin events.

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -101,12 +101,12 @@ def _build_template(name, template, files, config, nav):
 def _build_theme_template(template_name, env, files, config, nav):
     """ Build a template using the theme environment. """
 
-    log.debug("Building theme template: {}".format(template_name))
+    log.debug(f"Building theme template: {template_name}")
 
     try:
         template = env.get_template(template_name)
     except TemplateNotFound:
-        log.warning("Template skipped: '{}' not found in theme directories.".format(template_name))
+        log.warning(f"Template skipped: '{template_name}' not found in theme directories.")
         return
 
     output = _build_template(template_name, template, files, config, nav)
@@ -117,30 +117,30 @@ def _build_theme_template(template_name, env, files, config, nav):
 
         if template_name == 'sitemap.xml':
             log.debug("Gzipping template: %s", template_name)
-            gz_filename = '{}.gz'.format(output_path)
+            gz_filename = f'{output_path}.gz'
             with open(gz_filename, 'wb') as f:
                 timestamp = utils.get_build_timestamp()
                 with gzip.GzipFile(fileobj=f, filename=gz_filename, mode='wb', mtime=timestamp) as gz_buf:
                     gz_buf.write(output.encode('utf-8'))
     else:
-        log.info("Template skipped: '{}' generated empty output.".format(template_name))
+        log.info(f"Template skipped: '{template_name}' generated empty output.")
 
 
 def _build_extra_template(template_name, files, config, nav):
     """ Build user templates which are not part of the theme. """
 
-    log.debug("Building extra template: {}".format(template_name))
+    log.debug(f"Building extra template: {template_name}")
 
     file = files.get_file_from_path(template_name)
     if file is None:
-        log.warning("Template skipped: '{}' not found in docs_dir.".format(template_name))
+        log.warning(f"Template skipped: '{template_name}' not found in docs_dir.")
         return
 
     try:
         with open(file.abs_src_path, 'r', encoding='utf-8', errors='strict') as f:
             template = jinja2.Template(f.read())
     except Exception as e:
-        log.warning("Error reading template '{}': {}".format(template_name, e))
+        log.warning(f"Error reading template '{template_name}': {e}")
         return
 
     output = _build_template(template_name, template, files, config, nav)
@@ -148,7 +148,7 @@ def _build_extra_template(template_name, files, config, nav):
     if output.strip():
         utils.write_file(output.encode('utf-8'), file.abs_dest_path)
     else:
-        log.info("Template skipped: '{}' generated empty output.".format(template_name))
+        log.info(f"Template skipped: '{template_name}' generated empty output.")
 
 
 def _populate_page(page, config, files, dirty=False):
@@ -196,7 +196,7 @@ def _build_page(page, config, doc_files, nav, env, dirty=False):
         if dirty and not page.file.is_modified():
             return
 
-        log.debug("Building page {}".format(page.file.src_path))
+        log.debug(f"Building page {page.file.src_path}")
 
         # Activate page. Signals to theme that this is the current page.
         page.active = True
@@ -226,7 +226,7 @@ def _build_page(page, config, doc_files, nav, env, dirty=False):
         if output.strip():
             utils.write_file(output.encode('utf-8', errors='xmlcharrefreplace'), page.file.abs_dest_path)
         else:
-            log.info("Page skipped: '{}'. Generated empty output.".format(page.file.src_path))
+            log.info(f"Page skipped: '{page.file.src_path}'. Generated empty output.")
 
         # Deactivate page
         page.active = False
@@ -310,7 +310,7 @@ def build(config, live_server=False, dirty=False):
         config['plugins'].run_event('post_build', config=config)
 
         if config['strict'] and utils.warning_filter.count:
-            raise SystemExit('\nExited with {} warnings in strict mode.'.format(utils.warning_filter.count))
+            raise SystemExit(f'\nExited with {utils.warning_filter.count} warnings in strict mode.')
 
         log.info('Documentation built in %.2f seconds', time() - start)
 

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -123,8 +123,8 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
         # This GitHub pages repository has a CNAME configured.
         with(open(cname_file, 'r')) as f:
             cname_host = f.read().strip()
-        log.info('Based on your CNAME file, your documentation should be '
-                 'available shortly at: http://%s', cname_host)
+        log.info(f'Based on your CNAME file, your documentation should be '
+                 f'available shortly at: http://{cname_host}')
         log.info('NOTE: Your DNS records must be configured appropriately for '
                  'your CNAME URL to work.')
         return
@@ -139,4 +139,4 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
         if repo.endswith('.git'):
             repo = repo[:-len('.git')]
         url = f'https://{username}.github.io/{repo}/'
-        log.info('Your documentation should shortly be available at: ' + url)
+        log.info(f"Your documentation should shortly be available at: {url}")

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -40,7 +40,7 @@ def _get_remote_url(remote_name):
 
     # No CNAME found.  We will use the origin URL to determine the GitHub
     # pages location.
-    remote = "remote.%s.url" % remote_name
+    remote = f"remote.{remote_name}.url"
     proc = subprocess.Popen(["git", "config", "--get", remote],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -59,7 +59,7 @@ def _get_remote_url(remote_name):
 
 def _check_version(branch):
 
-    proc = subprocess.Popen(['git', 'show', '-s', '--format=%s', 'refs/heads/{}'.format(branch)],
+    proc = subprocess.Popen(['git', 'show', '-s', '--format=%s', f'refs/heads/{branch}'],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     stdout, _ = proc.communicate()
@@ -114,7 +114,7 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
             nojekyll=True
         )
     except ghp_import.GhpError as e:
-        log.error("Failed to deploy to GitHub with error: \n{}".format(e.message))
+        log.error(f"Failed to deploy to GitHub with error: \n{e.message}")
         raise SystemExit(1)
 
     cname_file = os.path.join(config['site_dir'], 'CNAME')
@@ -138,5 +138,5 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
         username, repo = path.split('/', 1)
         if repo.endswith('.git'):
             repo = repo[:-len('.git')]
-        url = 'https://{}.github.io/{}/'.format(username, repo)
+        url = f'https://{username}.github.io/{repo}/'
         log.info('Your documentation should shortly be available at: ' + url)

--- a/mkdocs/commands/new.py
+++ b/mkdocs/commands/new.py
@@ -35,17 +35,17 @@ def new(output_dir):
         return
 
     if not os.path.exists(output_dir):
-        log.info('Creating project directory: %s', output_dir)
+        log.info(f'Creating project directory: {output_dir}')
         os.mkdir(output_dir)
 
-    log.info('Writing config file: %s', config_path)
+    log.info(f'Writing config file: {config_path}')
     with open(config_path, 'w', encoding='utf-8') as f:
         f.write(config_text)
 
     if os.path.exists(index_path):
         return
 
-    log.info('Writing initial docs: %s', index_path)
+    log.info(f'Writing initial docs: {index_path}')
     if not os.path.exists(docs_dir):
         os.mkdir(docs_dir)
     with open(index_path, 'w', encoding='utf-8') as f:

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -39,7 +39,7 @@ def _get_handler(site_dir, StaticFileHandler):
         def write_error(self, status_code, **kwargs):
 
             if status_code in (404, 500):
-                error_page = '{}.html'.format(status_code)
+                error_page = f'{status_code}.html'
                 if isfile(join(site_dir, error_page)):
                     self.write(Loader(site_dir).load(error_page).generate())
                 else:

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -95,7 +95,7 @@ def _static_server(host, port, site_dir):
     ])
     application.listen(port=port, address=host)
 
-    log.info('Running at: http://%s:%s/', host, port)
+    log.info(f'Running at: http://{host}:{port}/')
     log.info('Hold ctrl+c to quit.')
     try:
         ioloop.IOLoop.instance().start()

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -197,13 +197,13 @@ def load_config(config_file=None, **kwargs):
     errors, warnings = cfg.validate()
 
     for config_name, warning in warnings:
-        log.warning("Config value: '%s'. Warning: %s", config_name, warning)
+        log.warning(f"Config value: '{config_name}'. Warning: {warning}")
 
     for config_name, error in errors:
-        log.error("Config value: '%s'. Error: %s", config_name, error)
+        log.error(f"Config value: '{config_name}'. Error: {error}")
 
     for key, value in cfg.items():
-        log.debug("Config value: '%s' = %r", key, value)
+        log.debug(f"Config value: '{key}' = {value!r}")
 
     if len(errors) > 0:
         raise exceptions.ConfigurationError(

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -67,7 +67,7 @@ class Config(UserDict):
 
         for key in (set(self.keys()) - self._schema_keys):
             warnings.append((
-                key, "Unrecognised configuration name: {}".format(key)
+                key, f"Unrecognised configuration name: {key}"
             ))
 
         return failed, warnings
@@ -135,7 +135,7 @@ class Config(UserDict):
         except YAMLError as e:
             # MkDocs knows and understands ConfigurationErrors
             raise exceptions.ConfigurationError(
-                "MkDocs encountered an error parsing the configuration file: {}".format(e)
+                f"MkDocs encountered an error parsing the configuration file: {e}"
             )
 
 
@@ -149,7 +149,7 @@ def _open_config_file(config_file):
     if hasattr(config_file, 'closed') and config_file.closed:
         config_file = config_file.name
 
-    log.debug("Loading configuration file: {}".format(config_file))
+    log.debug(f"Loading configuration file: {config_file}")
 
     # If it is a string, we can assume it is a path and attempt to open it.
     if isinstance(config_file, str):
@@ -157,7 +157,7 @@ def _open_config_file(config_file):
             config_file = open(config_file, 'rb')
         else:
             raise exceptions.ConfigurationError(
-                "Config file '{}' does not exist.".format(config_file))
+                f"Config file '{config_file}' does not exist.")
 
     # Ensure file descriptor is at begining
     config_file.seek(0)

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -207,11 +207,11 @@ def load_config(config_file=None, **kwargs):
 
     if len(errors) > 0:
         raise exceptions.ConfigurationError(
-            "Aborted with {} Configuration Errors!".format(len(errors))
+            f"Aborted with {len(errors)} Configuration Errors!"
         )
     elif cfg['strict'] and len(warnings) > 0:
         raise exceptions.ConfigurationError(
-            "Aborted with {} Configuration Warnings in 'strict' mode!".format(len(warnings))
+            f"Aborted with {len(warnings)} Configuration Warnings in 'strict' mode!"
         )
 
     return cfg

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -86,8 +86,8 @@ class ConfigItems(BaseConfigOption):
                 return ()
 
         if not isinstance(value, Sequence):
-            raise ValidationError('Expected a sequence of mappings, but a %s '
-                                  'was given.' % type(value))
+            raise ValidationError(f'Expected a sequence of mappings, but a '
+                                  f'{type(value)} was given.')
 
         return [self.item_config.validate(item) for item in value]
 
@@ -145,8 +145,7 @@ class Type(OptionallyRequired):
     def run_validation(self, value):
 
         if not isinstance(value, self._type):
-            msg = ("Expected type: {} but received: {}"
-                   .format(self._type, type(value)))
+            msg = f"Expected type: {self._type} but received: {type(value)}"
         elif self.length is not None and len(value) != self.length:
             msg = ("Expected type: {0} with length {2} but received: {1} with "
                    "length {3}").format(self._type, value, self.length,
@@ -178,8 +177,7 @@ class Choice(OptionallyRequired):
 
     def run_validation(self, value):
         if value not in self.choices:
-            msg = ("Expected one of: {} but received: {}"
-                   .format(self.choices, value))
+            msg = f"Expected one of: {self.choices} but received: {value}"
         else:
             return value
 
@@ -198,9 +196,8 @@ class Deprecated(BaseConfigOption):
         if config.get(key_name) is None or self.moved_to is None:
             return
 
-        warning = ('The configuration option {} has been deprecated and '
-                   'will be removed in a future release of MkDocs.'
-                   ''.format(key_name))
+        warning = (f'The configuration option {key_name} has been deprecated and '
+                   f'will be removed in a future release of MkDocs.')
         self.warnings.append(warning)
 
         if '.' not in self.moved_to:
@@ -348,8 +345,7 @@ class FilesystemObject(Type):
         if self.config_dir and not os.path.isabs(value):
             value = os.path.join(self.config_dir, value)
         if self.exists and not self.existence_test(value):
-            raise ValidationError("The path {path} isn't an existing {name}.".
-                                  format(path=value, name=self.name))
+            raise ValidationError(f"The path {value} isn't an existing {self.name}.")
         value = os.path.abspath(value)
         assert isinstance(value, str)
         return value
@@ -448,7 +444,7 @@ class Theme(BaseConfigOption):
 
             raise ValidationError("No theme name set.")
 
-        raise ValidationError('Invalid type "{}". Expected a string or key/value pairs.'.format(type(value)))
+        raise ValidationError(f'Invalid type "{type(value)}". Expected a string or key/value pairs.')
 
     def post_validation(self, config, key_name):
         theme_config = config[key_name]
@@ -482,8 +478,7 @@ class Nav(OptionallyRequired):
     def run_validation(self, value):
 
         if not isinstance(value, list):
-            raise ValidationError(
-                "Expected a list, got {}".format(type(value)))
+            raise ValidationError(f"Expected a list, got {type(value)}")
 
         if len(value) == 0:
             return
@@ -547,8 +542,7 @@ class MarkdownExtensions(OptionallyRequired):
                 if cfg is None:
                     continue
                 if not isinstance(cfg, dict):
-                    raise ValidationError('Invalid config options for Markdown '
-                                          "Extension '{}'.".format(ext))
+                    raise ValidationError(f"Invalid config options for Markdown Extension '{ext}'.")
                 self.configdata[ext] = cfg
             elif isinstance(item, str):
                 extensions.append(item)
@@ -596,8 +590,7 @@ class Plugins(OptionallyRequired):
                 name, cfg = item.popitem()
                 cfg = cfg or {}  # Users may define a null (None) config
                 if not isinstance(cfg, dict):
-                    raise ValidationError('Invalid config options for '
-                                          'the "{}" plugin.'.format(name))
+                    raise ValidationError(f'Invalid config options for the "{name}" plugin.')
                 item = name
             else:
                 cfg = {}

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -171,7 +171,7 @@ class Choice(OptionallyRequired):
             length = 0
 
         if not length or isinstance(choices, str):
-            raise ValueError('Expected iterable of choices, got {}', choices)
+            raise ValueError(f'Expected iterable of choices, got {choices}')
 
         self.choices = choices
 
@@ -438,8 +438,8 @@ class Theme(BaseConfigOption):
                     return value
 
                 raise ValidationError(
-                    "Unrecognised theme name: '{}'. The available installed themes "
-                    "are: {}".format(value['name'], ', '.join(themes))
+                    f"Unrecognised theme name: '{value['name']}'. "
+                    f"The available installed themes are: {', '.join(themes)}"
                 )
 
             raise ValidationError("No theme name set.")

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -76,7 +76,7 @@ class ConfigItems(BaseConfigOption):
         self.required = kwargs.get('required', False)
 
     def __repr__(self):
-        return '{}: {}'.format(self.__class__.__name__, self.item_config)
+        return f'{self.__class__.__name__}: {self.item_config}'
 
     def run_validation(self, value):
         if value is None:
@@ -243,11 +243,11 @@ class IpAddress(OptionallyRequired):
         try:
             port = int(port)
         except Exception:
-            raise ValidationError("'{}' is not a valid port".format(port))
+            raise ValidationError(f"'{port}' is not a valid port")
 
         class Address(namedtuple('Address', 'host port')):
             def __str__(self):
-                return '{}:{}'.format(self.host, self.port)
+                return f'{self.host}:{self.port}'
 
         return Address(host, port)
 
@@ -611,7 +611,7 @@ class Plugins(OptionallyRequired):
 
     def load_plugin(self, name, config):
         if name not in self.installed_plugins:
-            raise ValidationError('The "{}" plugin is not installed'.format(name))
+            raise ValidationError(f'The "{name}" plugin is not installed')
 
         Plugin = self.installed_plugins[name].load()
 
@@ -624,7 +624,7 @@ class Plugins(OptionallyRequired):
         errors, warnings = plugin.load_config(config, self.config_file_path)
         self.warnings.extend(warnings)
         errors_message = '\n'.join(
-            "Plugin value: '{}'. Error: {}".format(x, y)
+            f"Plugin value: '{x}'. Error: {y}"
             for x, y in errors
         )
         if errors_message:

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -14,7 +14,7 @@ class LangOption(config_options.OptionallyRequired):
     """ Validate Language(s) provided in config are known languages. """
 
     def lang_file_exists(self, lang):
-        path = os.path.join(base_path, 'lunr-language', 'lunr.{}.js'.format(lang))
+        path = os.path.join(base_path, 'lunr-language', f'lunr.{lang}.js')
         return os.path.isfile(path)
 
     def run_validation(self, value):
@@ -25,7 +25,7 @@ class LangOption(config_options.OptionallyRequired):
         for lang in value:
             if lang != 'en' and not self.lang_file_exists(lang):
                 raise config_options.ValidationError(
-                    '"{}" is not a supported language code.'.format(lang)
+                    f'"{lang}" is not a supported language code.'
                 )
         return value
 
@@ -76,7 +76,7 @@ class SearchPlugin(BasePlugin):
                 files.append('lunr.multi.js')
             for lang in self.config['lang']:
                 if (lang != 'en'):
-                    files.append('lunr.{}.js'.format(lang))
+                    files.append(f'lunr.{lang}.js')
 
             for filename in files:
                 from_path = os.path.join(base_path, 'lunr-language', filename)

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -114,9 +114,9 @@ class SearchIndex:
                     data = json.dumps(page_dicts, sort_keys=True, separators=(',', ':'))
                     log.debug('Pre-built search index created successfully.')
                 else:
-                    log.warning('Failed to pre-build search index. Error: {}'.format(err))
+                    log.warning(f'Failed to pre-build search index. Error: {err}')
             except (OSError, ValueError) as e:
-                log.warning('Failed to pre-build search index. Error: {}'.format(e))
+                log.warning(f'Failed to pre-build search index. Error: {e}')
         elif self.config['prebuild_index'] == 'python':
             idx = lunr(
                 ref='location', fields=('title', 'text'), documents=self._entries,

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -166,7 +166,7 @@ class ContentParser(HTMLParser):
         """Called at the start of every HTML tag."""
 
         # We only care about the opening tag for headings.
-        if tag not in (["h%d" % x for x in range(1, 7)]):
+        if tag not in ([f"h{x}" for x in range(1, 7)]):
             return
 
         # We are dealing with a new header, create a new section
@@ -183,7 +183,7 @@ class ContentParser(HTMLParser):
         """Called at the end of every HTML tag."""
 
         # We only care about the opening tag for headings.
-        if tag not in (["h%d" % x for x in range(1, 7)]):
+        if tag not in ([f"h{x}" for x in range(1, 7)]):
             return
 
         self.is_header_tag = False

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -68,7 +68,7 @@ class PluginCollection(OrderedDict):
     def __setitem__(self, key, value, **kwargs):
         if not isinstance(value, BasePlugin):
             raise TypeError(
-                '{0}.{1} only accepts values which are instances of {2}.{3} '
+                '{}.{} only accepts values which are instances of {}.{} '
                 'sublcasses'.format(self.__module__, self.__name__,
                                     BasePlugin.__module__, BasePlugin.__name__))
         super().__setitem__(key, value, **kwargs)

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -66,7 +66,7 @@ class Files:
         def filter(name):
             # '.*' filters dot files/dirs at root level whereas '*/.*' filters nested levels
             patterns = ['.*', '*/.*', '*.py', '*.pyc', '*.html', '*readme*', 'mkdocs_theme.yml']
-            patterns.extend('*{}'.format(x) for x in utils.markdown_extensions)
+            patterns.extend(f'*{x}' for x in utils.markdown_extensions)
             patterns.extend(config['theme'].static_templates)
             for pattern in patterns:
                 if fnmatch.fnmatch(name.lower(), pattern):
@@ -172,9 +172,9 @@ class File:
     def copy_file(self, dirty=False):
         """ Copy source file to destination, ensuring parent directories exist. """
         if dirty and not self.is_modified():
-            log.debug("Skip copying unmodified file: '{}'".format(self.src_path))
+            log.debug(f"Skip copying unmodified file: '{self.src_path}'")
         else:
-            log.debug("Copying media file: '{}'".format(self.src_path))
+            log.debug(f"Copying media file: '{self.src_path}'")
             utils.copy_file(self.abs_src_path, self.abs_dest_path)
 
     def is_modified(self):
@@ -235,7 +235,7 @@ def get_files(config):
                 continue
             # Skip README.md if an index file also exists in dir
             if filename.lower() == 'readme.md' and 'index.md' in filenames:
-                log.warning("Both index.md and readme.md found. Skipping readme.md from {}".format(source_dir))
+                log.warning(f"Both index.md and readme.md found. Skipping readme.md from {source_dir}")
                 continue
             files.append(File(path, config['docs_dir'], config['site_dir'], config['use_directory_urls']))
 

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -42,7 +42,7 @@ class Section:
         self.is_link = False
 
     def __repr__(self):
-        return "Section(title='{}')".format(self.title)
+        return f"Section(title='{self.title}')"
 
     def _get_active(self):
         """ Return active status of section. """
@@ -83,8 +83,8 @@ class Link:
         self.is_link = True
 
     def __repr__(self):
-        title = "'{}'".format(self.title) if (self.title is not None) else '[blank]'
-        return "Link(title={}, url='{}')".format(title, self.url)
+        title = f"'{self.title}'" if (self.title is not None) else '[blank]'
+        return f"Link(title={title}, url='{self.url}')"
 
     @property
     def ancestors(self):

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -219,8 +219,8 @@ class _RelativePathTreeprocessor(Treeprocessor):
         # Validate that the target exists in files collection.
         if target_path not in self.files:
             log.warning(
-                "Documentation file '{}' contains a link to '{}' which is not found "
-                "in the documentation files.".format(self.file.src_path, target_path)
+                f"Documentation file '{self.file.src_path}' contains a link to "
+                f"'{target_path}' which is not found in the documentation files."
             )
             return url
         target_file = self.files.get_file_from_path(target_path)

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -54,7 +54,7 @@ class Page:
         return not self.__eq__(other)
 
     def __repr__(self):
-        title = "'{}'".format(self.title) if (self.title is not None) else '[blank]'
+        title = f"'{self.title}'" if (self.title is not None) else '[blank]'
         return "Page(title={}, url='{}')".format(title, self.abs_url or self.file.url)
 
     def _indent_print(self, depth=0):
@@ -120,10 +120,10 @@ class Page:
                 with open(self.file.abs_src_path, 'r', encoding='utf-8-sig', errors='strict') as f:
                     source = f.read()
             except OSError:
-                log.error('File not found: {}'.format(self.file.src_path))
+                log.error(f'File not found: {self.file.src_path}')
                 raise
             except ValueError:
-                log.error('Encoding error reading file: {}'.format(self.file.src_path))
+                log.error(f'Encoding error reading file: {self.file.src_path}')
                 raise
 
         self.markdown, self.meta = meta.get_data(source)

--- a/mkdocs/structure/toc.py
+++ b/mkdocs/structure/toc.py
@@ -49,7 +49,7 @@ class AnchorLink:
 
     def indent_print(self, depth=0):
         indent = '    ' * depth
-        ret = '{}{} - {}\n'.format(indent, self.title, self.url)
+        ret = f'{indent}{self.title} - {self.url}\n'
         for item in self.children:
             ret += item.indent_print(depth + 1)
         return ret

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -95,35 +95,35 @@ class PathAssertionMixin:
     def assertPathExists(self, *parts):
         path = os.path.join(*parts)
         if not os.path.exists(path):
-            msg = self._formatMessage(None, "The path '{}' does not exist".format(path))
+            msg = self._formatMessage(None, f"The path '{path}' does not exist")
             raise self.failureException(msg)
 
     def assertPathNotExists(self, *parts):
         path = os.path.join(*parts)
         if os.path.exists(path):
-            msg = self._formatMessage(None, "The path '{}' does exist".format(path))
+            msg = self._formatMessage(None, f"The path '{path}' does exist")
             raise self.failureException(msg)
 
     def assertPathIsFile(self, *parts):
         path = os.path.join(*parts)
         if not os.path.isfile(path):
-            msg = self._formatMessage(None, "The path '{}' is not a file that exists".format(path))
+            msg = self._formatMessage(None, f"The path '{path}' is not a file that exists")
             raise self.failureException(msg)
 
     def assertPathNotFile(self, *parts):
         path = os.path.join(*parts)
         if os.path.isfile(path):
-            msg = self._formatMessage(None, "The path '{}' is a file that exists".format(path))
+            msg = self._formatMessage(None, f"The path '{path}' is a file that exists")
             raise self.failureException(msg)
 
     def assertPathIsDir(self, *parts):
         path = os.path.join(*parts)
         if not os.path.isdir(path):
-            msg = self._formatMessage(None, "The path '{}' is not a directory that exists".format(path))
+            msg = self._formatMessage(None, f"The path '{path}' is not a directory that exists")
             raise self.failureException(msg)
 
     def assertPathNotDir(self, *parts):
         path = os.path.join(*parts)
         if os.path.isfile(path):
-            msg = self._formatMessage(None, "The path '{}' is a directory that exists".format(path))
+            msg = self._formatMessage(None, f"The path '{path}' is a directory that exists")
             raise self.failureException(msg)

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -34,8 +34,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             mock.assert_called_once()
         except AttributeError:
             if not mock.call_count == 1:
-                msg = ("Expected '%s' to have been called once. Called %s times." %
-                       (mock._mock_name or 'mock', self.call_count))
+                mock_name = mock._mock_name or 'mock'
+                msg = f"Expected '{mock_name}' to have been called once. Called {self.call_count} times."
                 raise AssertionError(msg)
 
     # Test build.get_context

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -157,7 +157,7 @@ class TestGitHubDeploy(unittest.TestCase):
 
         self.assertRaises(SystemExit, gh_deploy.gh_deploy, config)
         mock_log.error.assert_called_once_with(
-            'Failed to deploy to GitHub with error: \n{}'.format(error_string)
+            f'Failed to deploy to GitHub with error: \n{error_string}'
         )
 
 

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -19,8 +19,8 @@ class TestGitHubDeploy(unittest.TestCase):
             mock.assert_called_once()
         except AttributeError:
             if not mock.call_count == 1:
-                msg = ("Expected '%s' to have been called once. Called %s times." %
-                       (mock._mock_name or 'mock', self.call_count))
+                mock_name = mock._mock_name or 'mock'
+                msg = f"Expected '{mock_name}' to have been called once. Called {self.call_count} times."
                 raise AssertionError(msg)
 
     @mock.patch('subprocess.Popen')

--- a/mkdocs/tests/integration.py
+++ b/mkdocs/tests/integration.py
@@ -49,7 +49,7 @@ def main(output=None):
 
     log.debug("Building installed themes.")
     for theme in sorted(MKDOCS_THEMES):
-        log.debug("Building theme: {}".format(theme))
+        log.debug(f"Building theme: {theme}")
         project_dir = os.path.dirname(MKDOCS_CONFIG)
         out = os.path.join(output, theme)
         command = base_cmd + [out, '--theme', theme]
@@ -57,13 +57,13 @@ def main(output=None):
 
     log.debug("Building test projects.")
     for project in os.listdir(TEST_PROJECTS):
-        log.debug("Building test project: {}".format(project))
+        log.debug(f"Building test project: {project}")
         project_dir = os.path.join(TEST_PROJECTS, project)
         out = os.path.join(output, project)
         command = base_cmd + [out, ]
         subprocess.check_call(command, cwd=project_dir)
 
-    log.debug("Theme and integration builds are in {}".format(output))
+    log.debug(f"Theme and integration builds are in {output}")
 
 
 if __name__ == '__main__':

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -324,15 +324,15 @@ class SearchIndexTests(unittest.TestCase):
 
             self.assertEqual(index._entries[1]['title'], "Heading 1")
             self.assertEqual(index._entries[1]['text'], "Content 1")
-            self.assertEqual(index._entries[1]['location'], "{}#heading-1".format(loc))
+            self.assertEqual(index._entries[1]['location'], f"{loc}#heading-1")
 
             self.assertEqual(index._entries[2]['title'], "Heading 2")
             self.assertEqual(strip_whitespace(index._entries[2]['text']), "Content2")
-            self.assertEqual(index._entries[2]['location'], "{}#heading-2".format(loc))
+            self.assertEqual(index._entries[2]['location'], f"{loc}#heading-2")
 
             self.assertEqual(index._entries[3]['title'], "Heading 3")
             self.assertEqual(strip_whitespace(index._entries[3]['text']), "Content3")
-            self.assertEqual(index._entries[3]['location'], "{}#heading-3".format(loc))
+            self.assertEqual(index._entries[3]['location'], f"{loc}#heading-3")
 
     @mock.patch('subprocess.Popen', autospec=True)
     def test_prebuild_index(self, mock_popen):

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -84,8 +84,8 @@ class Theme:
         except OSError as e:
             log.debug(e)
             raise ValidationError(
-                "The theme '{}' does not appear to have a configuration file. "
-                "Please upgrade to a current version of the theme.".format(name)
+                f"The theme '{name}' does not appear to have a configuration file. "
+                f"Please upgrade to a current version of the theme."
             )
 
         log.debug("Loaded theme configuration for '%s' from '%s': %s", name, file_path, theme_config)

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -54,7 +54,7 @@ class Theme:
     def __repr__(self):
         return "{}(name='{}', dirs={}, static_templates={}, {})".format(
             self.__class__.__name__, self.name, self.dirs, list(self.static_templates),
-            ', '.join('{}={}'.format(k, repr(v)) for k, v in self._vars.items())
+            ', '.join(f'{k}={v!r}' for k, v in self._vars.items())
         )
 
     def __getitem__(self, key):
@@ -95,8 +95,8 @@ class Theme:
             themes = utils.get_theme_names()
             if parent_theme not in themes:
                 raise ValidationError(
-                    "The theme '{}' inherits from '{}', which does not appear to be installed. "
-                    "The available installed themes are: {}".format(name, parent_theme, ', '.join(themes))
+                    f"The theme '{name}' inherits from '{parent_theme}', which does not appear to be installed. "
+                    f"The available installed themes are: {', '.join(themes)}"
                 )
             self._load_theme_config(parent_theme)
 

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -88,7 +88,7 @@ class Theme:
                 f"Please upgrade to a current version of the theme."
             )
 
-        log.debug("Loaded theme configuration for '%s' from '%s': %s", name, file_path, theme_config)
+        log.debug(f"Loaded theme configuration for '{name}' from '{file_path}': {theme_config}")
 
         parent_theme = theme_config.pop('extends', None)
         if parent_theme:

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -321,8 +321,8 @@ def get_themes():
 
         if theme.name in builtins and theme.dist.key != 'mkdocs':
             raise exceptions.ConfigurationError(
-                "The theme {} is a builtin theme but {} provides a theme "
-                "with the same name".format(theme.name, theme.dist.key))
+                f"The theme {theme.name} is a builtin theme but "
+                f"{theme.dist.key} provides a theme with the same name")
 
         elif theme.name in themes:
             multiple_packages = ','.join([themes[theme.name].dist.key, theme.dist.key])

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -325,10 +325,10 @@ def get_themes():
                 "with the same name".format(theme.name, theme.dist.key))
 
         elif theme.name in themes:
-            multiple_packages = [themes[theme.name].dist.key, theme.dist.key]
-            log.warning("The theme %s is provided by the Python packages "
-                        "'%s'. The one in %s will be used.",
-                        theme.name, ','.join(multiple_packages), theme.dist.key)
+            multiple_packages = ','.join([themes[theme.name].dist.key, theme.dist.key])
+            log.warning(
+                f"The theme {theme.name} is provided by the Python packages '{multiple_packages}'. "
+                f"The one in {theme.dist.key} will be used.")
 
         themes[theme.name] = theme
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -215,7 +215,7 @@ def is_markdown_file(path):
 
     https://superuser.com/questions/249436/file-extension-for-markdown-files
     """
-    return any(fnmatch.fnmatch(path.lower(), '*{}'.format(x)) for x in markdown_extensions)
+    return any(fnmatch.fnmatch(path.lower(), f'*{x}') for x in markdown_extensions)
 
 
 def is_html_file(path):

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -85,7 +85,7 @@ def get_data(doc):
             key = m1.group('key').lower().strip()
             value = m1.group('value').strip()
             if key in data:
-                data[key] += ' {}'.format(value)
+                data[key] += f' {value}'
             else:
                 data[key] = value
         else:


### PR DESCRIPTION
I saw in https://github.com/mkdocs/mkdocs/pull/2283 that you *support* f-strings.

Well, rather than changing them little by little (whenever a PR happens to touch something) why not change all at once.

Most of these were generated by automation (`pyupgrade`+`flynt`) but I excluded a few and added a few.

This is split into commits, ranging basically from ones requiring least caution (especially as the first commit is fully generated) to requiring most caution. So it's recommended to view this as commits, not as a whole.

And I can sympathize with merge conflicts with #2299, so you can leave my PR until that one is merged.