### PR TITLE
fix translation installation for locales with script name

### DIFF
--- a/mkdocs/localization.py
+++ b/mkdocs/localization.py
@@ -56,9 +56,13 @@ def _get_merged_translations(theme_dirs, locales_dir, locale):
     merged_translations = None
 
     log.debug(f"Looking for translations for locale '{locale}'")
+    if locale.territory:
+        locale_str = f"{locale.language}_{locale.territory}"
+    else:
+        locale_str = locale.language
     for theme_dir in reversed(theme_dirs):
         dirname = os.path.join(theme_dir, locales_dir)
-        translations = Translations.load(dirname, [locale])
+        translations = Translations.load(dirname, [locale_str])
 
         if type(translations) is NullTranslations:
             log.debug(f"No translations found here: '{dirname}'")


### PR DESCRIPTION
when a locale like zh_CN is parsed by babel.core.Locale, the
result Locale is zh_Hans_CN which is then used to find out if
translations exist for this locale name

the Hans part is the guessed script name part of the babel Locale
but is almost never contributed as translation locale name so
we have to make sure what we look for the language + territory
locale name instead of the fully parsed name from babel