### PR TITLE
Added configuration for search indexing strategy

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -83,6 +83,20 @@ MkDocs now has two new exceptions defined in `mkdocs.exceptions`,
 See [`Handling errors`](../user-guide/plugins.md#handling-errors)
 in the Plugins documentation for details.
 
+#### Search Indexing Strategy configuration
+
+Users can now specify which strategy they wish to use when indexing
+their site for search. A user can select between the following options:
+
+* **full**: Adds page title, section headings, and full page text to the
+search index.
+* **sections**: Adds page titles and section headings only to the search
+index.
+* **titles**: Adds only the page titles to the search index.
+
+See [`Search Indexing`](../user-guide/configuration.md#indexing) in the
+configuration documentation for details.
+
 ### Backward Incompatible Changes in 1.2
 
 A theme's files are now excluded from the list of watched files by default

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -628,6 +628,27 @@ report it on [Lunr.py's issues] and fall back to the Node.js version.
 
 **default**: `False`
 
+##### **indexing**
+
+Configures what strategy the search indexer will use when building the index
+for your pages. This property is particularly useful if your project is large in scale, and the index can take up an enormous amount of disk space.
+
+
+```yaml
+plugins:
+    - search:
+        indexing: 'full'
+```
+
+###### Options
+|Option|Description|
+|------|-----------|
+|`full`|Indexes the title, section headings, and full text of each page.|
+|`sections`|Indexes the title and section headings of each page.|
+|`titles`|Indexes only the title of each page.|
+
+**default**: `full`
+
 [custom themes]: custom-themes.md
 [variables that are available]: custom-themes.md#template-variables
 [pymdk-extensions]: https://python-markdown.github.io/extensions/

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -631,8 +631,8 @@ report it on [Lunr.py's issues] and fall back to the Node.js version.
 ##### **indexing**
 
 Configures what strategy the search indexer will use when building the index
-for your pages. This property is particularly useful if your project is large in scale, and the index can take up an enormous amount of disk space.
-
+for your pages. This property is particularly useful if your project is large
+in scale, and the index takes up an enormous amount of disk space.
 
 ```yaml
 plugins:
@@ -641,6 +641,7 @@ plugins:
 ```
 
 ###### Options
+
 |Option|Description|
 |------|-----------|
 |`full`|Indexes the title, section headings, and full text of each page.|

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -38,6 +38,7 @@ class SearchPlugin(BasePlugin):
         ('separator', config_options.Type(str, default=r'[\s\-]+')),
         ('min_search_length', config_options.Type(int, default=3)),
         ('prebuild_index', config_options.Choice((False, True, 'node', 'python'), default=False)),
+        ('indexing', config_options.Choice(('full', 'sections', 'titles'), default='full'))
     )
 
     def on_config(self, config, **kwargs):

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -65,14 +65,16 @@ class SearchIndex:
         url = page.url
 
         # Create an entry for the full page.
+        text = parser.stripped_html.rstrip('\n') if self.config['indexing'] == 'full' else ''
         self._add_entry(
             title=page.title,
-            text=parser.stripped_html.rstrip('\n'),
+            text=text,
             loc=url
         )
 
-        for section in parser.data:
-            self.create_entry_for_section(section, page.toc, url)
+        if self.config['indexing'] in ['full', 'sections']:
+            for section in parser.data:
+                self.create_entry_for_section(section, page.toc, url)
 
     def create_entry_for_section(self, section, toc, abs_url):
         """
@@ -83,10 +85,11 @@ class SearchIndex:
 
         toc_item = self._find_toc_by_id(toc, section.id)
 
+        text = ' '.join(section.text) if self.config['indexing'] == 'full' else ''
         if toc_item is not None:
             self._add_entry(
                 title=toc_item.title,
-                text=" ".join(section.text),
+                text=text,
                 loc=abs_url + toc_item.url
             )
 

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -59,7 +59,8 @@ class SearchPluginTests(unittest.TestCase):
             'lang': ['en'],
             'separator': r'[\s\-]+',
             'min_search_length': 3,
-            'prebuild_index': False
+            'prebuild_index': False,
+            'indexing': 'full'
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({})
@@ -72,7 +73,8 @@ class SearchPluginTests(unittest.TestCase):
             'lang': ['es'],
             'separator': r'[\s\-]+',
             'min_search_length': 3,
-            'prebuild_index': False
+            'prebuild_index': False,
+            'indexing': 'full'
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'lang': 'es'})
@@ -85,7 +87,8 @@ class SearchPluginTests(unittest.TestCase):
             'lang': ['en'],
             'separator': r'[\s\-\.]+',
             'min_search_length': 3,
-            'prebuild_index': False
+            'prebuild_index': False,
+            'indexing': 'full'
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'separator': r'[\s\-\.]+'})
@@ -98,7 +101,8 @@ class SearchPluginTests(unittest.TestCase):
             'lang': ['en'],
             'separator': r'[\s\-]+',
             'min_search_length': 2,
-            'prebuild_index': False
+            'prebuild_index': False,
+            'indexing': 'full'
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'min_search_length': 2})
@@ -111,10 +115,25 @@ class SearchPluginTests(unittest.TestCase):
             'lang': ['en'],
             'separator': r'[\s\-]+',
             'min_search_length': 3,
-            'prebuild_index': True
+            'prebuild_index': True,
+            'indexing': 'full'
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'prebuild_index': True})
+        self.assertEqual(plugin.config, expected)
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_plugin_config_indexing(self):
+        expected = {
+            'lang': ['en'],
+            'separator': r'[\s\-]+',
+            'min_search_length': 3,
+            'prebuild_index': False,
+            'indexing': 'titles'
+        }
+        plugin = search.SearchPlugin()
+        errors, warnings = plugin.load_config({'indexing': 'titles'})
         self.assertEqual(plugin.config, expected)
         self.assertEqual(errors, [])
         self.assertEqual(warnings, [])
@@ -290,10 +309,10 @@ class SearchIndexTests(unittest.TestCase):
         <p>Content 3</p>
         """
 
-        cfg = load_config()
+        base_cfg = load_config()
         pages = [
-            Page('Home', File('index.md',  cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']), cfg),
-            Page('About', File('about.md',  cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']), cfg)
+            Page('Home',  File('index.md', base_cfg['docs_dir'], base_cfg['site_dir'], base_cfg['use_directory_urls']), base_cfg),
+            Page('About', File('about.md', base_cfg['docs_dir'], base_cfg['site_dir'], base_cfg['use_directory_urls']), base_cfg)
         ]
 
         md = dedent("""
@@ -305,13 +324,16 @@ class SearchIndexTests(unittest.TestCase):
 
         full_content = ''.join("""Heading{0}Content{0}""".format(i) for i in range(1, 4))
 
+        plugin = search.SearchPlugin()
+        errors, warnings = plugin.load_config({})
+
         for page in pages:
             # Fake page.read_source() and page.render()
             page.markdown = md
             page.toc = toc
             page.content = html_content
 
-            index = search_index.SearchIndex()
+            index = search_index.SearchIndex(**plugin.config)
             index.add_entry_from_context(page)
 
             self.assertEqual(len(index._entries), 4)
@@ -333,6 +355,69 @@ class SearchIndexTests(unittest.TestCase):
             self.assertEqual(index._entries[3]['title'], "Heading 3")
             self.assertEqual(strip_whitespace(index._entries[3]['text']), "Content3")
             self.assertEqual(index._entries[3]['location'], "{}#heading-3".format(loc))
+
+    def test_search_indexing_options(self):
+        def test_page(title, filename, config):
+            test_page = Page(
+                title, File(
+                    filename,
+                    config['docs_dir'],
+                    config['site_dir'],
+                    config['use_directory_urls']),
+                config)
+            test_page.content="""
+                <h1 id="heading-1">Heading 1</h1>
+                <p>Content 1</p>
+                <h2 id="heading-2">Heading 2</h1>
+                <p>Content 2</p>
+                <h3 id="heading-3">Heading 3</h1>
+                <p>Content 3</p>"""
+            test_page.markdown=dedent("""
+                # Heading 1
+                ## Heading 2
+                ### Heading 3""")
+            test_page.toc = get_toc(get_markdown_toc(test_page.markdown))
+            return test_page
+
+        validate = {
+            'full': (lambda data:
+                self.assertEqual(len(data[0]), 4) and
+                self.assertTrue([x for x in data[0][0] if x['title'] and x['text']])),
+            'sections': (lambda data:
+                # Sanity
+                self.assertEqual(len(data[0]), 4) and
+                # Page
+                (self.assertEqual(data[0][0]['title'], data[1].title) and
+                    self.assertTrue(data[0][0]['text'])) and
+                # Headings
+                self.assertTrue([x for x in data[0][1:] if x['title'] and not x['text']])),
+            'titles': (lambda data:
+                # Sanity
+                self.assertEqual(len(data[0]), 1) and
+                self.assertFalse([x for x in data[0] if x['text']]))
+        }
+
+        for option in ['full', 'sections', 'titles']:
+            plugin = search.SearchPlugin()
+
+            # Load plugin config, overriding indexing for test case
+            errors, warnings = plugin.load_config({'indexing': option})
+            self.assertEqual(errors, [])
+            self.assertEqual(warnings, [])
+
+            base_cfg  = load_config()
+            base_cfg['plugins']['search'].config['indexing'] = option
+
+            pages = [
+                test_page('Home', 'index.md', base_cfg),
+                test_page('About', 'about.md', base_cfg)
+            ]
+
+            for page in pages:
+                index = search_index.SearchIndex(**plugin.config)
+                index.add_entry_from_context(page)
+                data = index.generate_search_index()
+                validate[option]((json.loads(data)['docs'], page))
 
     @mock.patch('subprocess.Popen', autospec=True)
     def test_prebuild_index(self, mock_popen):

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -311,8 +311,22 @@ class SearchIndexTests(unittest.TestCase):
 
         base_cfg = load_config()
         pages = [
-            Page('Home',  File('index.md', base_cfg['docs_dir'], base_cfg['site_dir'], base_cfg['use_directory_urls']), base_cfg),
-            Page('About', File('about.md', base_cfg['docs_dir'], base_cfg['site_dir'], base_cfg['use_directory_urls']), base_cfg)
+            Page(
+                'Home',
+                File(
+                    'index.md',
+                    base_cfg['docs_dir'],
+                    base_cfg['site_dir'],
+                    base_cfg['use_directory_urls']),
+                base_cfg),
+            Page(
+                'About',
+                File(
+                    'about.md',
+                    base_cfg['docs_dir'],
+                    base_cfg['site_dir'],
+                    base_cfg['use_directory_urls']),
+                base_cfg)
         ]
 
         md = dedent("""
@@ -365,14 +379,14 @@ class SearchIndexTests(unittest.TestCase):
                     config['site_dir'],
                     config['use_directory_urls']),
                 config)
-            test_page.content="""
+            test_page.content = """
                 <h1 id="heading-1">Heading 1</h1>
                 <p>Content 1</p>
                 <h2 id="heading-2">Heading 2</h1>
                 <p>Content 2</p>
                 <h3 id="heading-3">Heading 3</h1>
                 <p>Content 3</p>"""
-            test_page.markdown=dedent("""
+            test_page.markdown = dedent("""
                 # Heading 1
                 ## Heading 2
                 ### Heading 3""")
@@ -381,20 +395,20 @@ class SearchIndexTests(unittest.TestCase):
 
         validate = {
             'full': (lambda data:
-                self.assertEqual(len(data[0]), 4) and
-                self.assertTrue([x for x in data[0][0] if x['title'] and x['text']])),
+                     self.assertEqual(len(data[0]), 4) and
+                     self.assertTrue([x for x in data[0][0] if x['title'] and x['text']])),
             'sections': (lambda data:
-                # Sanity
-                self.assertEqual(len(data[0]), 4) and
-                # Page
-                (self.assertEqual(data[0][0]['title'], data[1].title) and
-                    self.assertTrue(data[0][0]['text'])) and
-                # Headings
-                self.assertTrue([x for x in data[0][1:] if x['title'] and not x['text']])),
+                         # Sanity
+                         self.assertEqual(len(data[0]), 4) and
+                         # Page
+                         (self.assertEqual(data[0][0]['title'], data[1].title) and
+                             self.assertTrue(data[0][0]['text'])) and
+                         # Headings
+                         self.assertTrue([x for x in data[0][1:] if x['title'] and not x['text']])),
             'titles': (lambda data:
-                # Sanity
-                self.assertEqual(len(data[0]), 1) and
-                self.assertFalse([x for x in data[0] if x['text']]))
+                       # Sanity
+                       self.assertEqual(len(data[0]), 1) and
+                       self.assertFalse([x for x in data[0] if x['text']]))
         }
 
         for option in ['full', 'sections', 'titles']:
@@ -405,7 +419,7 @@ class SearchIndexTests(unittest.TestCase):
             self.assertEqual(errors, [])
             self.assertEqual(warnings, [])
 
-            base_cfg  = load_config()
+            base_cfg = load_config()
             base_cfg['plugins']['search'].config['indexing'] = option
 
             pages = [


### PR DESCRIPTION
* Allows a user to supply a `indexing` configuration to the search
  plugin which controls what to include in the search index (full,
  sections, titles)

* Added test coverage

* Added documentation

Resolves: #2221 