### PR TITLE
Optimize getting relative page URLs, now with less custom code

### DIFF
--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -12,7 +12,6 @@ import shutil
 import re
 import yaml
 import fnmatch
-import pathlib
 import posixpath
 import functools
 import importlib_metadata
@@ -253,7 +252,10 @@ def is_error_template(path):
 
 @functools.lru_cache(maxsize=None)
 def _norm_parts(path):
-    return pathlib.PosixPath('/' + path).resolve().parts[1:]
+    if not path.startswith('/'):
+        path = '/' + path
+    path = posixpath.normpath(path)[1:]
+    return path.split('/') if path else []
 
 
 def get_relative_url(url, other):
@@ -279,7 +281,7 @@ def get_relative_url(url, other):
             break
         common += 1
 
-    rel_parts = ('..',) * (len(other_parts) - common) + dest_parts[common:]
+    rel_parts = ['..'] * (len(other_parts) - common) + dest_parts[common:]
     relurl = '/'.join(rel_parts) or '.'
     return relurl + '/' if url.endswith('/') else relurl
 


### PR DESCRIPTION
This is a custom implementation that's significantly faster but always gives the exact same results as the current one. The use of `posixpath.relpath` pulled in several path-specific transformations that are never needed here.

Efficiency is important because calls to `normalize_url` (e.g.) on a site with ~300 pages currently take up ~10% of the total run time due to the sheer number of them. The number of calls is at least the number of pages squared.

Generally, approximating that the number of these calls is N&times;N&times;2, this is the graph that we end up with:
![image](https://user-images.githubusercontent.com/371383/118406764-92809680-b67d-11eb-822b-ce26757bdb70.png)
[Full source code how I got this result](https://gist.github.com/b7d9b1e6bbecd4415dabb70aaba4c581)

This shows the total time spent getting relative paths (Y axis) over the course of building a site with that many pages (X axis).
With red color being "before" and green color being "after".
This does not show the total site build times, rather you can only subtract "red" from "green" to approximate the absolute savings of time.

In all other regards the sites' build times grow linearly, but only this particular place it grows as N^2 (because the templates end up linking to every page on every built page). So, with more and more pages, more and more percentage of time is spent just generating these relative URLs.
So I'm making it very optimal, because it's the place that really matters.

Previously: https://github.com/mkdocs/mkdocs/pull/2272, https://github.com/mkdocs/mkdocs/pull/2296 (a big number of tests was already added there)