### PR TITLE
Search plugin: added option to put full nav path to the search result title

### DIFF
--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -52,6 +52,7 @@ class _PluginConfig(base.Config):
     min_search_length = c.Type(int, default=3)
     prebuild_index = c.Choice((False, True, 'node', 'python'), default=False)
     indexing = c.Choice(('full', 'sections', 'titles'), default='full')
+    full_path_in_title = c.Choice((False, True), default=False)
 
 
 class SearchPlugin(BasePlugin[_PluginConfig]):

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -59,6 +59,12 @@ class SearchIndex:
         the page itself and then one for each of its' heading
         tags.
         """
+        title_parts = [page.title]
+        if self.config['full_path_in_title']:
+            for ancestor in page.ancestors:
+                title_parts.insert(0, ancestor.title)
+
+        page_title = ' / '.join(title_parts)
         # Create the content parser and feed in the HTML for the
         # full page. This handles all the parsing and prepares
         # us to iterate through it.
@@ -73,14 +79,23 @@ class SearchIndex:
 
         # Create an entry for the full page.
         text = parser.stripped_html.rstrip('\n') if self.config['indexing'] == 'full' else ''
-        self._add_entry(title=page.title, text=text, loc=url)
+
+        self._add_entry(
+            title=page_title,
+            text=text,
+            loc=url
+        )
 
         if self.config['indexing'] in ['full', 'sections']:
-            for section in parser.data:
-                self.create_entry_for_section(section, page.toc, url)
+            for i, section in enumerate(parser.data):
+                if self.config['full_path_in_title'] and i == 0:
+                    section_title = page_title
+                else:
+                    section_title = None
+                self.create_entry_for_section(section, page.toc, url, section_title)
 
     def create_entry_for_section(
-        self, section: ContentSection, toc: TableOfContents, abs_url: str
+        self, section: ContentSection, toc: TableOfContents, abs_url: str, title: Optional[str] = None
     ) -> None:
         """
         Given a section on the page, the table of contents and
@@ -91,7 +106,8 @@ class SearchIndex:
 
         text = ' '.join(section.text) if self.config['indexing'] == 'full' else ''
         if toc_item is not None:
-            self._add_entry(title=toc_item.title, text=text, loc=abs_url + toc_item.url)
+            self._add_entry(title=title or toc_item.title, text=text, loc=abs_url + toc_item.url)
+
 
     def generate_search_index(self) -> str:
         """python to json conversion"""

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -59,7 +59,7 @@ class SearchIndex:
         the page itself and then one for each of its' heading
         tags.
         """
-        title_parts = [page.title]
+        title_parts = [page.title] if page.title else []
         if self.config['full_path_in_title']:
             for ancestor in page.ancestors:
                 title_parts.insert(0, ancestor.title)
@@ -79,11 +79,7 @@ class SearchIndex:
         # Create an entry for the full page.
         text = parser.stripped_html.rstrip('\n') if self.config['indexing'] == 'full' else ''
 
-        self._add_entry(
-            title=page_title,
-            text=text,
-            loc=url
-        )
+        self._add_entry(title=page_title, text=text, loc=url)
 
         if self.config['indexing'] in ['full', 'sections']:
             for i, section in enumerate(parser.data):
@@ -94,7 +90,11 @@ class SearchIndex:
                 self.create_entry_for_section(section, page.toc, url, section_title)
 
     def create_entry_for_section(
-        self, section: ContentSection, toc: TableOfContents, abs_url: str, title: Optional[str] = None
+        self,
+        section: ContentSection,
+        toc: TableOfContents,
+        abs_url: str,
+        title: Optional[str] = None,
     ) -> None:
         """
         Given a section on the page, the table of contents and

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -63,7 +63,6 @@ class SearchIndex:
         if self.config['full_path_in_title']:
             for ancestor in page.ancestors:
                 title_parts.insert(0, ancestor.title)
-
         page_title = ' / '.join(title_parts)
         # Create the content parser and feed in the HTML for the
         # full page. This handles all the parsing and prepares
@@ -107,7 +106,6 @@ class SearchIndex:
         text = ' '.join(section.text) if self.config['indexing'] == 'full' else ''
         if toc_item is not None:
             self._add_entry(title=title or toc_item.title, text=text, loc=abs_url + toc_item.url)
-
 
     def generate_search_index(self) -> str:
         """python to json conversion"""

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -82,7 +82,7 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 3,
             'prebuild_index': False,
             'indexing': 'full',
-            'full_path_in_title': False
+            'full_path_in_title': False,
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({})
@@ -172,7 +172,7 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 3,
             'prebuild_index': False,
             'full_path_in_title': True,
-            'indexing': 'full'
+            'indexing': 'full',
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'full_path_in_title': True})

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -82,6 +82,7 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 3,
             'prebuild_index': False,
             'indexing': 'full',
+            'full_path_in_title': False
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({})
@@ -96,6 +97,7 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 3,
             'prebuild_index': False,
             'indexing': 'full',
+            'full_path_in_title': False,
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'lang': 'es'})
@@ -110,6 +112,7 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 3,
             'prebuild_index': False,
             'indexing': 'full',
+            'full_path_in_title': False,
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'separator': r'[\s\-\.]+'})
@@ -124,6 +127,7 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 2,
             'prebuild_index': False,
             'indexing': 'full',
+            'full_path_in_title': False,
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'min_search_length': 2})
@@ -138,6 +142,7 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 3,
             'prebuild_index': True,
             'indexing': 'full',
+            'full_path_in_title': False,
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'prebuild_index': True})
@@ -152,9 +157,25 @@ class SearchPluginTests(unittest.TestCase):
             'min_search_length': 3,
             'prebuild_index': False,
             'indexing': 'titles',
+            'full_path_in_title': False,
         }
         plugin = search.SearchPlugin()
         errors, warnings = plugin.load_config({'indexing': 'titles'})
+        self.assertEqual(plugin.config, expected)
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_plugin_config_full_path_in_title(self):
+        expected = {
+            'lang': None,
+            'separator': r'[\s\-]+',
+            'min_search_length': 3,
+            'prebuild_index': False,
+            'full_path_in_title': True,
+            'indexing': 'full'
+        }
+        plugin = search.SearchPlugin()
+        errors, warnings = plugin.load_config({'full_path_in_title': True})
         self.assertEqual(plugin.config, expected)
         self.assertEqual(errors, [])
         self.assertEqual(warnings, [])


### PR DESCRIPTION
Hi! Here is my first PR :grin: 

Added option `full_path_in_title` which allows to get not just page title in a search result, but full path separated with slashes, like: "Section 1 / Subsection / Page Title".

To enable the feature, one has to add following to mkdocs.yml:

``` yaml
plugins:
    - search:
        full_path_in_title: yes
```

Tests for search plugin is updated too.