### PR TITLE
Restore styling of tables in the `readthedocs` theme

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -124,6 +124,7 @@ instance of the configuration is unique (#2289).
 * Updated highlight.js to 10.5.0. See #2313.
 * Bugfix: Search plugin now works with Japanese language. See #2178.
 * Documentation has been refactored (#1629).
+* Restore styling of tables in the `readthedocs` theme (#2028).
 
 ## Version 1.1.2 (2020-05-14)
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -142,6 +142,7 @@
 
   {%- block scripts %}
     <script>var base_url = '{{ base_url }}';</script>
+    <script src="{{ 'js/theme_extra.js'|url }}" defer></script>
     <script src="{{ 'js/theme.js'|url }}" defer></script>
     {%- for path in config['extra_javascript'] %}
       <script src="{{ path|url }}" defer></script>

--- a/mkdocs/themes/readthedocs/js/theme_extra.js
+++ b/mkdocs/themes/readthedocs/js/theme_extra.js
@@ -1,0 +1,8 @@
+/*
+ * Assign 'docutils' class to tables so styling and
+ * JavaScript behavior is applied.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/2028
+ */
+
+$('div.rst-content table').addClass('docutils');


### PR DESCRIPTION
Rather than including this is the JS form the upstream theme, the JS
has been included in a separate file `theme_extra.js` so that is is not
lost in a future update copied form upstream. Fixes #2028.