### PR TITLE
Add __repr__ method to File class

### DIFF
--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -141,6 +141,9 @@ class File:
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __repr__(self):
+        return "File(src_path='{}', url='{}')".format(self.src_path, self.url)
+
     def _get_stem(self):
         """ Return the name of the file without it's extension. """
         filename = os.path.basename(self.src_path)

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -142,7 +142,9 @@ class File:
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "File(src_path='{}', url='{}')".format(self.src_path, self.url)
+        return "File(src_path='{}', dest_path='{}', name='{}', url='{}')".format(
+            self.src_path, self.dest_path, self.name, self.url
+        )
 
     def _get_stem(self):
         """ Return the name of the file without it's extension. """


### PR DESCRIPTION
I've found myself when developing plugins printing `File.src_path`, a lot of times, so I've created the reproduction method based on the same defined in `Page` class.