### PR TITLE
add a FAQ page and a newbie enty

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -343,7 +343,8 @@ you're done. For specific instructions on a number of common hosts, see the
 
 ## Getting help
 
-To get help with MkDocs, please use the [discussion group], [GitHub issues] or
+Take a look at the [FAQ][FAQ], maybe the answer is already there? If not,
+please use the [discussion group], [GitHub issues] or
 the MkDocs IRC channel `#mkdocs` on freenode.
 
 [deploy]: user-guide/deploying-your-docs/
@@ -362,3 +363,4 @@ the MkDocs IRC channel `#mkdocs` on freenode.
 [Python]: https://www.python.org/
 [site_name]: user-guide/configuration/#site_name
 [theme]: user-guide/configuration/#theme
+[FAQ]: user-guide/faq/

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,0 +1,20 @@
+# Frequently Asked Questions
+
+FAQ of common questions and problems
+
+---
+
+## Search has disappeared
+
+(copied from the [plugins][plugins] documentation)
+If the `plugins` config setting is defined in the `mkdocs.yml` config file, then
+any defaults (such as `search`) are ignored and you need to explicitly re-enable
+the defaults if you would like to continue using them:
+
+```yaml
+plugins:
+    - search
+    - your_other_plugin
+```
+
+[plugins]: /user-guide/configuration/#plugins

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
         - Deploying Your Docs: user-guide/deploying-your-docs.md
         - Custom Themes: user-guide/custom-themes.md
         - Plugins: user-guide/plugins.md
+        - FAQ: user-guide/faq.md
     - About:
         - Release Notes: about/release-notes.md
         - Contributing: about/contributing.md


### PR DESCRIPTION
xref joerick/cibuildwheel#616

I spent an hour or so tracking this down, so maybe others are also surprised when they enable a plugin and search disappears.
