### PR TITLE
Ensure gh-deploy always pushes

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,6 +21,10 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
+## Version 1.2.1 (Under Development)
+
+* Bugfix: Ensure 'gh-deploy' always pushes.
+
 ## Version 1.2 (2021-06-04)
 
 ### Major Additions to Version 1.2

--- a/mkdocs/__init__.py
+++ b/mkdocs/__init__.py
@@ -2,4 +2,4 @@
 
 
 # For acceptable version formats, see https://www.python.org/dev/peps/pep-0440/
-__version__ = '1.2'
+__version__ = '1.2.1.dev1'

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -110,7 +110,8 @@ def gh_deploy(config, message=None, force=False, ignore_version=False, shell=Fal
             mesg=message,
             remote=remote_name,
             branch=remote_branch,
-            push=force,
+            push=True,
+            force=force,
             use_shell=shell,
             nojekyll=True
         )


### PR DESCRIPTION
This was a regression in behavior. I had missed that `push` and `force`
are two separate parameters of `ghp_import.ghp_import` in #2257.

The old behavior has been restored (`push` is always enabled and `force` is overridable).