### PR TITLE
Ensure only one build runs at a time.

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -39,15 +39,6 @@ otherkey: !ENV [VAR_NAME, FALLBACK_VAR, 'default value']
 See [Environment Variables](../user-guide/configuration.md#environment-variables)
 in the Configuration documentation for details.
 
-#### A `--wait` flag has been added to the `serve` command (#2061)
-
-To delay a rebuild of the site when using the livereload server, use the
-`--wait` flag to specify the number of seconds to wait.
-
-```bash
-mkdocs serve --wait 60
-```
-
 #### Update `gh-deploy` command (#2170)
 
 The vendored (and modified) copy of ghp_import has been replaced with a

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -116,6 +116,7 @@ instance of the configuration is unique (#2289).
 * Bugfix: Search plugin now works with Japanese language. See #2178.
 * Documentation has been refactored (#1629).
 * Restore styling of tables in the `readthedocs` theme (#2028).
+* Ensure only one build runs at a time (#2061 and #2285).
 
 ## Version 1.1.2 (2020-05-14)
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -53,7 +53,6 @@ force_help = "Force the push to the repository."
 ignore_version_help = "Ignore check that build is not being deployed with an older version of MkDocs."
 watch_theme_help = ("Include the theme in list of files to watch for live reloading. "
                     "Ignored when live reload is not used.")
-wait_help = "Wait the specified number of seconds before reloading (default 0)."
 shell_help = "Use the shell when invoking Git."
 
 
@@ -126,7 +125,6 @@ def cli():
 @click.option('--no-livereload', 'livereload', flag_value='no-livereload', help=no_reload_help)
 @click.option('--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
 @click.option('--watch-theme', help=watch_theme_help, is_flag=True)
-@click.option('-w', '--wait', help=wait_help, default=0)
 @common_config_options
 @common_options
 def serve_command(dev_addr, livereload, **kwargs):

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -48,7 +48,7 @@ def _get_handler(site_dir, StaticFileHandler):
     return WebHandler
 
 
-def _livereload(host, port, config, builder, site_dir, watch_theme, delay):
+def _livereload(host, port, config, builder, site_dir, watch_theme):
 
     # We are importing here for anyone that has issues with livereload. Even if
     # this fails, the --no-livereload alternative should still work.
@@ -66,17 +66,17 @@ def _livereload(host, port, config, builder, site_dir, watch_theme, delay):
     server = LiveReloadServer()
 
     # Watch the documentation files, the config file and the theme files.
-    server.watch(config['docs_dir'], builder, delay=delay)
-    server.watch(config['config_file_path'], builder, delay=delay)
+    server.watch(config['docs_dir'], builder)
+    server.watch(config['config_file_path'], builder)
 
     if watch_theme:
         for d in config['theme'].dirs:
-            server.watch(d, builder, delay=delay)
+            server.watch(d, builder)
 
     # Run `serve` plugin events.
     server = config['plugins'].run_event('serve', server, config=config, builder=builder)
 
-    server.serve(root=site_dir, host=host, port=port, restart_delay=delay)
+    server.serve(root=site_dir, host=host, port=port, restart_delay=0)
 
 
 def _static_server(host, port, site_dir):
@@ -104,7 +104,7 @@ def _static_server(host, port, site_dir):
 
 
 def serve(config_file=None, dev_addr=None, strict=None, theme=None,
-          theme_dir=None, livereload='livereload', watch_theme=False, wait=0, **kwargs):
+          theme_dir=None, livereload='livereload', watch_theme=False, **kwargs):
     """
     Start the MkDocs development server
 
@@ -144,7 +144,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
         host, port = config['dev_addr']
 
         if livereload in ['livereload', 'dirty']:
-            _livereload(host, port, config, builder, site_dir, watch_theme, delay=wait)
+            _livereload(host, port, config, builder, site_dir, watch_theme)
         else:
             _static_server(host, port, site_dir)
     finally:

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -114,12 +114,14 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
     """
 
     # Any builds triggered when `build_running` is True are ignored.
+    global build_running
     build_running = False
 
     # Create a temporary build directory, and set some options to serve it
     site_dir = tempfile.mkdtemp(prefix='mkdocs_')
 
     def builder():
+        global build_running
         if build_running:
             # A build is already running. Don't start another.
             return

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -29,8 +29,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -60,8 +59,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -78,8 +76,7 @@ class CLITests(unittest.TestCase):
             strict=True,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -96,8 +93,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme='readthedocs',
             use_directory_urls=None,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -114,8 +110,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=True,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -132,8 +127,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=False,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -150,8 +144,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -168,8 +161,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -186,8 +178,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False,
-            wait=0
+            watch_theme=False
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -204,26 +195,7 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=True,
-            wait=0
-        )
-
-    @mock.patch('mkdocs.commands.serve.serve', autospec=True)
-    def test_serve_wait(self, mock_serve):
-
-        result = self.runner.invoke(
-            cli.cli, ["serve", '--wait', '60'], catch_exceptions=False)
-
-        self.assertEqual(result.exit_code, 0)
-        mock_serve.assert_called_once_with(
-            dev_addr=None,
-            livereload='livereload',
-            config_file=None,
-            strict=None,
-            theme=None,
-            use_directory_urls=None,
-            watch_theme=False,
-            wait=60
+            watch_theme=True
         )
 
     @mock.patch('mkdocs.config.load_config', autospec=True)


### PR DESCRIPTION
This reverts #2093 (by removing the `--wait` option) and adds some logic to the `builder` so that only one build will run at a time.

It I could get some reports back from users who are experiencing the issues involved that would be helpful. Does this resolve the problem for you?