### PR TITLE
Check for uppercase readme only

### DIFF
--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -243,8 +243,8 @@ def get_files(config):
             if _filter_paths(basename=filename, path=path, is_dir=False, exclude=exclude):
                 continue
             # Skip README.md if an index file also exists in dir
-            if filename.lower() == 'readme.md' and 'index.md' in filenames:
-                log.warning(f"Both index.md and readme.md found. Skipping readme.md from {source_dir}")
+            if filename == 'README.md' and 'index.md' in filenames:
+                log.warning(f"Both index.md and README.md found. Skipping README.md from {source_dir}")
                 continue
             files.append(File(path, config['docs_dir'], config['site_dir'], config['use_directory_urls']))
 

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -592,6 +592,7 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
 
     @tempdir(files=[
         'index.md',
+        'readme.md',
         'bar.css',
         'bar.html',
         'bar.jpg',
@@ -603,7 +604,7 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
     def test_get_files(self, tdir):
         config = load_config(docs_dir=tdir, extra_css=['bar.css'], extra_javascript=['bar.js'])
         files = get_files(config)
-        expected = ['index.md', 'bar.css', 'bar.html', 'bar.jpg', 'bar.js', 'bar.md']
+        expected = ['index.md', 'bar.css', 'bar.html', 'bar.jpg', 'bar.js', 'bar.md', 'readme.md']
         self.assertIsInstance(files, Files)
         self.assertEqual(len(files), len(expected))
         self.assertEqual([f.src_path for f in files], expected)


### PR DESCRIPTION
closes #2846

## Caveat

If both `README.md` and `readme.md` are present, `readme.md` is skipped.