### PR TITLE
Configuration doc: `site_url` is optional

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -10,8 +10,7 @@ Project settings are configured by default using a YAML configuration file in
 the project directory named `mkdocs.yml`. You can specify another path for it
 by using the `-f`/`--config-file` option (see `mkdocs build --help`).
 
-As a minimum, this configuration file must contain the `site_name` and
-`site_url` settings. All other settings are optional.
+As a minimum, this configuration file must contain the `site_name`. All other settings are optional.
 
 ## Project information
 


### PR DESCRIPTION
Only `site_name` is required.