### PR TITLE
Ignore hidden files during live reload

### DIFF
--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -79,6 +79,9 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
         def callback(event):
             if event.is_directory:
                 return
+            filename = os.path.basename(event.src_path)
+            if filename[0] == '.':
+                return
             log.debug(str(event))
             with self._rebuild_cond:
                 self._to_rebuild[func] = True


### PR DESCRIPTION
This patch resolves #2519 by changing the callback used by `--livereload` and `--dirtyreload` to ignore hidden files such as editor temporary swap files.  They are not included in the built site anyway, so they should not trigger a documentation rebuild.