### PR TITLE
Replace use of deprecated alias `jinja2.Markup`

### DIFF
--- a/mkdocs/utils/filters.py
+++ b/mkdocs/utils/filters.py
@@ -1,11 +1,13 @@
 import json
+
 import jinja2
+import markupsafe
 
 from mkdocs.utils import normalize_url
 
 
 def tojson(obj, **kwargs):
-    return jinja2.Markup(json.dumps(obj, **kwargs))
+    return markupsafe.Markup(json.dumps(obj, **kwargs))
 
 
 @jinja2.contextfilter

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -1,6 +1,7 @@
 babel==2.9.0
 click==3.3
 Jinja2==2.10.1
+MarkupSafe==0.23
 livereload==2.5.1
 Markdown==3.2.1
 PyYAML==5.1

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,6 +1,7 @@
 babel>=2.9.0
 click>=7.0
 Jinja2>=2.10.3
+MarkupSafe>=0.23
 livereload>=2.6.1
 Markdown>=3.2.1
 PyYAML>=5.2


### PR DESCRIPTION
-- use `markupsafe.Markup` directly instead.

Note: the choice of version is to match https://github.com/pallets/jinja/blob/2.10.1/setup.py

See the deprecation message already popping up in CI:
https://github.com/mkdocs/mkdocs/runs/2567454550?check_suite_focus=true#step:5:17
`DeprecationWarning: 'jinja2.Markup' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.`