### PR TITLE
Simplify utils, deprecate unused functions

### DIFF
--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -193,16 +193,11 @@ class File:
 
     def is_documentation_page(self):
         """ Return True if file is a Markdown page. """
-        return os.path.splitext(self.src_path)[1] in utils.markdown_extensions
+        return utils.is_markdown_file(self.src_path)
 
     def is_static_page(self):
         """ Return True if file is a static page (html, xml, json). """
-        return os.path.splitext(self.src_path)[1] in (
-            '.html',
-            '.htm',
-            '.xml',
-            '.json',
-        )
+        return self.src_path.endswith(('.html', '.htm', '.xml', '.json'))
 
     def is_media_file(self):
         """ Return True if file is not a documentation or static page. """
@@ -210,16 +205,11 @@ class File:
 
     def is_javascript(self):
         """ Return True if file is a JavaScript file. """
-        return os.path.splitext(self.src_path)[1] in (
-            '.js',
-            '.javascript',
-        )
+        return self.src_path.endswith(('.js', '.javascript'))
 
     def is_css(self):
         """ Return True if file is a CSS file. """
-        return os.path.splitext(self.src_path)[1] in (
-            '.css',
-        )
+        return self.src_path.endswith('.css')
 
 
 def get_files(config):

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -39,49 +39,17 @@ deep1:
 
 
 class UtilsTests(unittest.TestCase):
-    def test_html_path(self):
-        expected_results = {
-            'index.md': 'index.html',
-            'api-guide.md': 'api-guide/index.html',
-            'api-guide/index.md': 'api-guide/index.html',
-            'api-guide/testing.md': 'api-guide/testing/index.html',
-        }
-        for file_path, expected_html_path in expected_results.items():
-            html_path = utils.get_html_path(file_path)
-            self.assertEqual(html_path, expected_html_path)
-
-    def test_url_path(self):
-        expected_results = {
-            'index.md': '/',
-            'api-guide.md': '/api-guide/',
-            'api-guide/index.md': '/api-guide/',
-            'api-guide/testing.md': '/api-guide/testing/',
-        }
-        for file_path, expected_html_path in expected_results.items():
-            html_path = utils.get_url_path(file_path)
-            self.assertEqual(html_path, expected_html_path)
-
     def test_is_markdown_file(self):
         expected_results = {
             'index.md': True,
-            'index.MARKDOWN': True,
+            'index.markdown': True,
+            'index.MARKDOWN': False,
             'index.txt': False,
             'indexmd': False
         }
         for path, expected_result in expected_results.items():
             is_markdown = utils.is_markdown_file(path)
             self.assertEqual(is_markdown, expected_result)
