### PR TITLE
requirements: fix Markdown version to >=3.2.1 and <3.4

### DIFF
--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,7 +1,7 @@
 babel>=2.9.0
 click>=7.0
 Jinja2>=2.10.2
-Markdown>=3.2.1
+Markdown>=3.2.1,<3.4
 PyYAML>=5.2
 watchdog>=2.0.0
 mdx_gh_links>=0.2

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     install_requires=[
         'click>=3.3',
         'Jinja2>=2.10.2',
-        'Markdown>=3.2.1',
+        'Markdown>=3.2.1,<3.4',
         'PyYAML>=3.10',
         'watchdog>=2.0',
         'ghp-import>=1.0',


### PR DESCRIPTION
closes #2892

This hot fix should be considered temporary so not to break too many plugins and projects.

Mkdocs maybe should alert users and adopt Markdown>=3.4 itself before raising the requirement limit.