### PR TITLE
Refactor `Nav` config option

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -507,9 +507,8 @@ class Nav(OptionallyRequired):
         if len(value) == 0:
             return
 
-        valid_types = {str, dict}
         config_types = {type(item) for item in value}
-        if config_types.issubset(valid_types):
+        if config_types.issubset({str, dict}):
             return value
 
         types = ', '.join(set(


### PR DESCRIPTION
- Delete `__init__` method not dropped in #1504.
- Improve error message as is outdated because is referencing the old pages config option.