### PR TITLE
tox translation build: add tests for lunr.js language support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -r requirements/project.txt
+      - name: Check if the locales are supported by lunr.js
+        run: |
+          for locale in $(ls mkdocs/themes/mkdocs/locales/); do
+            python -m pip show -f mkdocs | grep -q "lunr.${locale}.js" || exit 1;
+          done
+        shell: bash
       - name: Check if Portable Object Templates should have been updated
         run: |
           python setup.py extract_messages -t mkdocs


### PR DESCRIPTION
this should avoid forgetting that a locale added to mkdocs theme
translations should be supported by lunr.js to work