### PR TITLE
CI: Run all lint checks in one job

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -55,36 +55,35 @@ jobs:
           fail_ci_if_error: false
 
   lint:
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        tox-env: ['flake8', 'markdown-lint', 'jshint', 'csslint']
-    env:
-      TOXENV: ${{ matrix.tox-env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip tox
       - name: Setup Node
-        if: ${{ matrix.tox-env != 'flake8' }}
         uses: actions/setup-node@v1
         with:
-          node-version: '10'
+          node-version: 14
       - name: Install Node dependencies
-        if: ${{ matrix.tox-env != 'flake8' }}
         run: |
-          if [[ "$TOXENV" == 'markdown-lint' ]]; then npm install -g markdownlint-cli; fi
-          if [[ "$TOXENV" == 'jshint' ]]; then npm install -g jshint; fi
-          if [[ "$TOXENV" == 'csslint' ]]; then npm install -g csslint; fi
-      - name: Run tox
-        run: python -m tox
+          npm install -g markdownlint-cli jshint csslint
+      - name: Check with flake8
+        if: always()
+        run: python -m tox -e flake8
+      - name: Check with markdown-lint
+        if: always()
+        run: python -m tox -e markdown-lint
+      - name: Check with jshint
+        if: always()
+        run: python -m tox -e jshint
+      - name: Check with csslint
+        if: always()
+        run: python -m tox -e csslint
 
   translation:
     strategy:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -86,9 +86,6 @@ jobs:
         run: python -m tox -e csslint
 
   translation:
-    strategy:
-      fail-fast: false
-      max-parallel: 4
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is more considerate of the computational resources. The lint checks are not the bottleneck, and now they won't starve other jobs from starting.
All checks will still run and a failure in any of them will fail the job.

Also upgrade Python and Node versions
