### PR TITLE
Add Japanese (`ja`) translation for built-in themes

### DIFF
--- a/docs/user-guide/choosing-your-theme.md
+++ b/docs/user-guide/choosing-your-theme.md
@@ -175,6 +175,7 @@ theme supports the following options:
     * `en`: English (default)
     * `fr`: French
     * `es`: Spanish
+    * `ja`: Japanese
 
     See the guide on [localizing your theme] for more information.
 

--- a/docs/user-guide/choosing-your-theme.md
+++ b/docs/user-guide/choosing-your-theme.md
@@ -102,6 +102,7 @@ supports the following options:
     * `en`: English (default)
     * `fr`: French
     * `es`: Spanish
+    * `ja`: Japanese
 
     See the guide on [localizing your theme] for more information.
 

--- a/mkdocs/themes/mkdocs/locales/ja/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/ja/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
 "POT-Creation-Date: 2021-04-08 22:44+0200\n"
 "PO-Revision-Date: 2021-07-31 12:06+0900\n"
-"Last-Translator: FULL NAME <@nickname or @email>\n"
+"Last-Translator: Goto Hayato <habita.gh@gmail.com>\n"
 "Language: ja\n"
 "Language-Team: ja <LL@li.org>\n"
 "Plural-Forms: nplurals=1; plural=0\n"
@@ -19,79 +19,79 @@ msgstr ""
 
 #: mkdocs/themes/mkdocs/404.html:8
 msgid "Page not found"
-msgstr ""
+msgstr "ページが見つかりません"
 
 #: mkdocs/themes/mkdocs/base.html:107
 #: mkdocs/themes/mkdocs/keyboard-modal.html:31
 #: mkdocs/themes/mkdocs/search-modal.html:5
 msgid "Search"
-msgstr ""
+msgstr "検索"
 
 #: mkdocs/themes/mkdocs/base.html:117
 msgid "Previous"
-msgstr ""
+msgstr "前へ"
 
 #: mkdocs/themes/mkdocs/base.html:122
 msgid "Next"
-msgstr ""
+msgstr "次へ"
 
 #: mkdocs/themes/mkdocs/base.html:133 mkdocs/themes/mkdocs/base.html:135
 #: mkdocs/themes/mkdocs/base.html:137 mkdocs/themes/mkdocs/base.html:139
 #, python-format
 msgid "Edit on %(repo_name)s"
-msgstr ""
+msgstr "%(repo_name)s で編集"
 
 #: mkdocs/themes/mkdocs/base.html:179
 #, python-format
 msgid "Documentation built with %(mkdocs_link)s."
-msgstr ""
+msgstr "%(mkdocs_link)s でビルドされたドキュメンテーション"
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:5
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "キーボードショートカット"
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:6
 #: mkdocs/themes/mkdocs/search-modal.html:6
 msgid "Close"
-msgstr ""
+msgstr "閉じる"
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:12
 msgid "Keys"
-msgstr ""
+msgstr "キー"
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:13
 msgid "Action"
-msgstr ""
+msgstr "アクション"
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:19
 msgid "Open this help"
-msgstr ""
+msgstr "このヘルプを開く"
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:23
 msgid "Next page"
-msgstr ""
+msgstr "次のページ"
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:27
 msgid "Previous page"
-msgstr ""
+msgstr "前のページ"
 
 #: mkdocs/themes/mkdocs/search-modal.html:9
 msgid "From here you can search these documents. Enter your search terms below."
-msgstr ""
+msgstr "これらのドキュメントをこちらから検索できます。検索語句を以下に入力してください。"
 
 #: mkdocs/themes/mkdocs/search-modal.html:12
 msgid "Search..."
-msgstr ""
+msgstr "検索..."
 
 #: mkdocs/themes/mkdocs/search-modal.html:12
 msgid "Type search term here"
-msgstr ""
+msgstr "検索語句を入力してください"
 
 #: mkdocs/themes/mkdocs/search-modal.html:15
 msgid "No results found"
-msgstr ""
+msgstr "結果がありません"
 
 #: mkdocs/themes/mkdocs/toc.html:3
 msgid "Table of Contents"
-msgstr ""
+msgstr "目次"
 

--- a/mkdocs/themes/mkdocs/locales/ja/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/ja/LC_MESSAGES/messages.po
@@ -1,0 +1,97 @@
+# Japanese translations for MkDocs.
+# Copyright (C) 2021 MkDocs
+# This file is distributed under the same license as the MkDocs project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MkDocs 1.2\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"POT-Creation-Date: 2021-04-08 22:44+0200\n"
+"PO-Revision-Date: 2021-07-31 12:06+0900\n"
+"Last-Translator: FULL NAME <@nickname or @email>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: mkdocs/themes/mkdocs/404.html:8
+msgid "Page not found"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/base.html:107
+#: mkdocs/themes/mkdocs/keyboard-modal.html:31
+#: mkdocs/themes/mkdocs/search-modal.html:5
+msgid "Search"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/base.html:117
+msgid "Previous"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/base.html:122
+msgid "Next"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/base.html:133 mkdocs/themes/mkdocs/base.html:135
+#: mkdocs/themes/mkdocs/base.html:137 mkdocs/themes/mkdocs/base.html:139
+#, python-format
+msgid "Edit on %(repo_name)s"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/base.html:179
+#, python-format
+msgid "Documentation built with %(mkdocs_link)s."
+msgstr ""
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:5
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:6
+#: mkdocs/themes/mkdocs/search-modal.html:6
+msgid "Close"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:12
+msgid "Keys"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:13
+msgid "Action"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:19
+msgid "Open this help"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:23
+msgid "Next page"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:27
+msgid "Previous page"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/search-modal.html:9
+msgid "From here you can search these documents. Enter your search terms below."
+msgstr ""
+
+#: mkdocs/themes/mkdocs/search-modal.html:12
+msgid "Search..."
+msgstr ""
+
+#: mkdocs/themes/mkdocs/search-modal.html:12
+msgid "Type search term here"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/search-modal.html:15
+msgid "No results found"
+msgstr ""
+
+#: mkdocs/themes/mkdocs/toc.html:3
+msgid "Table of Contents"
+msgstr ""
+

