### PR TITLE
Fix wrapping of multiline strings for the newly added ColorFormatter

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -28,19 +28,22 @@ class ColorFormatter(logging.Formatter):
         replace_whitespace=False,
         break_long_words=False,
         break_on_hyphens=False,
-        initial_indent=' '*12,
-        subsequent_indent=' '*12
+        initial_indent=' '*11,
+        subsequent_indent=' '*11
     )
 
     def format(self, record):
-        prefix = f'{record.levelname:<8} -  '
+        prefix = f'{record.levelname:<7} -  '
         if record.levelname in self.colors:
             prefix = click.style(prefix, fg=self.colors[record.levelname])
         if self.text_wrapper.width:
             # Only wrap text if a terminal width was detected
-            msg = self.text_wrapper.fill(record.getMessage())
+            msg = '\n'.join(
+                self.text_wrapper.fill(line)
+                for line in record.getMessage().splitlines()
+            )
             # Prepend prefix after wrapping so that color codes don't affect length
-            return prefix + msg[12:]
+            return prefix + msg[11:]
         return prefix + record.getMessage()
 
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -28,12 +28,12 @@ class ColorFormatter(logging.Formatter):
         replace_whitespace=False,
         break_long_words=False,
         break_on_hyphens=False,
-        initial_indent=' '*11,
-        subsequent_indent=' '*11
+        initial_indent=' '*12,
+        subsequent_indent=' '*12
     )
 
     def format(self, record):
-        prefix = f'{record.levelname:<7} -  '
+        prefix = f'{record.levelname:<8} -  '
         if record.levelname in self.colors:
             prefix = click.style(prefix, fg=self.colors[record.levelname])
         if self.text_wrapper.width:
@@ -43,7 +43,7 @@ class ColorFormatter(logging.Formatter):
                 for line in record.getMessage().splitlines()
             )
             # Prepend prefix after wrapping so that color codes don't affect length
-            return prefix + msg[11:]
+            return prefix + msg[12:]
         return prefix + record.getMessage()
 
 

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -113,8 +113,8 @@ def get_navigation(files, config):
     if missing_from_config:
         log.info(
             'The following pages exist in the docs directory, but are not '
-            'included in the "nav" configuration:\n  - {}'.format(
-                '\n  - '.join([file.src_path for file in missing_from_config]))
+            'included in the "nav" configuration:\n- {}'.format(
+                '\n- '.join([file.src_path for file in missing_from_config]))
         )
         # Any documentation files not found in the nav should still have an associated page, so we
         # create them here. The Page object will automatically be assigned to `file.page` during

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -113,8 +113,8 @@ def get_navigation(files, config):
     if missing_from_config:
         log.info(
             'The following pages exist in the docs directory, but are not '
-            'included in the "nav" configuration:\n- {}'.format(
-                '\n- '.join([file.src_path for file in missing_from_config]))
+            'included in the "nav" configuration:\n  - {}'.format(
+                '\n  - '.join([file.src_path for file in missing_from_config]))
         )
         # Any documentation files not found in the nav should still have an associated page, so we
         # create them here. The Page object will automatically be assigned to `file.page` during


### PR DESCRIPTION
1. Fix handling of messages that already have multiple lines.
  It looks like the wrapping code in stdlib just considers '\n' like any other character, so the result is really weird.
2. ~~Decrease indentation by one, to match the default logger.~~
3. ~~Semi-related: Drop one case of manual indentation now that it's centrally handled.~~

See examples of (1) and (2) at https://github.com/mkdocs/mkdocs/pull/2364#issuecomment-824381108