### PR TITLE
Revert to logging.StreamHandler

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -32,15 +32,6 @@ class ColorFormatter(logging.Formatter):
         return msg
 
 
-class ClickHandler(logging.Handler):
-    def emit(self, record):
-        try:
-            msg = self.format(record)
-            click.echo(msg)
-        except Exception:
-            self.handleError(record)
-
-
 class State:
     ''' Maintain logging level.'''
 
@@ -50,7 +41,7 @@ class State:
         self.logger.setLevel(1)
         self.logger.propagate = False
 
-        self.stream = ClickHandler()
+        self.stream = logging.StreamHandler()
         self.stream.setFormatter(ColorFormatter())
         self.stream.setLevel(level)
         self.stream.name = 'MkDocsStreamHandler'


### PR DESCRIPTION
The new ClickHandler was causing all log messages to be printed to the
test output. As it offered no real value and littered the test output,
we are reverting back to the logging.StreamHandler with no loss of
functionality. See #2364 for context.