### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -389,9 +389,9 @@ specific page. The following keys are supported:
 #### YAML Style Meta-Data
 
 YAML style meta-data consists of [YAML] key/value pairs wrapped in YAML style
-deliminators to mark the start and/or end of the meta-data. The first line of
+delimiters to mark the start and/or end of the meta-data. The first line of
 a document must be `---`. The meta-data ends at the first line containing an
-end deliminator (either `---` or `...`). The content between the deliminators is
+end deliminator (either `---` or `...`). The content between the delimiters is
 parsed as [YAML].
 
 ```no-highlight
@@ -448,11 +448,11 @@ line of a document must not be blank.
 
 !!! note
 
-    MkDocs does not support YAML style deliminators (`---` or `...`) for
+    MkDocs does not support YAML style delimiters (`---` or `...`) for
     MultiMarkdown style meta-data. In fact, MkDocs relies on the the presence or
-    absence of the deliminators to determine whether YAML style meta-data or
-    MultiMarkdown style meta-data is being used. If the deliminators are
-    detected, but the content between the deliminators is not valid YAML
+    absence of the delimiters to determine whether YAML style meta-data or
+    MultiMarkdown style meta-data is being used. If the delimiters are
+    detected, but the content between the delimiters is not valid YAML
     meta-data, MkDocs does not attempt to parse the content as MultiMarkdown
     style meta-data.
 

--- a/mkdocs/contrib/search/templates/search/lunr.js
+++ b/mkdocs/contrib/search/templates/search/lunr.js
@@ -3456,7 +3456,7 @@ lunr.QueryParser.parseBoost = function (parser) {
     } else if (typeof exports === 'object') {
       /**
        * Node. Does not work with strict CommonJS, but
-       * only CommonJS-like enviroments that support module.exports,
+       * only CommonJS-like environments that support module.exports,
        * like Node.
        */
       module.exports = factory()

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -71,7 +71,7 @@ def get_data(doc):
             pass
         return doc, data
 
-    # No YAML deliminators. Try MultiMarkdown style
+    # No YAML delimiters. Try MultiMarkdown style
     lines = doc.replace('\r\n', '\n').replace('\r', '\n').split('\n')
 
     key = None


### PR DESCRIPTION
There are small typos in:
- docs/user-guide/writing-your-docs.md
- mkdocs/contrib/search/templates/search/lunr.js
- mkdocs/utils/meta.py

Fixes:
- Should read `delimiters` rather than `deliminators`.
- Should read `environments` rather than `enviroments`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md