### PR TITLE
Added an extra space to the readthedocs theme breadcrumbs.

### DIFF
--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -10,7 +10,7 @@
         {%- endif %}
       {%- endfor %}
     {%- endif %}
-    {%- if page %}<li>{{ page.title }}</li>{%- endif %}
+    {%- if page %}<li>&nbsp;{{ page.title }}</li>{%- endif %}
     <li class="wy-breadcrumbs-aside">
       {%- block repo %}
       {%- if page and page.edit_url %}


### PR DESCRIPTION
In the `readthedocs` theme, the breadcrumbs of the last item needs an extra space.

**Before:**
![image](https://user-images.githubusercontent.com/16763358/160826584-ff2aa43f-7810-4dbe-b668-163d9cc72086.png)

**After:**
![image](https://user-images.githubusercontent.com/16763358/160826658-107a72dd-680e-4611-a875-2c231c4d05f4.png)

I hope you don't mind I didn't open an issue first.