### PR TITLE
Refactor Logging and Error handling

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -61,15 +61,17 @@ to execute code when an exception is raised while building the site.
 See [`on_build_error`](../dev-guide/plugins.md#on_build_error)
 in the Plugins documentation for details.
 
-#### Two new exceptions: BuildError and PluginError (#2103)
+#### Three new exceptions: BuildError PluginError and Abort (#2103)
 
-MkDocs now has two new exceptions defined in `mkdocs.exceptions`,
-`BuildError` and `PluginError`:
+MkDocs now has tree new exceptions defined in `mkdocs.exceptions`:
+`BuildError`, `PluginError`, and `Abort`:
 
 * `PluginError` can be raised from a plugin
   to stop the build and log an error message *without traceback*.
 * `BuildError` should not be used by third-party plugins developers
   and is reserved for internal use only.
+* `Abort` is used intenrally to abort the build and display an error
+  without a traceback.
 
 See [`Handling errors`](../dev-guide/plugins.md#handling-errors)
 in the Plugins documentation for details.
@@ -103,6 +105,11 @@ The `mkdocs.config.DEFAULT_SCHEMA` global variable has been replaced with the
 function `mkdocs.config.defaults.get_schema()`, which ensures that each
 instance of the configuration is unique (#2289).
 
+The `mkdocs.utils.warning_filter` is deprecated and now does nothing. Plugins
+ should remove any reference to is as it may be deleted in a future release.
+ To ensure any warnings get counted, simply log them to the `mkdocs` log (i.e:
+`mkdocs.plugins.pluginname`).
+
 ### Other Changes and Additions to Version 1.2
 
 * Bugfix: Properly process navigation child items in `_get_by_type` when
@@ -122,6 +129,8 @@ instance of the configuration is unique (#2289).
 * Correct documentation of `pages` template context variable (#1736).
 * The `lunr` dependency has been updated to 0.5.9, and `lunr.js` to
   the corresponding 2.3.9 version (#2306).
+* Color is now used in log messages to identify errors, warnings and debug
+  messages.
 
 ## Version 1.1.2 (2020-05-14)
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -24,7 +24,7 @@ class State:
         self.logger.propagate = False
 
         self.stream = logging.StreamHandler()
-        formatter = logging.Formatter("%(levelname)-7s -  %(message)s ")
+        formatter = logging.Formatter("{levelname:<7} -  {message} ", style='{')
         self.stream.setFormatter(formatter)
         self.stream.setLevel(level)
         self.stream.name = 'MkDocsStreamHandler'

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -8,7 +8,6 @@ import textwrap
 
 from mkdocs import __version__
 from mkdocs import utils
-from mkdocs import exceptions
 from mkdocs import config
 from mkdocs.commands import build, gh_deploy, new, serve
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -27,6 +27,7 @@ class State:
         formatter = logging.Formatter("%(levelname)-7s -  %(message)s ")
         self.stream.setFormatter(formatter)
         self.stream.setLevel(level)
+        self.stream.name = 'MkDocsStreamHandler'
         self.logger.addHandler(self.stream)
 
         # Add CountHandler for strict mode

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -167,15 +167,7 @@ def serve_command(dev_addr, livereload, **kwargs):
 
     logging.getLogger('tornado').setLevel(logging.WARNING)
 
-    try:
-        serve.serve(
-            dev_addr=dev_addr,
-            livereload=livereload,
-            **kwargs
-        )
-    except (exceptions.ConfigurationError, OSError) as e:  # pragma: no cover
-        # Avoid ugly, unhelpful traceback
-        raise SystemExit('\n' + str(e))
+    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
 
 
 @cli.command(name="build")
@@ -185,12 +177,7 @@ def serve_command(dev_addr, livereload, **kwargs):
 @common_options
 def build_command(clean, **kwargs):
     """Build the MkDocs documentation"""
-
-    try:
-        build.build(config.load_config(**kwargs), dirty=not clean)
-    except exceptions.ConfigurationError as e:  # pragma: no cover
-        # Avoid ugly, unhelpful traceback
-        raise SystemExit('\n' + str(e))
+    build.build(config.load_config(**kwargs), dirty=not clean)
 
 
 @cli.command(name="gh-deploy")
@@ -206,17 +193,13 @@ def build_command(clean, **kwargs):
 @common_options
 def gh_deploy_command(clean, message, remote_branch, remote_name, force, ignore_version, shell, **kwargs):
     """Deploy your documentation to GitHub Pages"""
-    try:
-        cfg = config.load_config(
-            remote_branch=remote_branch,
-            remote_name=remote_name,
-            **kwargs
-        )
-        build.build(cfg, dirty=not clean)
-        gh_deploy.gh_deploy(cfg, message=message, force=force, ignore_version=ignore_version, shell=shell)
-    except exceptions.ConfigurationError as e:  # pragma: no cover
-        # Avoid ugly, unhelpful traceback
-        raise SystemExit('\n' + str(e))
+    cfg = config.load_config(
+        remote_branch=remote_branch,
+        remote_name=remote_name,
+        **kwargs
+    )
+    build.build(cfg, dirty=not clean)
+    gh_deploy.gh_deploy(cfg, message=message, force=force, ignore_version=ignore_version, shell=shell)
 
 
 @cli.command(name="new")

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -7,7 +7,7 @@ from jinja2.exceptions import TemplateNotFound
 import jinja2
 
 from mkdocs import utils
-from mkdocs.exceptions import BuildError
+from mkdocs.exceptions import BuildError, Abort
 from mkdocs.structure.files import Files, get_files
 from mkdocs.structure.nav import get_navigation
 import mkdocs
@@ -311,7 +311,7 @@ def build(config, live_server=False, dirty=False):
         counts = utils.log_counter.get_counts()
         if config['strict'] and len(counts):
             msg = ', '.join([f'{v} {k.lower()}s' for k, v in counts])
-            raise SystemExit(f'\nAborted with {msg} in strict mode.')
+            raise Abort(f'\nAborted with {msg} in strict mode!')
 
         log.info('Documentation built in %.2f seconds', time() - start)
 
@@ -320,7 +320,7 @@ def build(config, live_server=False, dirty=False):
         config['plugins'].run_event('build_error', error=e)
         if isinstance(e, BuildError):
             log.error(str(e))
-            raise SystemExit('\nAborted with a BuildError!')
+            raise Abort('\nAborted with a BuildError!')
         raise
 
 

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -311,7 +311,7 @@ def build(config, live_server=False, dirty=False):
         counts = utils.log_counter.get_counts()
         if config['strict'] and len(counts):
             msg = ', '.join([f'{v} {k.lower()}s' for k, v in counts])
-            raise SystemExit(f'\nExited with {msg} in strict mode.')
+            raise SystemExit(f'\nAborted with {msg} in strict mode.')
 
         log.info('Documentation built in %.2f seconds', time() - start)
 
@@ -320,7 +320,7 @@ def build(config, live_server=False, dirty=False):
         config['plugins'].run_event('build_error', error=e)
         if isinstance(e, BuildError):
             log.error(str(e))
-            raise SystemExit('\nExited with a BuildError!')
+            raise SystemExit('\nAborted with a BuildError!')
         raise
 
 

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -26,7 +26,6 @@ class DuplicateFilter:
 
 log = logging.getLogger(__name__)
 log.addFilter(DuplicateFilter())
-log.addFilter(utils.warning_filter)
 
 
 def get_context(nav, files, config, page=None, base_url=''):
@@ -309,8 +308,10 @@ def build(config, live_server=False, dirty=False):
         # Run `post_build` plugin events.
         config['plugins'].run_event('post_build', config=config)
 
-        if config['strict'] and utils.warning_filter.count:
-            raise SystemExit('\nExited with {} warnings in strict mode.'.format(utils.warning_filter.count))
+        counts = utils.log_counter.get_counts()
+        if config['strict'] and len(counts):
+            msg = ', '.join([f'{v} {k.lower()}s' for k, v in counts])
+            raise SystemExit(f'\nExited with {msg} in strict mode.')
 
         log.info('Documentation built in %.2f seconds', time() - start)
 

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -319,7 +319,8 @@ def build(config, live_server=False, dirty=False):
         # Run `build_error` plugin events.
         config['plugins'].run_event('build_error', error=e)
         if isinstance(e, BuildError):
-            raise SystemExit('\n' + str(e))
+            log.error(str(e))
+            raise SystemExit('\nExited with a BuildError!')
         raise
 
 

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -6,6 +6,7 @@ from packaging import version
 
 import mkdocs
 import ghp_import
+from mkdocs.exceptions import Abort
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ def _is_cwd_git_repo():
         )
     except FileNotFoundError:
         log.error("Could not find git - is it installed and on your path?")
-        raise SystemExit(1)
+        raise Abort('Deployment Aborted!')
     proc.communicate()
     return proc.wait() == 0
 
@@ -80,7 +81,7 @@ def _check_version(branch):
             f'you are attempting to deploy with an older version ({currentv}). Use --ignore-version '
             'to deploy anyway.'
         )
-        raise SystemExit(1)
+        raise Abort('Deployment Aborted!')
 
 
 def gh_deploy(config, message=None, force=False, ignore_version=False, shell=False):
@@ -115,7 +116,7 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
         )
     except ghp_import.GhpError as e:
         log.error("Failed to deploy to GitHub with error: \n{}".format(e.message))
-        raise SystemExit(1)
+        raise Abort('Deployment Aborted!')
 
     cname_file = os.path.join(config['site_dir'], 'CNAME')
     # Does this repository have a CNAME set for GitHub pages?

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -6,6 +6,7 @@ import sys
 from os.path import isfile, join
 from mkdocs.commands.build import build
 from mkdocs.config import load_config
+from mkdocs.exceptions import Abort
 
 log = logging.getLogger(__name__)
 
@@ -147,5 +148,8 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             _livereload(host, port, config, builder, site_dir, watch_theme)
         else:
             _static_server(host, port, site_dir)
+    except OSError as e:  # pragma: no cover
+        # Avoid ugly, unhelpful traceback
+        raise Abort(str(e))
     finally:
         shutil.rmtree(site_dir)

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -206,11 +206,11 @@ def load_config(config_file=None, **kwargs):
         log.debug("Config value: '%s' = %r", key, value)
 
     if len(errors) > 0:
-        raise exceptions.ConfigurationError(
+        raise exceptions.Abort(
             "Aborted with {} Configuration Errors!".format(len(errors))
         )
     elif cfg['strict'] and len(warnings) > 0:
-        raise exceptions.ConfigurationError(
+        raise exceptions.Abort(
             "Aborted with {} Configuration Warnings in 'strict' mode!".format(len(warnings))
         )
 

--- a/mkdocs/exceptions.py
+++ b/mkdocs/exceptions.py
@@ -1,8 +1,14 @@
-from click import ClickException
+from click import ClickException, echo
 
 
 class MkDocsException(ClickException):
     """Base exceptions for all MkDocs Exceptions"""
+
+
+class Abort(MkDocsException):
+    """Abort the build"""
+    def show(self, **kwargs):
+        echo(self.format_message())
 
 
 class ConfigurationError(MkDocsException):

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -8,7 +8,6 @@ from mkdocs import utils
 
 
 log = logging.getLogger(__name__)
-log.addFilter(utils.warning_filter)
 
 
 class Files:

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -2,10 +2,9 @@ import logging
 from urllib.parse import urlparse
 
 from mkdocs.structure.pages import Page
-from mkdocs.utils import nest_paths, warning_filter
+from mkdocs.utils import nest_paths
 
 log = logging.getLogger(__name__)
-log.addFilter(warning_filter)
 
 
 class Navigation:

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -9,10 +9,9 @@ from markdown.treeprocessors import Treeprocessor
 from markdown.util import AMP_SUBSTITUTE
 
 from mkdocs.structure.toc import get_toc
-from mkdocs.utils import meta, get_build_date, get_markdown_title, warning_filter
+from mkdocs.utils import meta, get_build_date, get_markdown_title
 
 log = logging.getLogger(__name__)
-log.addFilter(warning_filter)
 
 
 class Page:

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -217,10 +217,8 @@ class CLITests(unittest.TestCase):
             use_directory_urls=None,
             site_dir=None
         )
-        logger = logging.getLogger('mkdocs')
-        for handler in logger.handlers:
-            if isinstance(handler, logging.StreamHandler):
-                self.assertEqual(handler.level, logging.INFO)
+        handler = logging._handlers.get('MkDocsStreamHandler')
+        self.assertEqual(handler.level, logging.INFO)
 
     @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
@@ -357,10 +355,8 @@ class CLITests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_build.call_count, 1)
-        logger = logging.getLogger('mkdocs')
-        for handler in logger.handlers:
-            if isinstance(handler, logging.StreamHandler):
-                self.assertEqual(handler.level, logging.DEBUG)
+        handler = logging._handlers.get('MkDocsStreamHandler')
+        self.assertEqual(handler.level, logging.DEBUG)
 
     @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
@@ -371,10 +367,8 @@ class CLITests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_build.call_count, 1)
-        logger = logging.getLogger('mkdocs')
-        for handler in logger.handlers:
-            if isinstance(handler, logging.StreamHandler):
-                self.assertEqual(handler.level, logging.ERROR)
+        handler = logging._handlers.get('MkDocsStreamHandler')
+        self.assertEqual(handler.level, logging.ERROR)
 
     @mock.patch('mkdocs.commands.new.new', autospec=True)
     def test_new(self, mock_new):

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -218,7 +218,9 @@ class CLITests(unittest.TestCase):
             site_dir=None
         )
         logger = logging.getLogger('mkdocs')
-        self.assertEqual(logger.level, logging.INFO)
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                self.assertEqual(handler.level, logging.INFO)
 
     @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
@@ -356,7 +358,9 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_build.call_count, 1)
         logger = logging.getLogger('mkdocs')
