### PR TITLE
Add Persian (fa) translation to the default themes.

### DIFF
--- a/docs/user-guide/choosing-your-theme.md
+++ b/docs/user-guide/choosing-your-theme.md
@@ -106,6 +106,7 @@ supports the following options:
     * `pt_BR`: Portuguese (Brazil)
     * `zh_CN`: Simplified Chinese
     * `de`: German
+    * `fa`: Persian (Farsi)
 
     See the guide on [localizing your theme] for more information.
 
@@ -184,6 +185,7 @@ theme supports the following options:
     * `pt_BR`: Portuguese (Brazil)
     * `zh_CN`: Simplified Chinese
     * `de`: German
+    * `fa`: Persian (Farsi)
 
     See the guide on [localizing your theme] for more information.
 

--- a/mkdocs/themes/mkdocs/locales/fa/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/fa/LC_MESSAGES/messages.po
@@ -1,0 +1,97 @@
+# Persian translations for MkDocs.
+# Copyright (C) 2021 MkDocs
+# This file is distributed under the same license as the MkDocs project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MkDocs 1.2\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"POT-Creation-Date: 2021-04-08 22:44+0200\n"
+"PO-Revision-Date: 2022-03-03 15:49+0330\n"
+"Last-Translator: Peyman Mohammadi <@peymanr34>\n"
+"Language: fa\n"
+"Language-Team: fa <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: mkdocs/themes/mkdocs/404.html:8
+msgid "Page not found"
+msgstr "صفحه یافت نشد"
+
+#: mkdocs/themes/mkdocs/base.html:107
+#: mkdocs/themes/mkdocs/keyboard-modal.html:31
+#: mkdocs/themes/mkdocs/search-modal.html:5
+msgid "Search"
+msgstr "جستجو"
+
+#: mkdocs/themes/mkdocs/base.html:117
+msgid "Previous"
+msgstr "قبلی"
+
+#: mkdocs/themes/mkdocs/base.html:122
+msgid "Next"
+msgstr "بعدی"
+
+#: mkdocs/themes/mkdocs/base.html:133 mkdocs/themes/mkdocs/base.html:135
+#: mkdocs/themes/mkdocs/base.html:137 mkdocs/themes/mkdocs/base.html:139
+#, python-format
+msgid "Edit on %(repo_name)s"
+msgstr "ویرایش در %(repo_name)s"
+
+#: mkdocs/themes/mkdocs/base.html:179
+#, python-format
+msgid "Documentation built with %(mkdocs_link)s."
+msgstr "مستندات ساخته شده توسط %(mkdocs_link)s."
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:5
+msgid "Keyboard Shortcuts"
+msgstr "میانبر های صفحه کلید"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:6
+#: mkdocs/themes/mkdocs/search-modal.html:6
+msgid "Close"
+msgstr "بستن"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:12
+msgid "Keys"
+msgstr "کلیدها"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:13
+msgid "Action"
+msgstr "عمل"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:19
+msgid "Open this help"
+msgstr "بازکردن این راهنما"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:23
+msgid "Next page"
+msgstr "صفحه بعدی"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:27
+msgid "Previous page"
+msgstr "صفحه قبلی"
+
+#: mkdocs/themes/mkdocs/search-modal.html:9
+msgid "From here you can search these documents. Enter your search terms below."
+msgstr "از این بخش می‌توانید اسناد را جستجو کنید. عبارت جستجوی خود را در بخش زیر وارد کنید."
+
+#: mkdocs/themes/mkdocs/search-modal.html:12
+msgid "Search..."
+msgstr "جستجو..."
+
+#: mkdocs/themes/mkdocs/search-modal.html:12
+msgid "Type search term here"
+msgstr "عبارت جستجو را اینجا وارد کنید"
+
+#: mkdocs/themes/mkdocs/search-modal.html:15
+msgid "No results found"
+msgstr "موردی یافت نشد"
+
+#: mkdocs/themes/mkdocs/toc.html:3
+msgid "Table of Contents"
+msgstr "فهرست مطالب"
+

--- a/mkdocs/themes/readthedocs/locales/fa/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/fa/LC_MESSAGES/messages.po
@@ -1,0 +1,102 @@
+# Persian translations for MkDocs.
+# Copyright (C) 2021 MkDocs
+# This file is distributed under the same license as the MkDocs project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MkDocs 1.2.2\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"POT-Creation-Date: 2021-09-27 10:43-0400\n"
+"PO-Revision-Date: 2022-03-03 15:56+0330\n"
+"Last-Translator: Peyman Mohammadi <@peymanr34>\n"
+"Language: fa\n"
+"Language-Team: fa <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: mkdocs/themes/readthedocs/404.html:7
+msgid "Page not found"
+msgstr "صفحه یافت نشد"
+
+#: mkdocs/themes/readthedocs/base.html:97
+msgid "Logo"
+msgstr "لوگو"
+
+#: mkdocs/themes/readthedocs/base.html:111
+msgid "Navigation menu"
+msgstr "منوی ناوبری"
+
+#: mkdocs/themes/readthedocs/base.html:140
+msgid "Mobile navigation menu"
+msgstr "منوی ناوبری موبایل"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:3
+msgid "Docs"
+msgstr "مستندات"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:24
+#, python-format
+msgid "Edit on %(repo_name)s"
+msgstr "ویرایش در %(repo_name)s"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:31
+msgid "Breadcrumb Navigation"
+msgstr "فهرست مسیر"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:33
+#: mkdocs/themes/readthedocs/footer.html:7
+#: mkdocs/themes/readthedocs/versions.html:17
+msgid "Previous"
+msgstr "قبلی"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:36
+#: mkdocs/themes/readthedocs/footer.html:10
+#: mkdocs/themes/readthedocs/versions.html:20
+msgid "Next"
+msgstr "بعدی"
+
+#: mkdocs/themes/readthedocs/footer.html:5
+msgid "Footer Navigation"
+msgstr "ناوبری پاورقی"
+
+#: mkdocs/themes/readthedocs/footer.html:25
+#, python-format
+msgid ""
+"Built with %(mkdocs_link)s using a %(sphinx_link)s provided by "
+"%(rtd_link)s."
+msgstr ""
+"ساخته شده توسط %(mkdocs_link)s با استفاده از %(sphinx_link)s "
+"ارائه شده توسط %(rtd_link)s."
+
+#: mkdocs/themes/readthedocs/search.html:5
+msgid "Search Results"
+msgstr "نتایج جستجو"
+
+#: mkdocs/themes/readthedocs/search.html:9
+msgid "Search the Docs"
+msgstr "جستجوی مستندات"
+
+#: mkdocs/themes/readthedocs/search.html:9
+#: mkdocs/themes/readthedocs/searchbox.html:3
+msgid "Type search term here"
+msgstr "عبارت جستجو را اینجا وارد کنید"
+
+#: mkdocs/themes/readthedocs/search.html:12
+msgid "No results found"
+msgstr "موردی یافت نشد"
+
+#: mkdocs/themes/readthedocs/search.html:13
+msgid "Searching..."
+msgstr "درحال جستجو..."
+
+#: mkdocs/themes/readthedocs/searchbox.html:3
+msgid "Search docs"
+msgstr "جستجوی مستندات"
+
+#: mkdocs/themes/readthedocs/versions.html:1
+msgid "Versions"
+msgstr "نسخه‌ها"
+


### PR DESCRIPTION
**Changes:**
- The Persian translation has been added to `mkdocs` and `readthedocs` themes.
- The `Choosing your theme` documentation has been updated to reflect the changes.