### PR TITLE
Revert the addition of Abort exception and clean up abort messages

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -61,17 +61,15 @@ to execute code when an exception is raised while building the site.
 See [`on_build_error`](../dev-guide/plugins.md#on_build_error)
 in the Plugins documentation for details.
 
-#### Three new exceptions: BuildError PluginError and Abort (#2103)
+#### Two new exceptions: BuildError and PluginError (#2103)
 
-MkDocs now has tree new exceptions defined in `mkdocs.exceptions`:
-`BuildError`, `PluginError`, and `Abort`:
+MkDocs now has two new exceptions defined in `mkdocs.exceptions`,
+`BuildError` and `PluginError`:
 
 * `PluginError` can be raised from a plugin
   to stop the build and log an error message *without traceback*.
 * `BuildError` should not be used by third-party plugins developers
   and is reserved for internal use only.
-* `Abort` is used internally to abort the build and display an error
-  without a traceback.
 
 See [`Handling errors`](../dev-guide/plugins.md#handling-errors)
 in the Plugins documentation for details.

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -7,7 +7,7 @@ from jinja2.exceptions import TemplateNotFound
 import jinja2
 
 from mkdocs import utils
-from mkdocs.exceptions import BuildError, Abort
+from mkdocs.exceptions import BuildError
 from mkdocs.structure.files import Files, get_files
 from mkdocs.structure.nav import get_navigation
 import mkdocs
@@ -311,7 +311,7 @@ def build(config, live_server=False, dirty=False):
         counts = utils.log_counter.get_counts()
         if config['strict'] and len(counts):
             msg = ', '.join([f'{v} {k.lower()}s' for k, v in counts])
-            raise Abort(f'\nAborted with {msg} in strict mode!')
+            raise SystemExit(f'Aborted with {msg} in strict mode.')
 
         log.info('Documentation built in %.2f seconds', time() - start)
 
@@ -320,7 +320,7 @@ def build(config, live_server=False, dirty=False):
         config['plugins'].run_event('build_error', error=e)
         if isinstance(e, BuildError):
             log.error(str(e))
-            raise Abort('\nAborted with a BuildError!')
+            raise SystemExit('Build terminated with an error.')
         raise
 
 

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -6,7 +6,6 @@ from packaging import version
 
 import mkdocs
 import ghp_import
-from mkdocs.exceptions import Abort
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ def _is_cwd_git_repo():
         )
     except FileNotFoundError:
         log.error("Could not find git - is it installed and on your path?")
-        raise Abort('Deployment Aborted!')
+        raise SystemExit(1)
     proc.communicate()
     return proc.wait() == 0
 
@@ -81,7 +80,7 @@ def _check_version(branch):
             f'you are attempting to deploy with an older version ({currentv}). Use --ignore-version '
             'to deploy anyway.'
         )
-        raise Abort('Deployment Aborted!')
+        raise SystemExit(1)
 
 
 def gh_deploy(config, message=None, force=False, ignore_version=False, shell=False):
@@ -116,7 +115,7 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
         )
     except ghp_import.GhpError as e:
         log.error("Failed to deploy to GitHub with error: \n{}".format(e.message))
-        raise Abort('Deployment Aborted!')
+        raise SystemExit(1)
 
     cname_file = os.path.join(config['site_dir'], 'CNAME')
     # Does this repository have a CNAME set for GitHub pages?

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -6,7 +6,6 @@ import sys
 from os.path import isfile, join
 from mkdocs.commands.build import build
 from mkdocs.config import load_config
-from mkdocs.exceptions import Abort
 
 log = logging.getLogger(__name__)
 
@@ -150,6 +149,6 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             _static_server(host, port, site_dir)
     except OSError as e:  # pragma: no cover
         # Avoid ugly, unhelpful traceback
-        raise Abort(str(e))
+        raise SystemExit(str(e))
     finally:
         shutil.rmtree(site_dir)

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -206,12 +206,12 @@ def load_config(config_file=None, **kwargs):
         log.debug("Config value: '%s' = %r", key, value)
 
     if len(errors) > 0:
