### PR TITLE
Add hint about `-f/--config-file` in configuration documentation

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -8,7 +8,7 @@ Guide to all available configuration settings.
 
 Project settings are configured by default using a YAML configuration file in
 the project directory named `mkdocs.yml`. You can specify another path for it
-by using the `-f/--config-file` option (see `mkdocs build --help`).
+by using the `-f`/`--config-file` option (see `mkdocs build --help`).
 
 As a minimum, this configuration file must contain the `site_name` and
 `site_url` settings. All other settings are optional.


### PR DESCRIPTION
Closes #2581

Note that the current statement says "...are **always** configured...", which is not true.