### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setup(
     name="mkdocs",
     version=get_version("mkdocs"),
     url='https://www.mkdocs.org',
+    project_urls={
+        'Source': 'https://github.com/mkdocs/mkdocs',
+    },
     license='BSD',
     description='Project documentation with Markdown.',
     long_description=long_description,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)