### PR TITLE
No exception if directory already removed, closes #2420

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -2,7 +2,7 @@ import logging
 import shutil
 import tempfile
 
-from os.path import isfile, join
+from os.path import isdir, isfile, join
 from mkdocs.commands.build import build
 from mkdocs.config import load_config
 from mkdocs.exceptions import Abort
@@ -84,4 +84,5 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
         # Avoid ugly, unhelpful traceback
         raise Abort(str(e))
     finally:
-        shutil.rmtree(site_dir)
+        if isdir(site_dir):
+            shutil.rmtree(site_dir)


### PR DESCRIPTION
When `mkdocs serve` is shutting down, it cleans up after itself removing the temporary directory created earlier.

Previously the condition whether the directory is to be removed was unchecked and prone to a file system race condition (shared resource).

Given the directory is absent on the file-system while shutting down, `mkdocs serve` threw an exception and exited in failure.

Change is to override the cause of the exception by preventing the attempt to remove a directory that is already gone.