### PR TITLE
Restore the functionality of watching files through symlinks

### DIFF
--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -70,8 +70,7 @@ def tempdir(files=None, **kw):
     """
     files = {f: '' for f in files} if isinstance(files, (list, tuple)) else files or {}
 
-    if 'prefix' not in kw:
-        kw['prefix'] = 'mkdocs_test-'
+    kw['prefix'] = 'mkdocs_test-' + kw.get('prefix', '')
 
     def decorator(fn):
         @wraps(fn)

--- a/mkdocs/tests/livereload_tests.py
+++ b/mkdocs/tests/livereload_tests.py
@@ -3,6 +3,7 @@
 import contextlib
 import email
 import io
+import sys
 import threading
 import time
 import unittest
@@ -36,6 +37,7 @@ def testing_server(root, builder=lambda: None, mount_path="/"):
             port=0,
             root=root,
             mount_path=mount_path,
+            build_delay=0.1,
             bind_and_activate=False,
         )
         server.setup_environ()
@@ -420,3 +422,99 @@ class BuildTests(unittest.TestCase):
                 headers, _ = do_request(server, "GET /")
             self.assertEqual(headers["_status"], "302 Found")
             self.assertEqual(headers.get("location"), "/mount/path/")
+
+    @tempdir({"mkdocs.yml": "original", "mkdocs2.yml": "original"}, prefix="tmp_dir")
+    @tempdir(prefix="origin_dir")
+    @tempdir({"subdir/foo.md": "original"}, prefix="dest_docs_dir")
+    def test_watches_direct_symlinks(self, dest_docs_dir, origin_dir, tmp_dir):
+        try:
+            Path(origin_dir, "docs").symlink_to(dest_docs_dir, target_is_directory=True)
+            Path(origin_dir, "mkdocs.yml").symlink_to(Path(tmp_dir, "mkdocs.yml"))
+        except NotImplementedError:  # PyPy on Windows
+            self.skipTest("Creating symlinks not supported")
+
+        started_building = threading.Event()
+
+        def wait_for_build():
+            result = started_building.wait(timeout=10)
+            started_building.clear()
+            with self.assertLogs("mkdocs.livereload"):
+                do_request(server, "GET /")
+            return result
+
+        with testing_server(tmp_dir, started_building.set) as server:
+            server.watch(Path(origin_dir, "docs"))
+            server.watch(Path(origin_dir, "mkdocs.yml"))
+            time.sleep(0.01)
+
+            Path(tmp_dir, "mkdocs.yml").write_text("edited")
+            self.assertTrue(wait_for_build())
+
+            Path(dest_docs_dir, "subdir", "foo.md").write_text("edited")
+            self.assertTrue(wait_for_build())
+
+            Path(origin_dir, "unrelated.md").write_text("foo")
+            self.assertFalse(started_building.wait(timeout=0.2))
+
+    @tempdir(["file_dest_1.md", "file_dest_2.md", "file_dest_unused.md"], prefix="tmp_dir")
+    @tempdir(["file_under.md"], prefix="dir_to_link_to")
+    @tempdir()
+    def test_watches_through_symlinks(self, docs_dir, dir_to_link_to, tmp_dir):
+        try:
+            Path(docs_dir, "link1.md").symlink_to(Path(tmp_dir, "file_dest_1.md"))
+            Path(docs_dir, "linked_dir").symlink_to(dir_to_link_to, target_is_directory=True)
+
+            Path(dir_to_link_to, "sublink.md").symlink_to(Path(tmp_dir, "file_dest_2.md"))
+        except NotImplementedError:  # PyPy on Windows
+            self.skipTest("Creating symlinks not supported")
+
+        started_building = threading.Event()
+
+        def wait_for_build():
+            result = started_building.wait(timeout=10)
+            started_building.clear()
+            with self.assertLogs("mkdocs.livereload"):
+                do_request(server, "GET /")
+            return result
+
+        with testing_server(docs_dir, started_building.set) as server:
+            server.watch(docs_dir)
+            time.sleep(0.01)
+
+            Path(tmp_dir, "file_dest_1.md").write_text("edited")
+            self.assertTrue(wait_for_build())
+
+            Path(dir_to_link_to, "file_under.md").write_text("edited")
+            self.assertTrue(wait_for_build())
+
+            Path(tmp_dir, "file_dest_2.md").write_text("edited")
+            self.assertTrue(wait_for_build())
+
+            Path(docs_dir, "link1.md").unlink()
+            self.assertTrue(wait_for_build())
+
+            Path(tmp_dir, "file_dest_unused.md").write_text("edited")
+            self.assertFalse(started_building.wait(timeout=0.2))
+
+    @tempdir()
+    def test_watch_with_broken_symlinks(self, docs_dir):
+        Path(docs_dir, "subdir").mkdir()
+
+        try:
+            if sys.platform != "win32":
+                Path(docs_dir, "subdir", "circular").symlink_to(Path(docs_dir))
+            Path(docs_dir, "self_link").symlink_to(Path(docs_dir, "self_link"))
+
+            Path(docs_dir, "broken_1").symlink_to(Path(docs_dir, "oh no"))
+            Path(docs_dir, "broken_2").symlink_to(Path(docs_dir, "oh no"), target_is_directory=True)
+            Path(docs_dir, "broken_3").symlink_to(Path(docs_dir, "broken_2"))
+        except NotImplementedError:  # PyPy on Windows
+            self.skipTest("Creating symlinks not supported")
+
+        started_building = threading.Event()
+        with testing_server(docs_dir, started_building.set) as server:
+            server.watch(docs_dir)
+            time.sleep(0.01)
+
+            Path(docs_dir, "subdir", "test").write_text("test")
+            self.assertTrue(started_building.wait(timeout=10))


### PR DESCRIPTION
### Fix the ability to watch single files

Watchdog doesn't support it directly but it happened to work everywhere except Windows

---

### Restore the functionality of watching files through symlinks

(lost in commit a444c43)

This is achieved by walking through the target directory, finding any symlinks in it, and watching their target too (+recursive walking of those too).

Important note: only symlinks that exist during startup will be taken into account, new ones aren't added.

Fixes #2425
Closes #2426
cc @ktomk 