### PR TITLE
Pin MarkupSafe to <= 2.0.1 in minimum requirements to test against Jinja2 v2 in CI

### DIFF
--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -1,6 +1,7 @@
 babel==2.9.0
 click==3.3
 Jinja2==2.10.2
+markupsafe<=2.0.1
 Markdown==3.2.1
 PyYAML==5.1
 watchdog==2.0.0


### PR DESCRIPTION
See https://github.com/pallets/jinja/issues/1585