### PR TITLE
Reduce the range of directories checked by codespell

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands=
 [testenv:codespell]
 deps=codespell
 commands=
-    {envbindir}/codespell . -S '*.min.js' -S 'lunr.*.js' -S lunr.js -S fontawesome-webfont.svg -S .tox -S venv -S tinyseg.js
+    {envbindir}/codespell mkdocs docs *.* -S .tox -S LC_MESSAGES -S '*.min.js' -S 'lunr*.js' -S fontawesome-webfont.svg -S tinyseg.js
 
 [testenv:linkchecker]
 basepython = python2.7


### PR DESCRIPTION
The main goal was to exclude translations, because obviously they're not in English.
But this also starts with an allowlist on top-level directories because locally myself I had a few false positives such as '.git', 'node_modules'.