--- a/mkdocs/themes/readthedocs/locales/ja/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/ja/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
 "POT-Creation-Date: 2021-04-08 22:46+0200\n"
 "PO-Revision-Date: 2021-07-31 12:07+0900\n"
-"Last-Translator: FULL NAME <@nickname or @email>\n"
+"Last-Translator: Goto Hayato <habita.gh@gmail.com>\n"
 "Language: ja\n"
 "Language-Team: ja <LL@li.org>\n"
 "Plural-Forms: nplurals=1; plural=0\n"
@@ -19,58 +19,59 @@ msgstr ""
 
 #: mkdocs/themes/readthedocs/404.html:7
 msgid "Page not found"
-msgstr ""
+msgstr "ページが見つかりません"
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:3
 msgid "Docs"
-msgstr ""
+msgstr "ドキュメント"
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:24
 #, python-format
 msgid "Edit on %(repo_name)s"
-msgstr ""
+msgstr "%(repo_name)s で編集"
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:33
 #: mkdocs/themes/readthedocs/footer.html:7
 #: mkdocs/themes/readthedocs/versions.html:14
 msgid "Next"
-msgstr ""
+msgstr "次へ"
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:36
 #: mkdocs/themes/readthedocs/footer.html:10
 #: mkdocs/themes/readthedocs/versions.html:11
 msgid "Previous"
-msgstr ""
+msgstr "前へ"
 
 #: mkdocs/themes/readthedocs/footer.html:25
 #, python-format
 msgid ""
 "Built with %(mkdocs_link)s using a %(sphinx_link)s provided by "
 "%(rtd_link)s."
-msgstr ""
+msgstr "%(rtd_link)s 提供の %(sphinx_link)s を使って "
+"%(mkdocs_link)s でビルドされました。"
 
 #: mkdocs/themes/readthedocs/search.html:5
 msgid "Search Results"
-msgstr ""
+msgstr "検索結果"
 
 #: mkdocs/themes/readthedocs/search.html:9
 msgid "Search the Docs"
-msgstr ""
+msgstr "ドキュメントを検索"
 
 #: mkdocs/themes/readthedocs/search.html:9
 #: mkdocs/themes/readthedocs/searchbox.html:3
 msgid "Type search term here"
-msgstr ""
+msgstr "検索語句を入力してください"
 
 #: mkdocs/themes/readthedocs/search.html:12
 msgid "No results found"
-msgstr ""
+msgstr "結果がありません"
 
 #: mkdocs/themes/readthedocs/search.html:13
 msgid "Searching..."
-msgstr ""
+msgstr "検索しています..."
 
 #: mkdocs/themes/readthedocs/searchbox.html:3
 msgid "Search docs"
-msgstr ""
+msgstr "ドキュメントを検索"
 

--- a/mkdocs/themes/readthedocs/locales/ja/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/ja/LC_MESSAGES/messages.po
@@ -1,0 +1,76 @@
+# Japanese translations for MkDocs.
+# Copyright (C) 2021 MkDocs
+# This file is distributed under the same license as the MkDocs project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MkDocs 1.2\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"POT-Creation-Date: 2021-04-08 22:46+0200\n"
+"PO-Revision-Date: 2021-07-31 12:07+0900\n"
+"Last-Translator: FULL NAME <@nickname or @email>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: mkdocs/themes/readthedocs/404.html:7
+msgid "Page not found"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:3
+msgid "Docs"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:24
+#, python-format
+msgid "Edit on %(repo_name)s"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:33
+#: mkdocs/themes/readthedocs/footer.html:7
+#: mkdocs/themes/readthedocs/versions.html:14
+msgid "Next"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:36
+#: mkdocs/themes/readthedocs/footer.html:10
+#: mkdocs/themes/readthedocs/versions.html:11
+msgid "Previous"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/footer.html:25
+#, python-format
+msgid ""
+"Built with %(mkdocs_link)s using a %(sphinx_link)s provided by "
+"%(rtd_link)s."
+msgstr ""
+
+#: mkdocs/themes/readthedocs/search.html:5
+msgid "Search Results"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/search.html:9
+msgid "Search the Docs"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/search.html:9
+#: mkdocs/themes/readthedocs/searchbox.html:3
+msgid "Type search term here"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/search.html:12
+msgid "No results found"
+msgstr ""
+
+#: mkdocs/themes/readthedocs/search.html:13
+msgid "Searching..."
+msgstr ""
+
+#: mkdocs/themes/readthedocs/searchbox.html:3
+msgid "Search docs"
+msgstr ""
+


### PR DESCRIPTION
I'd like to add Japanese translation for built-in themes.

- `mkdocs`
- `readthedocs`

I read the following guides for contribution before I made this PR.

- https://www.mkdocs.org/about/contributing/
- https://www.mkdocs.org/dev-guide/translations/

I tested them locally following the instruction https://www.mkdocs.org/dev-guide/translations/#testing-theme-translations and they look fine.

Please let me know if there's anything I missed. Thank you in advance!