### PR TITLE
Add "clean_names" option

### DIFF
--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -121,5 +121,8 @@ def get_schema():
         ('plugins', config_options.Plugins(default=['search'])),
 
         # a list of extra paths to watch while running `mkdocs serve`
-        ('watch', config_options.ListOfPaths(default=[]))
+        ('watch', config_options.ListOfPaths(default=[])),
+
+        # Clean the directory names when auto generating page names from them
+        ('clean_names', config_options.Type(bool, default=True))
     )

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -97,7 +97,7 @@ class Link:
 
 def get_navigation(files, config):
     """ Build site navigation from config and files."""
-    nav_config = config['nav'] or nest_paths(f.src_path for f in files.documentation_pages())
+    nav_config = config['nav'] or nest_paths([f.src_path for f in files.documentation_pages()], config)
     items = _data_to_navigation(nav_config, files, config)
     if not isinstance(items, list):
         items = [items]

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -36,6 +36,8 @@ class Page:
         self._set_canonical_url(config.get('site_url', None))
         self._set_edit_url(config.get('repo_url', None), config.get('edit_uri', None))
 
+        self.clean_names = config.get('clean_names', None)
+
         # Placeholders to be filled in later in the build process.
         self.markdown = None
         self.content = None
@@ -152,10 +154,13 @@ class Page:
             if self.is_homepage:
                 title = 'Home'
             else:
-                title = self.file.name.replace('-', ' ').replace('_', ' ')
-                # Capitalize if the filename was all lowercase, otherwise leave it as-is.
-                if title.lower() == title:
-                    title = title.capitalize()
+                if self.clean_names:
+                    title = self.file.name.replace('-', ' ').replace('_', ' ')
+                    # Capitalize if the filename was all lowercase, otherwise leave it as-is.
+                    if title.lower() == title:
+                        title = title.capitalize()
+                else:
+                    title = self.file.name
 
         self.title = title
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -398,7 +398,7 @@ def find_or_create_node(branch, key):
     return new_branch
 
 
-def nest_paths(paths):
+def nest_paths(paths, config):
     """
     Given a list of paths, convert them into a nested structure that will match
     the pages config.
@@ -415,8 +415,11 @@ def nest_paths(paths):
         parts = directory.split(os.path.sep)
 
         branch = nested
+
+        clean_names = config.get('clean_names', None)
         for part in parts:
-            part = dirname_to_title(part)
+            if clean_names:
+                part = dirname_to_title(part)
             branch = find_or_create_node(branch, part)
 
         branch.append(path)


### PR DESCRIPTION
Add "clean_names" option to prevent auto generated nav from formatting directory/page names if not desired:

![image](https://user-images.githubusercontent.com/37331850/146766549-041713bb-3e5a-4d8c-a411-640e40d62308.png)

I have a use case in which I need the auto built nav to remain named exactly as the folders show. 
Suggested option of "clean_names" added to config...

Not sure where to add this in documentation but will happily add if guided (it could be too niche?)