### PR TITLE
Support custom directories to watch when running mkdocs serve

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -371,6 +371,12 @@ watch:
 Allows a custom default to be set without the need to pass it through the `-w`/`--watch`
 option every time the `mkdocs serve` command is called.
 
+!!! Note
+
+    The paths provided via the configuration file are relative to the configuration file.
+
+    The paths provided via the `-w`/`--watch` CLI parameters are not. 
+
 ### use_directory_urls
 
 This setting controls the style used for linking to pages within the

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -355,6 +355,22 @@ extra:
 
 ## Preview controls
 
+## Live Reloading
+
+### watch
+
+Determines additional directories to watch when running `mkdocs serve`.
+Configuration is a YAML list.
+
+```yaml
+watch:
+- directory_a
+- directory_b
+```
+
+Allows a custom default to be set without the need to pass it through the `-w`/`--watch`
+option every time the `mkdocs serve` command is called.
+
 ### use_directory_urls
 
 This setting controls the style used for linking to pages within the

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -172,7 +172,7 @@ def cli():
 @click.option('--no-livereload', 'livereload', flag_value='no-livereload', help=no_reload_help)
 @click.option('--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
 @click.option('--watch-theme', help=watch_theme_help, is_flag=True)
-@click.option('-w', '--watch', help=watch_help, type=click.Path(), multiple=True, default=[])
+@click.option('-w', '--watch', help=watch_help, type=click.Path(exists=True), multiple=True, default=[])
 @common_config_options
 @common_options
 def serve_command(dev_addr, livereload, watch, **kwargs):

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -99,7 +99,7 @@ ignore_version_help = "Ignore check that build is not being deployed with an old
 watch_theme_help = ("Include the theme in list of files to watch for live reloading. "
                     "Ignored when live reload is not used.")
 shell_help = "Use the shell when invoking Git."
-watch_help = ("A directory to watch for live reloading. "
+watch_help = ("A directory or file to watch for live reloading. "
               "Can be supplied multiple times.")
 
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -99,6 +99,8 @@ ignore_version_help = "Ignore check that build is not being deployed with an old
 watch_theme_help = ("Include the theme in list of files to watch for live reloading. "
                     "Ignored when live reload is not used.")
 shell_help = "Use the shell when invoking Git."
+watch_help = ("A directory to watch for live reloading. "
+              "Can be supplied multiple times.")
 
 
 def add_options(opts):
@@ -170,11 +172,12 @@ def cli():
 @click.option('--no-livereload', 'livereload', flag_value='no-livereload', help=no_reload_help)
 @click.option('--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
 @click.option('--watch-theme', help=watch_theme_help, is_flag=True)
+@click.option('-w', '--watch', help=watch_help, multiple=True, default=[])
 @common_config_options
 @common_options
-def serve_command(dev_addr, livereload, **kwargs):
+def serve_command(dev_addr, livereload, watch, **kwargs):
     """Run the builtin development server"""
-    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
+    serve.serve(dev_addr=dev_addr, livereload=livereload, watch=watch, **kwargs)
 
 
 @cli.command(name="build")

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -172,7 +172,7 @@ def cli():
 @click.option('--no-livereload', 'livereload', flag_value='no-livereload', help=no_reload_help)
 @click.option('--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
 @click.option('--watch-theme', help=watch_theme_help, is_flag=True)
-@click.option('-w', '--watch', help=watch_help, multiple=True, default=[])
+@click.option('-w', '--watch', help=watch_help, type=click.Path(), multiple=True, default=[])
 @common_config_options
 @common_options
 def serve_command(dev_addr, livereload, watch, **kwargs):

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -43,10 +43,10 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
         )
 
         # combine CLI watch arguments with config file values
-        if not config["watch"] is None:
-            config["watch"].extend(watch)
-        else:
+        if config["watch"] is None:
             config["watch"] = watch
+        else:
+            config["watch"].extend(watch)
 
         # Override a few config settings after validation
         config['site_url'] = 'http://{}{}'.format(config['dev_addr'], mount_path(config))

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -79,7 +79,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
                     server.watch(d)
 
             # convert to set in case CLI params match config file settings
-            watch_list = set(config["watch"])
+            watch_list = dict.fromkeys(config["watch"])
             for item in watch_list:
                 log.info(f"Watching additional directory: {item}")
                 server.watch(item)

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -81,7 +81,7 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             # convert to set in case CLI params match config file settings
             watch_list = dict.fromkeys(config["watch"])
             for item in watch_list:
-                log.info(f"Watching additional directory: {item}")
+                log.info(f"Watching additional path: {item}")
                 server.watch(item)
 
             # Run `serve` plugin events.

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -43,7 +43,10 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
         )
 
         # combine CLI watch arguments with config file values
-        config["watch"].extend(watch)
+        if not config["watch"] is None:
+            config["watch"].extend(watch)
+        else:
+            config["watch"] = watch
 
         # Override a few config settings after validation
         config['site_url'] = 'http://{}{}'.format(config['dev_addr'], mount_path(config))

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -78,14 +78,11 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
                 for d in config['theme'].dirs:
                     server.watch(d)
 
-            # convert to set in case CLI params match config file settings
-            watch_list = dict.fromkeys(config["watch"])
-            for item in watch_list:
-                log.info(f"Watching additional path: {item}")
-                server.watch(item)
-
             # Run `serve` plugin events.
             server = config['plugins'].run_event('serve', server, config=config, builder=builder)
+
+            for item in config['watch']:
+                server.watch(item)
 
         try:
             server.serve()

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 def serve(config_file=None, dev_addr=None, strict=None, theme=None,
-          theme_dir=None, livereload='livereload', watch_theme=False, **kwargs):
+          theme_dir=None, livereload='livereload', watch_theme=False, watch=[], **kwargs):
     """
     Start the MkDocs development server
 
@@ -41,6 +41,10 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             site_dir=site_dir,
             **kwargs
         )
+
+        # combine CLI watch arguments with config file values
+        config["watch"].extend(watch)
+
         # Override a few config settings after validation
         config['site_url'] = 'http://{}{}'.format(config['dev_addr'], mount_path(config))
 
@@ -73,6 +77,12 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             if watch_theme:
                 for d in config['theme'].dirs:
                     server.watch(d)
+
+            # convert to set in case CLI params match config file settings
+            watch_list = set(config["watch"])
+            for item in watch_list:
+                log.info(f"Watching additional directory: {item}")
+                server.watch(item)
 
             # Run `serve` plugin events.
             server = config['plugins'].run_event('serve', server, config=config, builder=builder)

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -433,7 +433,6 @@ class ListOfPaths(OptionallyRequired):
             if not os.path.exists(path):
                 raise ValidationError(f"The path {path} does not exist.")
             path = os.path.abspath(path)
-            assert isinstance(path, str)
             paths.append(path)
         return paths
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -414,6 +414,10 @@ class ListOfPaths(OptionallyRequired):
     A list of file system paths. Raises an error if one of the paths does not exist. 
     """
 
+    def __init__(self, default=[], required=False):
+        self.config_dir = None
+        super().__init__(default, required)
+
     def pre_validation(self, config, key_name):
         self.config_dir = os.path.dirname(config.config_file_path) if config.config_file_path else None
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -411,7 +411,7 @@ class ListOfPaths(OptionallyRequired):
     """
     List of Paths Config Option
 
-    A list of file system paths. Raises an error if one of the paths does not exist. 
+    A list of file system paths. Raises an error if one of the paths does not exist.
     """
 
     def __init__(self, default=[], required=False):

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -356,6 +356,7 @@ class FilesystemObject(Type):
     """
     Base class for options that point to filesystem objects.
     """
+
     def __init__(self, exists=False, **kwargs):
         super().__init__(type_=str, **kwargs)
         self.exists = exists
@@ -404,6 +405,33 @@ class File(FilesystemObject):
     """
     existence_test = staticmethod(os.path.isfile)
     name = 'file'
+
+
+class ListOfPaths(OptionallyRequired):
+    """
+    List of Paths Config Option
+
+    A list of file system paths. Raises an error if one of the paths does not exist. 
+    """
+
+    def pre_validation(self, config, key_name):
+        self.config_dir = os.path.dirname(config.config_file_path) if config.config_file_path else None
+
+    def run_validation(self, value):
+        if not isinstance(value, list):
+            raise ValidationError(f"Expected a list, got {type(value)}")
+        if len(value) == 0:
+            return
+        paths = []
+        for path in value:
+            if self.config_dir and not os.path.isabs(path):
+                path = os.path.join(self.config_dir, path)
+            if not os.path.exists(path):
+                raise ValidationError(f"The path {path} does not exist.")
+            path = os.path.abspath(path)
+            assert isinstance(path, str)
+            paths.append(path)
+        return paths
 
 
 class SiteDir(Dir):

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -120,4 +120,7 @@ def get_schema():
         # A key value pair should be the string name (as the key) and a dict of config
         # options (as the value).
         ('plugins', config_options.Plugins(default=['search'])),
+
+        # a list of extra directories to watch while running `mkdocs serve`
+        ('watch', config_options.Type(list, default=[]))
     )

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -121,6 +121,6 @@ def get_schema():
         # options (as the value).
         ('plugins', config_options.Plugins(default=['search'])),
 
-        # a list of extra directories to watch while running `mkdocs serve`
-        ('watch', config_options.Type(list, default=[]))
+        # a list of extra paths to watch while running `mkdocs serve`
+        ('watch', config_options.ListOfPaths(default=[]))
     )

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -29,7 +29,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -59,7 +60,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -76,7 +78,8 @@ class CLITests(unittest.TestCase):
             strict=True,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -93,7 +96,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme='readthedocs',
             use_directory_urls=None,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -110,7 +114,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=True,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -127,7 +132,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=False,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -144,7 +150,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -161,7 +168,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -178,7 +186,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=False
+            watch_theme=False,
+            watch=()
         )
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
@@ -195,7 +204,8 @@ class CLITests(unittest.TestCase):
             strict=None,
             theme=None,
             use_directory_urls=None,
-            watch_theme=True
+            watch_theme=True,
+            watch=()
         )
 
     @mock.patch('mkdocs.config.load_config', autospec=True)

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -497,12 +497,12 @@ class DirTest(unittest.TestCase):
 class ListOfPathsTest(unittest.TestCase):
 
     def test_valid_path(self):
-        paths = [ os.path.dirname(__file__) ]
+        paths = [os.path.dirname(__file__)]
         option = config_options.ListOfPaths()
         option.validate(paths)
 
     def test_missing_path(self):
-        paths = [ os.path.join("doesnt", "exist", "i", "hope") ]
+        paths = [os.path.join("doesnt", "exist", "i", "hope")]
         option = config_options.ListOfPaths()
         self.assertRaises(config_options.ValidationError, option.validate, paths)
 
@@ -517,7 +517,7 @@ class ListOfPathsTest(unittest.TestCase):
         self.assertRaises(config_options.ValidationError, option.validate, paths)
 
     def test_file(self):
-        paths = [ __file__ ]
+        paths = [__file__]
         option = config_options.ListOfPaths()
         option.validate(paths)
 
@@ -528,15 +528,15 @@ class ListOfPathsTest(unittest.TestCase):
             config_file_path=os.path.join(base_path, 'mkdocs.yml'),
         )
         test_config = {
-            'watch': [ 'foo' ]
+            'watch': ['foo']
         }
         cfg.load_dict(test_config)
         fails, warns = cfg.validate()
         self.assertEqual(len(fails), 0)
         self.assertEqual(len(warns), 0)
         self.assertIsInstance(cfg['watch'], list)
-        self.assertEqual(cfg['watch'], [ os.path.join(base_path, 'foo') ])
-    
+        self.assertEqual(cfg['watch'], [os.path.join(base_path, 'foo')])
+
 
 class SiteDirTest(unittest.TestCase):
 

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -502,9 +502,10 @@ class ListOfPathsTest(unittest.TestCase):
         option.validate(paths)
 
     def test_missing_path(self):
-        paths = [os.path.join("doesnt", "exist", "i", "hope")]
+        paths = [os.path.join("does", "not", "exist", "i", "hope")]
         option = config_options.ListOfPaths()
-        self.assertRaises(config_options.ValidationError, option.validate, paths)
+        with self.assertRaises(config_options.ValidationError):
+            option.validate(paths)
 
     def test_empty_list(self):
         paths = []
@@ -514,7 +515,8 @@ class ListOfPathsTest(unittest.TestCase):
     def test_non_list(self):
         paths = os.path.dirname(__file__)
         option = config_options.ListOfPaths()
-        self.assertRaises(config_options.ValidationError, option.validate, paths)
+        with self.assertRaises(config_options.ValidationError):
+            option.validate(paths)
 
     def test_file(self):
         paths = [__file__]

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -494,6 +494,50 @@ class DirTest(unittest.TestCase):
         self.assertEqual(len(warns), 0)
 
 
+class ListOfPathsTest(unittest.TestCase):
+
+    def test_valid_path(self):
+        paths = [ os.path.dirname(__file__) ]
+        option = config_options.ListOfPaths()
+        option.validate(paths)
+
+    def test_missing_path(self):
+        paths = [ os.path.join("doesnt", "exist", "i", "hope") ]
+        option = config_options.ListOfPaths()
+        self.assertRaises(config_options.ValidationError, option.validate, paths)
+
+    def test_empty_list(self):
+        paths = []
+        option = config_options.ListOfPaths()
+        option.validate(paths)
+
+    def test_non_list(self):
+        paths = os.path.dirname(__file__)
+        option = config_options.ListOfPaths()
+        self.assertRaises(config_options.ValidationError, option.validate, paths)
+
+    def test_file(self):
+        paths = [ __file__ ]
+        option = config_options.ListOfPaths()
+        option.validate(paths)
+
+    def test_paths_localized_to_config(self):
+        base_path = os.path.abspath('.')
+        cfg = Config(
+            [('watch', config_options.ListOfPaths())],
+            config_file_path=os.path.join(base_path, 'mkdocs.yml'),
+        )
+        test_config = {
+            'watch': [ 'foo' ]
+        }
+        cfg.load_dict(test_config)
+        fails, warns = cfg.validate()
+        self.assertEqual(len(fails), 0)
+        self.assertEqual(len(warns), 0)
+        self.assertIsInstance(cfg['watch'], list)
+        self.assertEqual(cfg['watch'], [ os.path.join(base_path, 'foo') ])
+    
+
 class SiteDirTest(unittest.TestCase):
 
     def validate_config(self, config):


### PR DESCRIPTION
Implements #2632

* adds a `watch` property to the `mkdocs.yaml` schema. Accepts a list of directories to watch.
* adds a `-w`/`--watch` command line option to `mkdocs serve` that can be passed multiple times
* options from `mkdocs.yaml` and CLI flags are combined
* docs updated 