-        raise exceptions.Abort(
-            "Aborted with {} Configuration Errors!".format(len(errors))
+        raise SystemExit(
+            "Aborted with {} configuration errors!".format(len(errors))
         )
     elif cfg['strict'] and len(warnings) > 0:
-        raise exceptions.Abort(
-            "Aborted with {} Configuration Warnings in 'strict' mode!".format(len(warnings))
+        raise SystemExit(
+            "Aborted with {} configuration warnings in 'strict' mode!".format(len(warnings))
         )
 
     return cfg

--- a/mkdocs/exceptions.py
+++ b/mkdocs/exceptions.py
@@ -1,14 +1,8 @@
-from click import ClickException, echo
+from click import ClickException
 
 
 class MkDocsException(ClickException):
     """Base exceptions for all MkDocs Exceptions"""
-
-
-class Abort(MkDocsException):
-    """Abort the build"""
-    def show(self, **kwargs):
-        echo(self.format_message())
 
 
 class ConfigurationError(MkDocsException):

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -133,7 +133,7 @@ class ConfigBaseTests(unittest.TestCase):
             config_file.flush()
             config_file.close()
 
-            self.assertRaises(exceptions.Abort,
+            self.assertRaises(SystemExit,
                               base.load_config, config_file=config_file.name)
         finally:
             os.remove(config_file.name)

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -4,7 +4,6 @@ from ghp_import import GhpError
 
 from mkdocs.tests.base import load_config
 from mkdocs.commands import gh_deploy
-from mkdocs.exceptions import Abort
 from mkdocs import __version__
 
 
@@ -156,7 +155,7 @@ class TestGitHubDeploy(unittest.TestCase):
             remote_branch='test',
         )
 
-        self.assertRaises(Abort, gh_deploy.gh_deploy, config)
+        self.assertRaises(SystemExit, gh_deploy.gh_deploy, config)
         mock_log.error.assert_called_once_with(
             'Failed to deploy to GitHub with error: \n{}'.format(error_string)
         )
@@ -182,7 +181,7 @@ class TestGitHubDeployLogs(unittest.TestCase):
         mock_popeno().communicate.return_value = (b'Deployed 12345678 with MkDocs version: 10.1.2\n', b'')
 
         with self.assertLogs('mkdocs', level='ERROR') as cm:
-            self.assertRaises(Abort, gh_deploy._check_version, 'gh-pages')
+            self.assertRaises(SystemExit, gh_deploy._check_version, 'gh-pages')
         self.assertEqual(
             cm.output, ['ERROR:mkdocs.commands.gh_deploy:Deployment terminated: Previous deployment was made with '
                         'MkDocs version 10.1.2; you are attempting to deploy with an older version ({}). Use '

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -8,7 +8,7 @@ import os
 from mkdocs import plugins
 from mkdocs import config
 from mkdocs.commands import build
-from mkdocs.exceptions import BuildError, PluginError, Abort
+from mkdocs.exceptions import BuildError, PluginError
 from mkdocs.tests.base import load_config
 
 
@@ -177,15 +177,15 @@ class TestPluginCollection(unittest.TestCase):
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='pre_page')
-        self.assertRaises(Abort, build.build, cfg)
+        self.assertRaises(SystemExit, build.build, cfg)
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='page_markdown')
-        self.assertRaises(Abort, build.build, cfg)
+        self.assertRaises(SystemExit, build.build, cfg)
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='page_content')
-        self.assertRaises(Abort, build.build, cfg)
+        self.assertRaises(SystemExit, build.build, cfg)
 
         cfg = load_config()
         cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='post_page')


### PR DESCRIPTION
I see no upside to having that exception type, but the downside is that it always requires some message, even when we have nothing additional to say.

I also revert some recently added exclamation marks and fix messages where each word is capitalized.