### PR TITLE
Update IpAddress normalization test broken in Python3.9.5

### DIFF
--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -132,13 +132,17 @@ class IpAddressTest(unittest.TestCase):
         self.assertEqual(value.host, '127.0.0.1')
         self.assertEqual(value.port, 8000)
 
-    def test_invalid_leading_zeros(self):
-        addr = '0127.000.000.001:8000'
+    @unittest.skipIf(
+        sys.version_info >= (3, 9, 5),
+        "Leading zeros not allowed in IP addresses since Python3.9.5",
+    )
+    def test_IP_normalization(self):
+        addr = '127.000.000.001:8000'
         option = config_options.IpAddress(default=addr)
-        self.assertRaises(
-            config_options.ValidationError,
-            option.validate, addr
-        )
+        value = option.validate(None)
+        self.assertEqual(str(value), '127.0.0.1:8000')
+        self.assertEqual(value.host, '127.0.0.1')
+        self.assertEqual(value.port, 8000)
 
     def test_invalid_address_range(self):
         option = config_options.IpAddress()

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -144,6 +144,18 @@ class IpAddressTest(unittest.TestCase):
         self.assertEqual(value.host, '127.0.0.1')
         self.assertEqual(value.port, 8000)
 
+    @unittest.skipIf(
+        sys.version_info < (3, 9, 5),
+        "Leading zeros allowed in IP addresses before Python3.9.5",
+    )
+    def test_invalid_leading_zeros(self):
+        addr = '127.000.000.001:8000'
+        option = config_options.IpAddress(default=addr)
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, addr
+        )
+
     def test_invalid_address_range(self):
         option = config_options.IpAddress()
         self.assertRaises(

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -132,13 +132,13 @@ class IpAddressTest(unittest.TestCase):
         self.assertEqual(value.host, '127.0.0.1')
         self.assertEqual(value.port, 8000)
 
-    def test_IP_normalization(self):
-        addr = '127.000.000.001:8000'
+    def test_invalid_leading_zeros(self):
+        addr = '0127.000.000.001:8000'
         option = config_options.IpAddress(default=addr)
-        value = option.validate(None)
-        self.assertEqual(str(value), '127.0.0.1:8000')
-        self.assertEqual(value.host, '127.0.0.1')
-        self.assertEqual(value.port, 8000)
+        self.assertRaises(
+            config_options.ValidationError,
+            option.validate, addr
+        )
 
     def test_invalid_address_range(self):
         option = config_options.IpAddress()


### PR DESCRIPTION
[`ipaddress.ip_address`](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address) behaviour has been changed in Python3.9.5 due to a [security fix](https://www.ehackingnews.com/2021/05/python-affected-by-critical-ip-address.html). Now, leading zeros are not treated as part of valid ip addresses.

~~This pull proposes the change of the affected test, adding a leading zero at the beginning to make it break in earlier versions of Python, but the other option would be to delete it because this normalization would be invalid.~~