### PR TITLE
Revert to disregarding the mount path for /livereload/ endpoint

### DIFF
--- a/mkdocs/tests/livereload_tests.py
+++ b/mkdocs/tests/livereload_tests.py
@@ -343,9 +343,9 @@ class BuildTests(unittest.TestCase):
             self.assertTrue(output.isdigit())
 
     @tempdir()
-    def test_serves_polling_from_mount_path(self, site_dir):
+    def test_serves_polling_with_mount_path(self, site_dir):
         with testing_server(site_dir, mount_path="/test/f*o") as server:
-            _, output = do_request(server, "GET /test/f*o/livereload/0/0")
+            _, output = do_request(server, "GET /livereload/0/0")
             self.assertTrue(output.isdigit())
 
     @tempdir()


### PR DESCRIPTION
Previously there was a pull request "Move livereload endpoint under the mount path (#2740)"
and it definitely makes sense as a way to make livereload work behind a proxy.

However, this change also caused a major annoyance when working on several different sites.
Steps to reproduce:

1. `serve` one site (needs to have `site_url` customized)
2. open the site in a browser
3. stop serving it but keep the browser
4. `serve` another site with a different mount point
5. observe spam of "404" errors in the new terminal (also in the old browser but that's whatever)

So, this reverts the observable effect of commit fafdcc240e0520e34ac30b4dcf78adc4514101ec by @robertaistleitner
