### PR TITLE
Prevent error with future Jinja2 v3.1

### DIFF
--- a/mkdocs/utils/filters.py
+++ b/mkdocs/utils/filters.py
@@ -3,7 +3,13 @@ import jinja2
 from mkdocs.utils import normalize_url
 
 
-@jinja2.contextfilter
+jinja2_version_info = tuple(
+    int(n) for n in jinja2.__version__.split('.') if n.isdigit()
+)
+
+pass_context_decorator = jinja2.contextfilter if jinja2_version_info < (3,) else jinja2.pass_context
+
+@pass_context_decorator
 def url_filter(context, value):
     """ A Template filter to normalize URLs. """
     return normalize_url(value, page=context['page'], base=context['base_url'])


### PR DESCRIPTION
Fixes #2794

See [Jinja2 v3.0.0 changes](https://jinja.palletsprojects.com/en/3.0.x/changes/#version-3-0-0):

> The function and filter decorators have been renamed and unified. The old names are deprecated...
> 
> - `pass_context` replaces `contextfunction` and `contextfilter`.