### PR TITLE
Add codespell step to CI lint workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Check with csslint
         if: always()
         run: python -m tox -e csslint
+      - name: Check with codespell
+        if: always()
+        run: python -m tox -e codespell
 
   translation:
     runs-on: ubuntu-latest

--- a/mkdocs/themes/mkdocs/js/base.js
+++ b/mkdocs/themes/mkdocs/js/base.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
         $search_modal.modal();
     }
 
-    // make sure search input gets autofocus everytime modal opens.
+    // make sure search input gets autofocus every time modal opens.
     $search_modal.on('shown.bs.modal', function() {
         $search_modal.find('#mkdocs-search-query').focus();
     });

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands=
 [testenv:codespell]
 deps=codespell
 commands=
-    {envbindir}/codespell . -S '*.min.js' -S 'lunr.*.js' -S lunr.js -S fontawesome-webfont.svg -S .tox -S venv
+    {envbindir}/codespell . -S '*.min.js' -S 'lunr.*.js' -S lunr.js -S fontawesome-webfont.svg -S .tox -S venv -S tinyseg.js
 
 [testenv:linkchecker]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands=
 [testenv:codespell]
 deps=codespell
 commands=
-    {envbindir}/codespell . -S '*.min.js' -S 'lunr.*.js' -S lunr.js -S fontawesome-webfont.svg -S .tox -S venv -S tinyseg.js
+    {envbindir}/codespell . -S '*.min.js' -S 'lunr.*.js' -S lunr.js -S fontawesome-webfont.svg -S .tox -S venv
 
 [testenv:linkchecker]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38,39,py3}-{unittests,min-req,integration,integration-no-babel},
-    flake8, markdown-lint, linkchecker, jshint, csslint, nobabel
+    flake8, markdown-lint, linkchecker, jshint, csslint, nobabel, codespell
 
 [testenv]
 passenv = LANG
@@ -29,6 +29,11 @@ commands=
     node --version
     markdownlint --version
     markdownlint README.md CONTRIBUTING.md docs/ --ignore docs/CNAME
+
+[testenv:codespell]
+deps=codespell
+commands=
+    {envbindir}/codespell . -S '*.min.js' -S 'lunr.*.js' -S lunr.js -S fontawesome-webfont.svg -S .tox -S venv -S tinyseg.js
 
 [testenv:linkchecker]
 basepython = python2.7


### PR DESCRIPTION
As suggested by [this comment in previous PR](https://github.com/mkdocs/mkdocs/pull/2549#issuecomment-902757777), add spelling check to lint workflow in CI.