-        self.assertEqual(logger.level, logging.DEBUG)
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                self.assertEqual(handler.level, logging.DEBUG)
 
     @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
@@ -368,7 +372,9 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_build.call_count, 1)
         logger = logging.getLogger('mkdocs')
-        self.assertEqual(logger.level, logging.ERROR)
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                self.assertEqual(handler.level, logging.ERROR)
 
     @mock.patch('mkdocs.commands.new.new', autospec=True)
     def test_new(self, mock_new):

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -133,7 +133,7 @@ class ConfigBaseTests(unittest.TestCase):
             config_file.flush()
             config_file.close()
 
-            self.assertRaises(exceptions.ConfigurationError,
+            self.assertRaises(exceptions.Abort,
                               base.load_config, config_file=config_file.name)
         finally:
             os.remove(config_file.name)

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -4,6 +4,7 @@ from ghp_import import GhpError
 
 from mkdocs.tests.base import load_config
 from mkdocs.commands import gh_deploy
+from mkdocs.exceptions import Abort
 from mkdocs import __version__
 
 
@@ -155,7 +156,7 @@ class TestGitHubDeploy(unittest.TestCase):
             remote_branch='test',
         )
 
-        self.assertRaises(SystemExit, gh_deploy.gh_deploy, config)
+        self.assertRaises(Abort, gh_deploy.gh_deploy, config)
         mock_log.error.assert_called_once_with(
             'Failed to deploy to GitHub with error: \n{}'.format(error_string)
         )
