### PR TITLE
Make mkdocs-static-i18n plugin compatible with mkdocs-with-pdf plugin

### DIFF
--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -63,6 +63,8 @@ class PluginCollection(OrderedDict):
 
     def _register_event(self, event_name, method):
         """ Register a method for an event. """
+        if(event_name in self.events and method in self.events[event_name]):
+            return
         self.events[event_name].append(method)
 
     def __setitem__(self, key, value, **kwargs):


### PR DESCRIPTION
For my documentation I need multi language switch and multi language generated pdf. I thought that this is a very common requirement for documentation but sadly there is no build in support. So I had to deal with the plugins:
- https://github.com/orzih/mkdocs-with-pdf
- https://github.com/ultrabug/mkdocs-static-i18n

This plugins used to work independent of each other. If both plugins are configured, build failes with errors. So I had to patch 3 different repositories to make them work together:

- mkdocs/plugins.py: i18n plugin creates deepcopy of config for each language. While copying the register event methode are called twice so we must avoid these.
- https://github.com/orzih/mkdocs-with-pdf/pull/68
- https://github.com/ultrabug/mkdocs-static-i18n/pull/42
