### PR TITLE
Fix gh_deploy with config-file in the current directory

### DIFF
--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -29,7 +29,7 @@ def _is_cwd_git_repo():
 
 def _get_current_sha(repo_path):
 
-    proc = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], cwd=repo_path,
+    proc = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], cwd=repo_path or None,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     stdout, _ = proc.communicate()


### PR DESCRIPTION
If the config file is specified as relative and is in the current directory, the `dirname` transform came out empty, which `subprocess` doesn't like as `cwd`.

Fixes #2471