-
-    def test_is_html_file(self):
-        expected_results = {
-            'index.htm': True,
-            'index.HTML': True,
-            'index.txt': False,
-            'indexhtml': False
-        }
-        for path, expected_result in expected_results.items():
-            is_html = utils.is_html_file(path)
-            self.assertEqual(is_html, expected_result)
 
     def test_get_relative_url(self):
         expected_results = {

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import re
 import yaml
-import fnmatch
 import posixpath
 import functools
 import importlib_metadata
@@ -25,13 +24,13 @@ from mkdocs import exceptions
 
 log = logging.getLogger(__name__)
 
-markdown_extensions = [
+markdown_extensions = (
     '.markdown',
     '.mdown',
     '.mkdn',
     '.mkd',
     '.md'
-]
+)
 
 
 def get_yaml_loader(loader=yaml.Loader):
@@ -65,17 +64,6 @@ def yaml_load(source, loader=None):
             parent = yaml_load(fd, Loader)
         result = merge(parent, result)
     return result
-
-
-def modified_time(file_path):
-    """
-    Return the modified time of the supplied file. If the file does not exists zero is returned.
-    see build_pages for use.
-    """
-    if os.path.exists(file_path):
-        return os.path.getmtime(file_path)
-    else:
-        return 0.0
 
 
 def get_build_timestamp():
@@ -118,9 +106,7 @@ def get_build_date():
 
 def reduce_list(data_set):
     """ Reduce duplicate items in a list and preserve order """
-    seen = set()
-    return [item for item in data_set if
-            item not in seen and not seen.add(item)]
+    return list(dict.fromkeys(data_set))
 
 
 def copy_file(source_path, output_path):
@@ -167,68 +153,13 @@ def clean_directory(directory):
             os.unlink(path)
 
 
-def get_html_path(path):
-    """
-    Map a source file path to an output html path.
-
-    Paths like 'index.md' will be converted to 'index.html'
-    Paths like 'about.md' will be converted to 'about/index.html'
-    Paths like 'api-guide/core.md' will be converted to 'api-guide/core/index.html'
-    """
-    path = os.path.splitext(path)[0]
-    if os.path.basename(path) == 'index':
-        return path + '.html'
-    return "/".join((path, 'index.html'))
-
-
-def get_url_path(path, use_directory_urls=True):
-    """
-    Map a source file path to an output html path.
-
-    Paths like 'index.md' will be converted to '/'
-    Paths like 'about.md' will be converted to '/about/'
-    Paths like 'api-guide/core.md' will be converted to '/api-guide/core/'
-
-    If `use_directory_urls` is `False`, returned URLs will include the a trailing
-    `index.html` rather than just returning the directory path.
-    """
-    path = get_html_path(path)
-    url = '/' + path.replace(os.path.sep, '/')
-    if use_directory_urls:
-        return url[:-len('index.html')]
-    return url
-
-
 def is_markdown_file(path):
     """
     Return True if the given file path is a Markdown file.
 
     https://superuser.com/questions/249436/file-extension-for-markdown-files
     """
-    return any(fnmatch.fnmatch(path.lower(), f'*{x}') for x in markdown_extensions)
-
-
-def is_html_file(path):
-    """
-    Return True if the given file path is an HTML file.
-    """
-    ext = os.path.splitext(path)[1].lower()
-    return ext in [
-        '.html',
-        '.htm',
-    ]
-
-
-def is_template_file(path):
-    """
-    Return True if the given file path is an HTML file.
-    """
-    ext = os.path.splitext(path)[1].lower()
-    return ext in [
-        '.html',
-        '.htm',
-        '.xml',
-    ]
+    return path.endswith(markdown_extensions)
 
 
 _ERROR_TEMPLATE_RE = re.compile(r'^\d{3}\.html?$')

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -13,6 +13,7 @@ import re
 import yaml
 import posixpath
 import functools
+import warnings
 import importlib_metadata
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -64,6 +65,16 @@ def yaml_load(source, loader=None):
             parent = yaml_load(fd, Loader)
         result = merge(parent, result)
     return result
+
+
+def modified_time(file_path):
+    warnings.warn(
+        "modified_time is never used in MkDocs and will be removed soon.", DeprecationWarning
+    )
+    if os.path.exists(file_path):
+        return os.path.getmtime(file_path)
+    else:
+        return 0.0
 
 
 def get_build_timestamp():
@@ -153,6 +164,27 @@ def clean_directory(directory):
             os.unlink(path)
 
 
+def get_html_path(path):
+    warnings.warn(
+        "get_html_path is never used in MkDocs and will be removed soon.", DeprecationWarning
+    )
+    path = os.path.splitext(path)[0]
+    if os.path.basename(path) == 'index':
+        return path + '.html'
+    return "/".join((path, 'index.html'))
+
+
+def get_url_path(path, use_directory_urls=True):
+    warnings.warn(
+        "get_url_path is never used in MkDocs and will be removed soon.", DeprecationWarning
+    )
+    path = get_html_path(path)
+    url = '/' + path.replace(os.path.sep, '/')
+    if use_directory_urls:
+        return url[:-len('index.html')]
+    return url
+
+
 def is_markdown_file(path):
     """
     Return True if the given file path is a Markdown file.
@@ -160,6 +192,20 @@ def is_markdown_file(path):
     https://superuser.com/questions/249436/file-extension-for-markdown-files
     """
     return path.endswith(markdown_extensions)
+
+
+def is_html_file(path):
+    warnings.warn(
+        "is_html_file is never used in MkDocs and will be removed soon.", DeprecationWarning
+    )
+    return path.lower().endswith(('.html', '.htm'))
+
+
+def is_template_file(path):
+    warnings.warn(
+        "is_template_file is never used in MkDocs and will be removed soon.", DeprecationWarning
+    )
+    return path.lower().endswith(('.html', '.htm', '.xml'))
 
 
 _ERROR_TEMPLATE_RE = re.compile(r'^\d{3}\.html?$')


### PR DESCRIPTION
[(I also searched across GitHub that nobody uses these)](https://cs.github.com/?q=%2F\bis_html_file\b%2F+mkdocs+path%3A%2Fpy%24%2F+NOT+path%3A%2Fmkdocs\%2F(utils|build|nav|test|relative_path_ext|config)%2F)

For `is_markdown_file` instead do a breaking change so it matches the actual behavior of MkDocs build: don't accept uppercase extensions anymore.