@@ -181,7 +182,7 @@ class TestGitHubDeployLogs(unittest.TestCase):
         mock_popeno().communicate.return_value = (b'Deployed 12345678 with MkDocs version: 10.1.2\n', b'')
 
         with self.assertLogs('mkdocs', level='ERROR') as cm:
-            self.assertRaises(SystemExit, gh_deploy._check_version, 'gh-pages')
+            self.assertRaises(Abort, gh_deploy._check_version, 'gh-pages')
         self.assertEqual(
             cm.output, ['ERROR:mkdocs.commands.gh_deploy:Deployment terminated: Previous deployment was made with '
                         'MkDocs version 10.1.2; you are attempting to deploy with an older version ({}). Use '

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -8,7 +8,7 @@ import os
 from mkdocs import plugins
 from mkdocs import config
 from mkdocs.commands import build
-from mkdocs.exceptions import BuildError, PluginError
+from mkdocs.exceptions import BuildError, PluginError, Abort
 from mkdocs.tests.base import load_config
 
 
@@ -177,15 +177,15 @@ class TestPluginCollection(unittest.TestCase):
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='pre_page')
-        self.assertRaises(SystemExit, build.build, cfg)
+        self.assertRaises(Abort, build.build, cfg)
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='page_markdown')
-        self.assertRaises(SystemExit, build.build, cfg)
+        self.assertRaises(Abort, build.build, cfg)
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='page_content')
-        self.assertRaises(SystemExit, build.build, cfg)
+        self.assertRaises(Abort, build.build, cfg)
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='post_page')

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -7,7 +7,6 @@ from mkdocs.utils import filters
 from mkdocs.config.base import ValidationError
 
 log = logging.getLogger(__name__)
