### PR TITLE
Add a link to best-of-mkdocs in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Make sure to stick around to answer some questions as well!
 - [Official Documentation][mkdocs]
 - [Latest Release Notes][release-notes]
 - [MkDocs Wiki][wiki] (Third-party themes, recipes, plugins and more)
+- [Best-of-MkDocs][best-of] (Curated list of themes, plugins and more)
 
 ## Contributing to MkDocs
 
@@ -73,6 +74,7 @@ discussion forums is expected to follow the [PyPA Code of Conduct].
 [wiki]: https://github.com/mkdocs/mkdocs/wiki
 [Contributing Guide]: https://www.mkdocs.org/about/contributing/
 [PyPA Code of Conduct]: https://www.pypa.io/en/latest/code-of-conduct/
+[best-of]: https://github.com/pawamoy/best-of-mkdocs
 
 ## License
 


### PR DESCRIPTION
Following the advice of @squidfunk, I'm opening this PR to get feedback from MkDocs maintainers and open a discussion :slightly_smiling_face: 

This PR adds a link to the [best-of-mkdocs](https://github.com/pawamoy/best-of-mkdocs) list I've just created to the README.

Providing such curated data / galleries of examples in MkDocs own docs has been discussed previously in #2700.
I wouldn't mind transferring the best-of list to the MkDocs org and keep maintaining it, if that's something you'd like (it's pretty low maintenance as the only file to update is the YAML data, the rest is automatically rendered through a GitHub action).

One of the benefits of the best-of list is that it logs useful information during the rendering process. For example, I was able to fix several plugins URLs as they had been renamed or transferred to other GitHub accounts.

Another small benefit is that with a restricted access (PRs, contrary to the wiki), we won't have to remove spam contents added from time to time by users, or revert accidental/malicious deletions. And it's still very easy for the community to contribute.