### PR TITLE
Replace urlparse with urlsplit

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import gzip
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from jinja2.exceptions import TemplateNotFound
 import jinja2
@@ -76,7 +76,7 @@ def _build_template(name, template, files, config, nav):
         # See https://github.com/mkdocs/mkdocs/issues/77.
         # However, if site_url is not set, assume the docs root and server root
         # are the same. See https://github.com/mkdocs/mkdocs/issues/1598.
-        base_url = urlparse(config['site_url'] or '/').path
+        base_url = urlsplit(config['site_url'] or '/').path
     else:
         base_url = utils.get_relative_url('.', name)
 

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -1,7 +1,7 @@
 import logging
 import shutil
 import tempfile
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 from os.path import isdir, isfile, join
 
 from mkdocs.commands.build import build
@@ -28,7 +28,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
     site_dir = tempfile.mkdtemp(prefix='mkdocs_')
 
     def mount_path(config):
-        return urlparse(config['site_url'] or '/').path
+        return urlsplit(config['site_url'] or '/').path
 
     def builder():
         log.info("Building documentation...")

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1,7 +1,7 @@
 import os
 from collections import namedtuple
 from collections.abc import Sequence
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlsplit, urlunsplit
 import ipaddress
 import markdown
 
@@ -297,14 +297,14 @@ class URL(OptionallyRequired):
             return value
 
         try:
-            parsed_url = urlparse(value)
+            parsed_url = urlsplit(value)
         except (AttributeError, TypeError):
             raise ValidationError("Unable to parse the URL.")
 
         if parsed_url.scheme:
             if self.is_dir and not parsed_url.path.endswith('/'):
                 parsed_url = parsed_url._replace(path=f'{parsed_url.path}/')
-            return urlunparse(parsed_url)
+            return urlunsplit(parsed_url)
 
         raise ValidationError(
             "The URL isn't valid, it should include the http:// (scheme)")
@@ -319,7 +319,7 @@ class RepoURL(URL):
     """
 
     def post_validation(self, config, key_name):
-        repo_host = urlparse(config['repo_url']).netloc.lower()
+        repo_host = urlsplit(config['repo_url']).netloc.lower()
         edit_uri = config.get('edit_uri')
 
         # derive repo_name from repo_url if unset

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from mkdocs.structure.pages import Page
 from mkdocs.utils import nest_paths
@@ -124,7 +124,7 @@ def get_navigation(files, config):
 
     links = _get_by_type(items, Link)
     for link in links:
-        scheme, netloc, path, params, query, fragment = urlparse(link.url)
+        scheme, netloc, path, query, fragment = urlsplit(link.url)
         if scheme or netloc:
             log.debug(
                 "An external link to '{}' is included in "

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from urllib.parse import urlparse, urlunparse, urljoin
+from urllib.parse import urlsplit, urlunsplit, urljoin
 from urllib.parse import unquote as urlunquote
 
 import markdown
@@ -98,7 +98,7 @@ class Page:
             if not base.endswith('/'):
                 base += '/'
             self.canonical_url = urljoin(base, self.url)
-            self.abs_url = urlparse(self.canonical_url).path
+            self.abs_url = urlsplit(self.canonical_url).path
         else:
             self.canonical_url = None
             self.abs_url = None
@@ -202,7 +202,7 @@ class _RelativePathTreeprocessor(Treeprocessor):
         return root
 
     def path_to_url(self, url):
-        scheme, netloc, path, params, query, fragment = urlparse(url)
+        scheme, netloc, path, query, fragment = urlsplit(url)
 
         if (scheme or netloc or not path or url.startswith('/') or url.startswith('\\')
                 or AMP_SUBSTITUTE in url or '.' not in os.path.split(path)[-1]):
@@ -224,8 +224,8 @@ class _RelativePathTreeprocessor(Treeprocessor):
             return url
         target_file = self.files.get_file_from_path(target_path)
         path = target_file.url_relative_to(self.file)
-        components = (scheme, netloc, path, params, query, fragment)
-        return urlunparse(components)
+        components = (scheme, netloc, path, query, fragment)
+        return urlunsplit(components)
 
 
 class _RelativePathExtension(Extension):

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -17,7 +17,7 @@ import functools
 import importlib_metadata
 from collections import defaultdict
 from datetime import datetime, timezone
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 from yaml_env_tag import construct_env_tag
 from mergedeep import merge
 
@@ -291,7 +291,7 @@ def normalize_url(path, page=None, base=''):
 def _get_norm_url(path):
     path = path_to_url(path or '.')
     # Allow links to be fully qualified URLs
-    parsed = urlparse(path)
+    parsed = urlsplit(path)
     if parsed.scheme or parsed.netloc or path.startswith(('/', '#')):
         return path, True
     return path, False


### PR DESCRIPTION
https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit
https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse

It's the same but doesn't treat ';' as a special character in paths; and I don't think anyone would expect it to be special
