### PR TITLE
Offset the local site root according to the sub-path of the site_url

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -100,6 +100,13 @@ Degradations in behavior are not expected, and should be reported if found.
 [livereload]: https://pypi.org/project/livereload/
 [tornado]: https://pypi.org/project/tornado/
 
+##### Offset the local site root according to the sub-path of the `site_url` (#2424)
+
+When using `mkdocs serve` and having the `site_url` specified as e.g.
+`http://example.org/sub/path/`, now the root of the locally served site
+becomes `http://127.0.0.1:8000/sub/path/` and all document paths are offset
+accordingly.
+
 #### A `build_error` event was added (#2103)
 
 Plugin developers can now use the `on_build_error` hook


### PR DESCRIPTION
E.g. if `site_url` is specified as `http://example.org/sub/path/`, then upon opening `http://127.0.0.1:8000/` you will be redirected to `http://127.0.0.1:8000/sub/path/`. And the file `docs/foo/index.md` will be served at `http://127.0.0.1:8000/sub/path/foo/`

Ref https://github.com/mkdocs/mkdocs/issues/2404#issuecomment-840622229