### PR TITLE
fix: abort with an obvious error message

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -85,7 +85,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             server.shutdown()
     except OSError as e:  # pragma: no cover
         # Avoid ugly, unhelpful traceback
-        raise Abort(str(e))
+        raise Abort("Unexpected error: " + str(e))
     finally:
         if isdir(site_dir):
             shutil.rmtree(site_dir)


### PR DESCRIPTION
Generic errors like `TemplateNotFound` (issue #2623) are not clear

It seems there are no tests for "serve.py".

Signed-off-by: Eric Swanson <ericis@users.noreply.github.com>