### PR TITLE
config_options: display the name of the plugin failing validation

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -624,7 +624,7 @@ class Plugins(OptionallyRequired):
         errors, warnings = plugin.load_config(config, self.config_file_path)
         self.warnings.extend(warnings)
         errors_message = '\n'.join(
-            "Plugin value: '{}'. Error: {}".format(x, y)
+            "Plugin '{}' value: '{}'. Error: {}".format(name, x, y)
             for x, y in errors
         )
         if errors_message:


### PR DESCRIPTION
When a parameter value validation fails for a plugin the name of
the failing plugin is not displayed

This commit adds the name of the plugin in the error message for
completeness