### PR TITLE
Avoid a race condition creating the subdirectory for a site file

### DIFF
--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -138,8 +138,7 @@ def copy_file(source_path, output_path):
     The output_path may be a directory.
     """
     output_dir = os.path.dirname(output_path)
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
     if os.path.isdir(output_path):
         output_path = os.path.join(output_path, os.path.basename(source_path))
     shutil.copyfile(source_path, output_path)
@@ -150,8 +149,7 @@ def write_file(content, output_path):
     Write content to output_path, making sure any parent directories exist.
     """
     output_dir = os.path.dirname(output_path)
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
     with open(output_path, 'wb') as f:
         f.write(content)
 


### PR DESCRIPTION
It is possible that this directory does not exist when checking but already exists when trying to create it. I ran into that when parallelizing a test suite. Now, mind you, this almost always means a bug elsewhere, but still, this is simpler code anyway.
`exist_ok` is "new" in Python 3, I guess that's why it wasn't used previously.