### PR TITLE
Fix imports to get tests passing

### DIFF
--- a/mkdocs/config/__init__.py
+++ b/mkdocs/config/__init__.py
@@ -1,4 +1,7 @@
 from mkdocs.config.base import load_config, Config
+from mkdocs.config import config_options, defaults
 
 __all__ = [load_config.__name__,
-           Config.__name__]
+           Config.__name__,
+           config_options.__name__,
+           defaults.__name__]

--- a/mkdocs/config/__init__.py
+++ b/mkdocs/config/__init__.py
@@ -1,7 +1,4 @@
 from mkdocs.config.base import load_config, Config
-from mkdocs.config import config_options, defaults
 
 __all__ = [load_config.__name__,
-           Config.__name__,
-           config_options.__name__,
-           defaults.__name__]
+           Config.__name__]

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 
 from mkdocs import config
 from mkdocs import utils
+from mkdocs.config import defaults as config_defaults
 
 
 def dedent(text):
@@ -32,7 +33,7 @@ def load_config(**cfg):
     if 'docs_dir' not in cfg:
         # Point to an actual dir to avoid a 'does not exist' error on validation.
         cfg['docs_dir'] = os.path.join(path_base, 'docs')
-    conf = config.Config(schema=config.defaults.get_schema(), config_file_path=cfg['config_file_path'])
+    conf = config.Config(schema=config_defaults.get_schema(), config_file_path=cfg['config_file_path'])
     conf.load_dict(cfg)
 
     errors_warnings = conf.validate()

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -8,15 +8,16 @@ import os
 from mkdocs import plugins
 from mkdocs import config
 from mkdocs.commands import build
+from mkdocs.config import config_options
 from mkdocs.exceptions import BuildError, PluginError, Abort
 from mkdocs.tests.base import load_config
 
 
 class DummyPlugin(plugins.BasePlugin):
     config_scheme = (
-        ('foo', config.config_options.Type(str, default='default foo')),
-        ('bar', config.config_options.Type(int, default=0)),
-        ('dir', config.config_options.Dir(exists=False)),
+        ('foo', config_options.Type(str, default='default foo')),
+        ('bar', config_options.Type(int, default=0)),
+        ('dir', config_options.Dir(exists=False)),
     )
 
     def on_pre_page(self, content, **kwargs):

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import mkdocs
 from mkdocs.theme import Theme
-from localization import parse_locale
+from mkdocs.localization import parse_locale
 
 abs_path = os.path.abspath(os.path.dirname(__file__))
 mkdocs_dir = os.path.abspath(os.path.dirname(mkdocs.__file__))

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
     py{36,37,38,39,310,py3}-{unittests,min-req}: -rrequirements/test.txt
 commands=
     {envpython} --version
-    py{36,37,38,39,310,py3}-{unittests,min-req}:  {envbindir}/coverage run --source=mkdocs --omit 'mkdocs/tests/*' -m unittest discover -p '*tests.py' mkdocs
+    py{36,37,38,39,310,py3}-{unittests,min-req}:  {envbindir}/coverage run --source=mkdocs --omit 'mkdocs/tests/*' -m unittest discover -p '*tests.py' mkdocs --top-level-directory .
     py{36,37,38,39,310,py3}-unittests: {envbindir}/coverage xml
     py{36,37,38,39,310,py3}-unittests: {envbindir}/coverage report --show-missing
     py{36,37,38,39,310,py3}-integration: {envpython} -m mkdocs.tests.integration --output={envtmpdir}/builds


### PR DESCRIPTION
While bumping the version of this package from 1.2.1 to 1.2.3 for nixpkgs
I noticed the tests started failing.

I dug around a bit found that an import was incorrect (`import localization` in `theme_tests.py`)
and `config_options` and `defaults` were missing from `mkdocs/config/__init__.py`.
