### PR TITLE
Fix `nav` configuration error in documentation

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -171,9 +171,10 @@ nav:
     - 'about.md'
 ```
 
-All paths must be relative to the `mkdocs.yml` configuration file. See the
-section on [configuring pages and navigation] for a more detailed breakdown,
-including how to create sub-sections.
+All paths in the navigation configuration must be relative to the
+[`docs_dir`](#docs_dir) configuration option. See the section on [configuring
+pages and navigation] for a more detailed breakdown, including how to create
+sub-sections.
 
 Navigation items may also include links to external sites. While titles are
 optional for internal links, they are required for external links. An external


### PR DESCRIPTION
In ["Configure pages and navigation" section](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation) of the documentation is correctly defined that "All paths in the navigation configuration must be relative to the `docs_dir` configuration option", but [`nav` configuration option documentation](https://www.mkdocs.org/user-guide/configuration/#nav) incorrectly says that "All paths must be relative to the `mkdocs.yml` configuration file". 