### PR TITLE
Allow CI to run when pushing to a branch

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,14 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - master
-    tags:
-      - '**'
-  pull_request:
-    branches:
-      - '**'
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
The motivation is that contributors currently have no good way to test their changes before opening a pull request.