### PR TITLE
Remove line length limit from Markdown documents

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -2,8 +2,8 @@
   // Enable all markdownlint rules
   "default": true,
 
-  // Disable line length check for tables and code blocks
-  "MD013": { "line_length": 80, "code_blocks": false, "tables": false },
+  // Disable line length check
+  "MD013": false,
 
   // Set Ordered list item prefix to "ordered" (use 1. 2. 3. not 1. 1. 1.)
   "MD029": { "style": "ordered" },

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -29,47 +29,35 @@ The current and past members of the MkDocs team.
     * Brazilian Portuguese (#2535)
     * Spanish (#2545, previously #2396)
 
-* Third-party plugins will take precedence over built-in plugins with the same
-  name (#2591)
+* Third-party plugins will take precedence over built-in plugins with the same name (#2591)
 
-* Bugfix: Fix ability to load translations for some languages:
-  core support (#2565) and search plugin support with fallbacks (#2602)
+* Bugfix: Fix ability to load translations for some languages: core support (#2565) and search plugin support with fallbacks (#2602)
 
-* Bugfix (regression in 1.2): Prevent directory traversal in the dev server
-  (#2604)
+* Bugfix (regression in 1.2): Prevent directory traversal in the dev server (#2604)
 
-* Bugfix (regression in 1.2): Prevent webserver warnings from being treated as
-  a build failure in strict mode (#2607)
+* Bugfix (regression in 1.2): Prevent webserver warnings from being treated as a build failure in strict mode (#2607)
 
 * Bugfix: Correctly print colorful messages in the terminal on Windows (#2606)
 
 * Bugfix: Python version 3.10 was displayed incorrectly in `--version` (#2618)
 
-Other small improvements; see
-[commit log](https://github.com/mkdocs/mkdocs/compare/1.2.2...1.2.3).
+Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.2.2...1.2.3).
 
 ## Version 1.2.2 (2021-07-18)
 
-* Bugfix (regression in 1.2): Fix serving files/paths with Unicode characters
-  (#2464)
+* Bugfix (regression in 1.2): Fix serving files/paths with Unicode characters (#2464)
 
-* Bugfix (regression in 1.2): Revert livereload file watching to use polling
-  observer (#2477)
+* Bugfix (regression in 1.2): Revert livereload file watching to use polling observer (#2477)
 
-    This had to be done to reasonably support usages that span virtual
-    filesystems such as non-native Docker and network mounts.
+    This had to be done to reasonably support usages that span virtual filesystems such as non-native Docker and network mounts.
 
-    This goes back to the polling approach, very similar to that was always used
-    prior, meaning most of the same downsides with latency and CPU usage.
+    This goes back to the polling approach, very similar to that was always used prior, meaning most of the same downsides with latency and CPU usage.
 
-* Revert from 1.2: Remove the requirement of a `site_url` config and the
-  restriction on `use_directory_urls` (#2490)
-  
-* Bugfix (regression in 1.2): Don't require trailing slash in the URL when
-  serving a directory index in `mkdocs serve` server (#2507)
+* Revert from 1.2: Remove the requirement of a `site_url` config and the restriction on `use_directory_urls` (#2490)
 
-    Instead of showing a 404 error, detect if it's a directory and redirect to a
-    path with a trailing slash added, like before.
+* Bugfix (regression in 1.2): Don't require trailing slash in the URL when serving a directory index in `mkdocs serve` server (#2507)
+
+    Instead of showing a 404 error, detect if it's a directory and redirect to a path with a trailing slash added, like before.
 
 * Bugfix: Fix `gh_deploy` with config-file in the current directory (#2481)
 
@@ -79,8 +67,7 @@ Other small improvements; see
 
 * Stop treating ";" as a special character in URLs: urlparse -> urlsplit (#2502)
 
-* Improve build performance for sites with many pages (partly already done in
-  1.2) (#2407)
+* Improve build performance for sites with many pages (partly already done in 1.2) (#2407)
 
 ## Version 1.2.1 (2021-06-09)
 


### PR DESCRIPTION
Also try it out on some part of one document.

Note that I do *not* intend to automatically change all documents like that.

---

Disadvantages of forced line length:

* I really hate manually wrapping and re-wrapping stuff
* It makes `git blame` confusing

Advantages of forced line length:

?????
