### PR TITLE
Add support for caching builds between calls to "mkdocs serve"

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -88,6 +88,7 @@ use_directory_urls_help = "Use directory URLs when building pages (the default).
 reload_help = "Enable the live reloading in the development server (this is the default)"
 no_reload_help = "Disable the live reloading in the development server."
 dirty_reload_help = "Enable the live reloading in the development server, but only re-build files that have changed"
+cached_help = "Use a cached build directory. Only re-build files that have changed."
 commit_message_help = ("A commit message to use when committing to the "
                        "Github Pages remote branch. Commit {sha} and MkDocs {version} are available as expansions")
 remote_branch_help = ("The remote branch to commit to for Github Pages. This "
@@ -171,13 +172,14 @@ def cli():
 @click.option('--livereload', 'livereload', flag_value='livereload', help=reload_help, default=True)
 @click.option('--no-livereload', 'livereload', flag_value='no-livereload', help=no_reload_help)
 @click.option('--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
+@click.option('--cached', help=cached_help, default=False)
 @click.option('--watch-theme', help=watch_theme_help, is_flag=True)
 @click.option('-w', '--watch', help=watch_help, type=click.Path(exists=True), multiple=True, default=[])
 @common_config_options
 @common_options
-def serve_command(dev_addr, livereload, watch, **kwargs):
+def serve_command(dev_addr, livereload, cached, watch, **kwargs):
     """Run the builtin development server"""
-    serve.serve(dev_addr=dev_addr, livereload=livereload, watch=watch, **kwargs)
+    serve.serve(dev_addr=dev_addr, livereload=livereload, cached=cached, watch=watch, **kwargs)
 
 
 @cli.command(name="build")

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -1,6 +1,7 @@
 import logging
 import shutil
 import tempfile
+import os
 from urllib.parse import urlsplit
 from os.path import isdir, isfile, join
 
@@ -13,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def serve(config_file=None, dev_addr=None, strict=None, theme=None,
-          theme_dir=None, livereload='livereload', watch_theme=False, watch=[], **kwargs):
+          theme_dir=None, livereload='livereload', cached=False, watch_theme=False, watch=[], **kwargs):
     """
     Start the MkDocs development server
 
@@ -38,9 +39,13 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
             strict=strict,
             theme=theme,
             theme_dir=theme_dir,
-            site_dir=site_dir,
             **kwargs
         )
+
+        if not cached:
+            config["site_dir"] = site_dir
+        elif not config["site_dir"]:
+            config["site_dir"] = os.path.join(os.path.dirname(config_file), "__mkdocs_cache__")
 
         # combine CLI watch arguments with config file values
         if config["watch"] is None:
@@ -97,5 +102,5 @@ def serve(config_file=None, dev_addr=None, strict=None, theme=None,
         # Avoid ugly, unhelpful traceback
         raise Abort(str(e))
     finally:
-        if isdir(site_dir):
+        if isdir(site_dir) and not cached:
             shutil.rmtree(site_dir)


### PR DESCRIPTION
Hello mkdocs team:

Thank you all for making such a wonderful documentation tool!

I recently joined a large project with extensive multi-language documentation. Compiling this documentation takes roughly 30 minutes each run for a single language. The `--dirtyreload` flag has been helpful in reducing some build redundancy during development, however stopping and starting the development server with the serve command causes the entire documentation to be rebuilt and this is slowing our doc development cycles way down.

mkdocs has hard-coded the use of a temporary directory for the site_dir configuration when the serve command is called. Since the entire temporary directory is new, when build is called by the serve command, then the entire project's docs gets recompiled. For most projects this probably isn't a problem and is even desirable. For our project it has been quite cumbersome and we'd like to optimize this! :D

This PR introduces a `--cached` argument to the serve command. It is turned off by default. But if the developer enables it when calling serve then mkdocs will use a `__mkdocs_cache__` directory in the root of the project instead of the temporary directory that is typically used. The `--cached` flag also disables the deleting of the `__mkdocs_cache__` directory when serve is exited from. This is a feature to allow the build to persist to disk across multiple calls to `mkdocs serve`.

So far I have tested this manually and it seems to work very well without needing to make any other changes besides modifying `__main__` and the `serve.py` file. It's a small change that has a large beneficial impact for some users, and it doesn't change any existing behavior. It's the best kind of PR. :-)

Example of use:

`mkdocs serve --dirtyreload --cached`