### PR TITLE
Ensure site_url ends with a slash

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -118,6 +118,7 @@ instance of the configuration is unique (#2289).
 * Bugfix: Search plugin now works with Japanese language. See #2178.
 * Documentation has been refactored (#1629).
 * Restore styling of tables in the `readthedocs` theme (#2028).
+* Ensure `site_url` ends with a slash (#1785).
 
 ## Version 1.1.2 (2020-05-14)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: MkDocs
-site_url: https://www.mkdocs.org
+site_url: https://www.mkdocs.org/
 site_description: Project documentation with Markdown.
 site_author: MkDocs Team
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1,7 +1,7 @@
 import os
 from collections import namedtuple
 from collections.abc import Sequence
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 import ipaddress
 import markdown
 
@@ -269,7 +269,8 @@ class URL(OptionallyRequired):
     Validate a URL by requiring a scheme is present.
     """
 
-    def __init__(self, default='', required=False):
+    def __init__(self, default='', required=False, is_dir=False):
+        self.is_dir = is_dir
         super().__init__(default, required)
 
     def run_validation(self, value):
@@ -282,7 +283,9 @@ class URL(OptionallyRequired):
             raise ValidationError("Unable to parse the URL.")
 
         if parsed_url.scheme:
-            return value
+            if self.is_dir and not parsed_url.path.endswith('/'):
+                parsed_url = parsed_url._replace(path=f'{parsed_url.path}/')
+            return urlunparse(parsed_url)
 
         raise ValidationError(
             "The URL isn't valid, it should include the http:// (scheme)")

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -24,7 +24,7 @@ def get_schema():
         ('pages', config_options.Nav()),
 
         # The full URL to where the documentation will be hosted
-        ('site_url', config_options.URL()),
+        ('site_url', config_options.URL(is_dir=True)),
 
         # A description for the documentation project that will be added to the
         # HTML meta tags.

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -217,6 +217,20 @@ class URLTest(unittest.TestCase):
         self.assertRaises(config_options.ValidationError,
                           option.validate, 1)
 
+    def test_url_is_dir(self):
+        url = "https://mkdocs.org/"
+
+        option = config_options.URL(is_dir=True)
+        value = option.validate(url)
+        self.assertEqual(value, url)
+
+    def test_url_transform_to_dir(self):
+        url = "https://mkdocs.org"
+
+        option = config_options.URL(is_dir=True)
+        value = option.validate(url)
+        self.assertEqual(value, f'{url}/')
+
 
 class RepoURLTest(unittest.TestCase):
 


### PR DESCRIPTION
`urlparse(config['site_url']).path` can be empty if `site_url` does not end
in a slash. This ensures at least a slash is returned. Config validation
will add the slash if it is missing. Fixes #1785.