### PR TITLE
Reuse Jinja2 `tojson` builtin filter

### DIFF
--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -112,7 +112,6 @@ class Theme:
         loader = jinja2.FileSystemLoader(self.dirs)
         # No autoreload because editing a template in the middle of a build is not useful.
         env = jinja2.Environment(loader=loader, auto_reload=False)
-        env.filters['tojson'] = filters.tojson
         env.filters['url'] = filters.url_filter
         localization.install_translations(env, self._vars['locale'], self.dirs)
         return env

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -34,9 +34,9 @@
     {% if page %}
       <script>
         // Current page data
-        var mkdocs_page_name = {{ page.title|tojson|safe }};
-        var mkdocs_page_input_path = {{ page.file.src_path|string|tojson|safe }};
-        var mkdocs_page_url = {{ page.abs_url|tojson|safe }};
+        var mkdocs_page_name = {{ page.title|tojson }};
+        var mkdocs_page_input_path = {{ page.file.src_path|string|tojson }};
+        var mkdocs_page_url = {{ page.abs_url|tojson }};
       </script>
     {% endif %}
     <script src="{{ 'js/jquery-3.6.0.min.js'|url }}" defer></script>

--- a/mkdocs/utils/filters.py
+++ b/mkdocs/utils/filters.py
@@ -1,13 +1,6 @@
-import json
-
 import jinja2
-import markupsafe
 
 from mkdocs.utils import normalize_url
-
-
-def tojson(obj, **kwargs):
-    return markupsafe.Markup(json.dumps(obj, **kwargs))
 
 
 @jinja2.contextfilter

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -1,7 +1,6 @@
 babel==2.9.0
 click==3.3
 Jinja2==2.10.1
-MarkupSafe==0.23
 Markdown==3.2.1
 PyYAML==5.1
 watchdog==2.0.0

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,7 +1,6 @@
 babel>=2.9.0
 click>=7.0
 Jinja2>=2.10.3
-MarkupSafe>=0.23
 Markdown>=3.2.1
 PyYAML>=5.2
 watchdog>=2.0.0


### PR DESCRIPTION
[`tojson` filter](https://jinja.palletsprojects.com/en/3.0.x/templates/?highlight=tojson#jinja-filters.tojson) was added to Jinja2 in v2.9 and Mkdocs uses `Jinja2>=2.10.1`, so this builtin Jinja2 filter can be used instead of the custom one currently in Mkdocs, added 6 years ago in the commit https://github.com/mkdocs/mkdocs/commit/1c252ba4bb5d3d161c6c62ca790488287a69880f, when the dependency was being pinned to `Jinja2>=2.7.1`.

This filter is HTML and JS safe, so there is no need to use the `safe` filter in Readthedocs theme. Markupsafe is only explicitly used in this filter, so dropped from `project-min.txt` and `project.txt` requirements files.