### PR TITLE
babel is required for deployment

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3.7
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel babel
       - name: Compile localization message files
         run: |
           python setup.py compile_catalog -t mkdocs


### PR DESCRIPTION
I just manually deployed version 1.2 as the deploy script failed because the babel commands were not available. This fixes that. As babel is an optional dependency, we need to explicitly require it for any automated scripts.