### PR TITLE
 Improve memory consumption: del page.markdown

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -177,6 +177,9 @@ def _populate_page(page, config, files, dirty=False):
         page.content = config['plugins'].run_event(
             'page_content', page.content, page=page, config=config, files=files
         )
+        
+        del page.markdown
+        
     except Exception as e:
         message = f"Error reading page '{page.file.src_path}':"
         # Prevent duplicated the error message because it will be printed immediately afterwards.


### PR DESCRIPTION
Hi,

This pull request follow the discussion on the #2669 issue and improve only the "First phase" because in this case theory and graph match:  **more 1 MB earned**

The graph show the full memory consumption of `mkdocs` because I put the `tracemalloc.start()` at the beginning of the "main".

![fc-mkdocs-malloc-profiling-del-page markdown-01](https://user-images.githubusercontent.com/46624375/141968058-067c98bb-0ff5-4f75-a4c9-0ce4eded62f1.png)
```
traefik-official-docs/content$ du -ch *.md ./*/*.md ./*/*/*.md | tail
28K	./routing/providers/kubernetes-gateway.md
24K	./routing/providers/kubernetes-ingress.md
20K	./routing/providers/kv.md
16K	./routing/providers/marathon.md
20K	./routing/providers/rancher.md
4,0K	./routing/providers/service-by-label.md
40K	./routing/routers/index.md
40K	./routing/services/index.md
8,0K	./user-guides/crd-acme/index.md
1,2M	total
```
