### PR TITLE
fix doc: template arg and return types of on_pre_template() have wrong type

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -253,12 +253,12 @@ called after the [env] event and before any [page events].
     loaded and can be used to alter the content of the template.
 
     Parameters:
-    : __template__: the template contents as string
+    : __template__: the template contents as a [Jinja2 Template object](http://code.nabla.net/doc/jinja2/api/jinja2/environment/jinja2.environment.Template.html).
     : __template_name__: string filename of template
     : __config:__ global configuration object
 
     Returns:
-    : template contents as string
+    : template contents as a [Jinja2 Template object](http://code.nabla.net/doc/jinja2/api/jinja2/environment/jinja2.environment.Template.html)
 
 ##### on_template_context
 


### PR DESCRIPTION
In the documentation, updates the `__template__` argument and return type from the on_pre_template() method:

"the template contents as **string**" -> "the template contents as **a [Jinja2 Template object](http://code.nabla.net/doc/jinja2/api/jinja2/environment/jinja2.environment.Template.html)**"

test code:

```py
from mkdocs.plugins import BasePlugin

class TestPlugin(BasePlugin):
    def on_pre_template(self, template, template_name, config):
        print('on_pre_template:', type(template))
        return template
```

returns:

```
on_pre_template: <class 'jinja2.environment.Template'>
```