-log.addFilter(utils.warning_filter)
 
 
 class Theme:

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -443,3 +443,8 @@ class CountHandler(logging.NullHandler):
 
 # A global instance to use throughout package
 log_counter = CountHandler()
+
+# For backward compatability as some plugins import it.
+# It is no longer nessecary as all messages on the
+# `mkdocs` logger get counted automaticaly.
+warning_filter = logging.Filter()

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -440,5 +440,6 @@ class CountHandler(logging.NullHandler):
     def get_counts(self):
         return [(logging.getLevelName(k), v) for k, v in sorted(self.counts.items(), reverse=True)]
 
+
 # A global instance to use throughout package
 log_counter = CountHandler()


### PR DESCRIPTION
This provides for better reporting to users, makes for easier maintenance going forward, and will allow future expandability. The following major changes were made:

1. The logging config is now defined in a way which will allow future expandability. For example, we could add additional levels of `strict` or `verbosity`. All log messages are fed to a single log, which has two handlers (one for strict mode and one for verbosity). All level restrictions are defined per handler so that one restriction does not interfere with another. As filters do not have a level assigned to them, the previous count filter is now a nullhandler which counts all messages is receives (restricted only by level). The previous filter still exists (as a do-nothing instance) for any third-party plugins which called it. Those plugins should remove the call going forward.
2. A new exception `mkdocs.exceptions.Abort` was added. Rather than calling `SystemExit`, we now call `Abort`, which is a custom `click` exception that aborts with a readable error message and no traceback. Where appropriate, we catch errors, log them, and then call `Abort`. This allows us to remove all error handling from the CLI code and include it where errors originate from. Of course, as previously, unanticipated errors will still generate a traceback to allow debugging.
3. Log formatting has been improved. All log messages are now hard wrapped and indented for easier reading and color is used to identify each by type. Note that colors are only used to highlight errors, warnings and debug messages. Under normal operation with no issues, the user will not see any color.