### PR TITLE
Fix the code to abbreviate Python's version

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -146,7 +146,7 @@ common_config_options = add_options([
     click.option('--use-directory-urls/--no-directory-urls', is_flag=True, default=None, help=use_directory_urls_help)
 ])
 
-PYTHON_VERSION = sys.version[:3]
+PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
This breaks for Python >= 3.10

Extracting just this part from #2617