### PR TITLE
Fix PyPy version in MacOS CI workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,8 +8,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3.7]
+        os: [ubuntu-latest, windows-latest, macos-10.15]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3]
         include:
           - python-version: 3.6
             tox-env: py36
@@ -21,7 +21,7 @@ jobs:
             tox-env: py39
           - python-version: '3.10'
             tox-env: py310
-          - python-version: pypy3.7
+          - python-version: pypy3
             tox-env: pypy3
     env:
       TOXENV: ${{ matrix.tox-env }}-{unittests,min-req,integration,integration-no-babel}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,8 +8,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-10.15]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy-3.7-v7.x]
         include:
           - python-version: 3.6
             tox-env: py36
@@ -21,7 +21,7 @@ jobs:
             tox-env: py39
           - python-version: '3.10'
             tox-env: py310
-          - python-version: pypy3
+          - python-version: pypy-3.7-v7.x
             tox-env: pypy3
     env:
       TOXENV: ${{ matrix.tox-env }}-{unittests,min-req,integration,integration-no-babel}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3.7]
         include:
           - python-version: 3.6
             tox-env: py36
@@ -21,7 +21,7 @@ jobs:
             tox-env: py39
           - python-version: '3.10'
             tox-env: py310
-          - python-version: pypy3
+          - python-version: pypy3.7
             tox-env: pypy3
     env:
       TOXENV: ${{ matrix.tox-env }}-{unittests,min-req,integration,integration-no-babel}


### PR DESCRIPTION
Github Actions now uses MacOS 11 as `macos-latest` and this version [does not includes PyPy 3.6](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#pypy). There are two options to fix this problem:

- a) Use `macos-10.15` instead of `macos-latest` in the CI. This allows to continue the testing against PyPy 3.6 (see [tests passing](https://github.com/mondeja/mkdocs/runs/4942876969?check_suite_focus=true)).
- b) Use PyPy 3.7, included in latest MacOS (see [tests passing](https://github.com/mondeja/mkdocs/actions/runs/1747596121)).

I've opted for option *b* because Python3.6 EOL has been reached some months ago and because the CI is currently using latest OS builds for Windows and Linux.