### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -21,7 +21,7 @@ The current and past members of the MkDocs team.
 * [@d0ugal](https://github.com/d0ugal/)
 * [@waylan](https://github.com/waylan/)
 
-## Version 1.2.1 (Under Development)
+## Version 1.2.1 (2021-06-09)
 
 * Bugfix: Ensure 'gh-deploy' always pushes.
 

--- a/mkdocs/__init__.py
+++ b/mkdocs/__init__.py
@@ -2,4 +2,4 @@
 
 
 # For acceptable version formats, see https://www.python.org/dev/peps/pep-0440/
-__version__ = '1.2.1.dev1'
+__version__ = '1.2.1'


### PR DESCRIPTION
Normally I would wait for a few more bug reports/fixes to come in before making another release, but the one fix in here is needed for users deploy scripts to work. As the regression is very disruptive to users, we should get this fix out immediately (see #2444, #2447 and #2448).