### PR TITLE
Depend on 'colorama' on Windows to fix color output in terminal

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -12,6 +12,15 @@ from mkdocs import utils
 from mkdocs import config
 from mkdocs.commands import build, gh_deploy, new, serve
 
+
+if sys.platform.startswith("win"):
+    try:
+        import colorama
+    except ImportError:
+        pass
+    else:
+        colorama.init()
+
 log = logging.getLogger(__name__)
 
 

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -12,3 +12,4 @@ mkdocs-redirects==1.0.1
 importlib_metadata==3.10.0
 packaging==20.5
 mergedeep==1.3.4
+colorama==0.4; platform_system == 'Windows'

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -12,3 +12,4 @@ mkdocs-redirects>=1.0.1
 importlib_metadata>=3.10
 packaging>=20.5
 mergedeep>=1.3.4
+colorama>=0.4; platform_system == 'Windows'


### PR DESCRIPTION
Adding the explicit dependency, because

1. 'click' prior to v8.0 did not have this dependency, it was used "only if present"
2. We *are* importing it, let's declare it as such

Fixes #2570
