### PR TITLE
Add missing es translations to readthedocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/locales/es/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/es/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
-"POT-Creation-Date: 2021-04-08 22:44+0200\n"
+"POT-Creation-Date: 2021-04-08 22:46+0200\n"
 "PO-Revision-Date: 2021-05-07 12:06+0200\n"
 "Last-Translator: Álvaro Mondéjar Rubio <mondejar1994@gmail.com>\n"
 "Language: es\n"
@@ -17,82 +17,62 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: mkdocs/themes/mkdocs/404.html:8
+#: mkdocs/themes/readthedocs/404.html:7
 msgid "Page not found"
 msgstr "Página no encontrada"
 
-#: mkdocs/themes/mkdocs/base.html:107
-#: mkdocs/themes/mkdocs/keyboard-modal.html:31
-#: mkdocs/themes/mkdocs/search-modal.html:5
-msgid "Search"
-msgstr "Buscar"
+#: mkdocs/themes/readthedocs/breadcrumbs.html:3
+msgid "Docs"
+msgstr "Documentos"
 
-#: mkdocs/themes/mkdocs/base.html:117
-msgid "Previous"
-msgstr "Anterior"
-
-#: mkdocs/themes/mkdocs/base.html:122
-msgid "Next"
-msgstr "Siguiente"
-
-#: mkdocs/themes/mkdocs/base.html:133 mkdocs/themes/mkdocs/base.html:135
-#: mkdocs/themes/mkdocs/base.html:137 mkdocs/themes/mkdocs/base.html:139
+#: mkdocs/themes/readthedocs/breadcrumbs.html:24
 #, python-format
 msgid "Edit on %(repo_name)s"
 msgstr "Editar en %(repo_name)s"
 
-#: mkdocs/themes/mkdocs/base.html:179
+#: mkdocs/themes/readthedocs/breadcrumbs.html:33
+#: mkdocs/themes/readthedocs/footer.html:7
+#: mkdocs/themes/readthedocs/versions.html:14
+msgid "Next"
+msgstr "Siguiente"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:36
+#: mkdocs/themes/readthedocs/footer.html:10
+#: mkdocs/themes/readthedocs/versions.html:11
+msgid "Previous"
+msgstr "Anterior"
+
+#: mkdocs/themes/readthedocs/footer.html:25
 #, python-format
-msgid "Documentation built with %(mkdocs_link)s."
-msgstr "Documentación construida con %(mkdocs_link)s."
-
-#: mkdocs/themes/mkdocs/keyboard-modal.html:5
-msgid "Keyboard Shortcuts"
-msgstr "Atajos de teclado"
-
-#: mkdocs/themes/mkdocs/keyboard-modal.html:6
-#: mkdocs/themes/mkdocs/search-modal.html:6
-msgid "Close"
-msgstr "Cerrar"
-
-#: mkdocs/themes/mkdocs/keyboard-modal.html:12
-msgid "Keys"
-msgstr "Teclas"
-
-#: mkdocs/themes/mkdocs/keyboard-modal.html:13
-msgid "Action"
-msgstr "Acción"
-
-#: mkdocs/themes/mkdocs/keyboard-modal.html:19
-msgid "Open this help"
-msgstr "Abrir esta ayuda"
-
-#: mkdocs/themes/mkdocs/keyboard-modal.html:23
-msgid "Next page"
-msgstr "Página siguiente"
-
-#: mkdocs/themes/mkdocs/keyboard-modal.html:27
-msgid "Previous page"
-msgstr "Página anterior"
-
-#: mkdocs/themes/mkdocs/search-modal.html:9
-msgid "From here you can search these documents. Enter your search terms below."
+msgid ""
+"Built with %(mkdocs_link)s using a %(sphinx_link)s provided by "
+"%(rtd_link)s."
 msgstr ""
-"Desde aquí puede buscar estos documentos. Ingrese sus términos de búsqueda a "
-"continuación."
+"Construído con %(mkdocs_link)s usando %(sphinx_link)s provisto "
+"por%(rtd_link)s."
 
-#: mkdocs/themes/mkdocs/search-modal.html:12
-msgid "Search..."
-msgstr "Buscando..."
+#: mkdocs/themes/readthedocs/search.html:5
+msgid "Search Results"
+msgstr "Resultados de búsqueda"
 
-#: mkdocs/themes/mkdocs/search-modal.html:12
+#: mkdocs/themes/readthedocs/search.html:9
+msgid "Search the Docs"
+msgstr "Buscar en la documentación"
+
+#: mkdocs/themes/readthedocs/search.html:9
+#: mkdocs/themes/readthedocs/searchbox.html:3
 msgid "Type search term here"
 msgstr "Escriba el término de búsqueda aquí"
 
-#: mkdocs/themes/mkdocs/search-modal.html:15
+#: mkdocs/themes/readthedocs/search.html:12
 msgid "No results found"
 msgstr "No se encontraron resultados"
 
-#: mkdocs/themes/mkdocs/toc.html:3
-msgid "Table of Contents"
-msgstr "Tabla de contenidos"
+#: mkdocs/themes/readthedocs/search.html:13
+#, fuzzy
+msgid "Searching..."
+msgstr "Buscando..."
+
+#: mkdocs/themes/readthedocs/searchbox.html:3
+msgid "Search docs"
+msgstr "Buscar documentos"


### PR DESCRIPTION
I'm not sure why these weren't added in #2396, maybe I forget to run `update_catalog` after `init_catalog`. This is the cause of the [failure ocurred in latest release workflow](https://github.com/mkdocs/mkdocs/runs/3098566096). 