### PR TITLE
Refactor tests to use `subTest`

### DIFF
--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -564,8 +564,9 @@ class SiteDirTest(unittest.TestCase):
         )
 
         for test_config in test_configs:
-            with self.assertRaises(config_options.ValidationError):
-                self.validate_config(test_config)
+            with self.subTest(test_config):
+                with self.assertRaises(config_options.ValidationError):
+                    self.validate_config(test_config)
 
     def test_site_dir_in_docs_dir(self):
 
@@ -579,8 +580,9 @@ class SiteDirTest(unittest.TestCase):
         )
 
         for test_config in test_configs:
-            with self.assertRaises(config_options.ValidationError):
-                self.validate_config(test_config)
+            with self.subTest(test_config):
+                with self.assertRaises(config_options.ValidationError):
+                    self.validate_config(test_config)
 
     def test_common_prefix(self):
         """Legitimate settings with common prefixes should not fail validation."""
@@ -591,7 +593,8 @@ class SiteDirTest(unittest.TestCase):
         )
 
         for test_config in test_configs:
-            assert self.validate_config(test_config)
+            with self.subTest(test_config):
+                assert self.validate_config(test_config)
 
 
 class ThemeTest(unittest.TestCase):

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -209,14 +209,14 @@ class ConfigTests(unittest.TestCase):
             )
 
             for config_contents, result in zip(configs, results):
-
-                c = config.Config(schema=(('theme', config_options.Theme(default='mkdocs')),))
-                c.load_dict(config_contents)
-                errors, warnings = c.validate()
-                self.assertEqual(len(errors), 0)
-                self.assertEqual(c['theme'].dirs, result['dirs'])
-                self.assertEqual(c['theme'].static_templates, set(result['static_templates']))
-                self.assertEqual({k: c['theme'][k] for k in iter(c['theme'])}, result['vars'])
+                with self.subTest(config_contents):
+                    c = config.Config(schema=(('theme', config_options.Theme(default='mkdocs')),))
+                    c.load_dict(config_contents)
+                    errors, warnings = c.validate()
+                    self.assertEqual(len(errors), 0)
+                    self.assertEqual(c['theme'].dirs, result['dirs'])
+                    self.assertEqual(c['theme'].static_templates, set(result['static_templates']))
+                    self.assertEqual({k: c['theme'][k] for k in iter(c['theme'])}, result['vars'])
 
     def test_empty_nav(self):
         conf = config.Config(schema=defaults.get_schema())
@@ -263,24 +263,24 @@ class ConfigTests(unittest.TestCase):
         }
 
         for test_config in test_configs:
+            with self.subTest(test_config):
+                patch = conf.copy()
+                patch.update(test_config)
 
-            patch = conf.copy()
-            patch.update(test_config)
-
-            # Same as the default schema, but don't verify the docs_dir exists.
-            c = config.Config(
-                schema=(
-                    ('docs_dir', config_options.Dir(default='docs')),
-                    ('site_dir', config_options.SiteDir(default='site')),
-                    ('config_file_path', config_options.Type(str)),
+                # Same as the default schema, but don't verify the docs_dir exists.
+                c = config.Config(
+                    schema=(
+                        ('docs_dir', config_options.Dir(default='docs')),
+                        ('site_dir', config_options.SiteDir(default='site')),
+                        ('config_file_path', config_options.Type(str)),
+                    )
                 )
-            )
-            c.load_dict(patch)
+                c.load_dict(patch)
 
-            errors, warnings = c.validate()
+                errors, warnings = c.validate()
 
-            self.assertEqual(len(errors), 1)
-            self.assertEqual(warnings, [])
+                self.assertEqual(len(errors), 1)
+                self.assertEqual(warnings, [])
 
     SUBCONFIG_TEST_SCHEMA = {
         "items": mkdocs.config.config_options.ConfigItems(

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -477,26 +477,27 @@ class SearchIndexTests(unittest.TestCase):
             'sections': validate_sections,
             'titles': validate_titles,
         }.items():
-            plugin = search.SearchPlugin()
+            with self.subTest(option):
+                plugin = search.SearchPlugin()
 
-            # Load plugin config, overriding indexing for test case
-            errors, warnings = plugin.load_config({'indexing': option})
-            self.assertEqual(errors, [])
-            self.assertEqual(warnings, [])
+                # Load plugin config, overriding indexing for test case
+                errors, warnings = plugin.load_config({'indexing': option})
+                self.assertEqual(errors, [])
+                self.assertEqual(warnings, [])
 
-            base_cfg = load_config()
-            base_cfg['plugins']['search'].config['indexing'] = option
+                base_cfg = load_config()
+                base_cfg['plugins']['search'].config['indexing'] = option
 
-            pages = [
-                test_page('Home', 'index.md', base_cfg),
-                test_page('About', 'about.md', base_cfg),
-            ]
+                pages = [
+                    test_page('Home', 'index.md', base_cfg),
+                    test_page('About', 'about.md', base_cfg),
+                ]
 
-            for page in pages:
-                index = search_index.SearchIndex(**plugin.config)
-                index.add_entry_from_context(page)
-                data = index.generate_search_index()
-                validate(json.loads(data)['docs'], page)
+                for page in pages:
+                    index = search_index.SearchIndex(**plugin.config)
+                    index.add_entry_from_context(page)
+                    data = index.generate_search_index()
+                    validate(json.loads(data)['docs'], page)
 
     @mock.patch('subprocess.Popen', autospec=True)
     def test_prebuild_index(self, mock_popen):

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -541,11 +541,12 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         ]
 
         for i, filename in enumerate(to_files):
-            file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
-            self.assertEqual(from_file.url, 'img.jpg')
-            self.assertEqual(file.url, to_file_urls[i])
-            self.assertEqual(from_file.url_relative_to(file.url), expected[i])
-            self.assertEqual(from_file.url_relative_to(file), expected[i])
+            with self.subTest(from_file=from_file.src_path, to_file=filename):
+                file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
+                self.assertEqual(from_file.url, 'img.jpg')
+                self.assertEqual(file.url, to_file_urls[i])
+                self.assertEqual(from_file.url_relative_to(file.url), expected[i])
+                self.assertEqual(from_file.url_relative_to(file), expected[i])
 
         from_file = File('foo/img.jpg', '/path/to/docs', '/path/to/site', use_directory_urls=False)
         expected = [
@@ -559,11 +560,12 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         ]
 
         for i, filename in enumerate(to_files):
-            file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
-            self.assertEqual(from_file.url, 'foo/img.jpg')
-            self.assertEqual(file.url, to_file_urls[i])
-            self.assertEqual(from_file.url_relative_to(file.url), expected[i])
-            self.assertEqual(from_file.url_relative_to(file), expected[i])
+            with self.subTest(from_file=from_file.src_path, to_file=filename):
+                file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
+                self.assertEqual(from_file.url, 'foo/img.jpg')
+                self.assertEqual(file.url, to_file_urls[i])
+                self.assertEqual(from_file.url_relative_to(file.url), expected[i])
+                self.assertEqual(from_file.url_relative_to(file), expected[i])
 
         from_file = File('index.html', '/path/to/docs', '/path/to/site', use_directory_urls=False)
         expected = [
@@ -577,11 +579,12 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         ]
 
         for i, filename in enumerate(to_files):
-            file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
-            self.assertEqual(from_file.url, 'index.html')
-            self.assertEqual(file.url, to_file_urls[i])
-            self.assertEqual(from_file.url_relative_to(file.url), expected[i])
-            self.assertEqual(from_file.url_relative_to(file), expected[i])
+            with self.subTest(from_file=from_file.src_path, to_file=filename):
+                file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
+                self.assertEqual(from_file.url, 'index.html')
+                self.assertEqual(file.url, to_file_urls[i])
+                self.assertEqual(from_file.url_relative_to(file.url), expected[i])
+                self.assertEqual(from_file.url_relative_to(file), expected[i])
 
         from_file = File('file.html', '/path/to/docs', '/path/to/site', use_directory_urls=False)
         expected = [
@@ -595,11 +598,12 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         ]
 
         for i, filename in enumerate(to_files):
-            file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
-            self.assertEqual(from_file.url, 'file.html')
-            self.assertEqual(file.url, to_file_urls[i])
-            self.assertEqual(from_file.url_relative_to(file.url), expected[i])
-            self.assertEqual(from_file.url_relative_to(file), expected[i])
+            with self.subTest(from_file=from_file.src_path, to_file=filename):
+                file = File(filename, '/path/to/docs', '/path/to/site', use_directory_urls=False)
+                self.assertEqual(from_file.url, 'file.html')
+                self.assertEqual(file.url, to_file_urls[i])
+                self.assertEqual(from_file.url_relative_to(file.url), expected[i])
+                self.assertEqual(from_file.url_relative_to(file), expected[i])
 
     @tempdir(
         files=[

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -430,95 +430,143 @@ class PageTests(unittest.TestCase):
             self.assertEqual(pg.meta, {})
 
     def test_page_edit_url(self):
-        configs = [
-            {'repo_url': 'http://github.com/mkdocs/mkdocs'},
-            {'repo_url': 'https://github.com/mkdocs/mkdocs/'},
-            {'repo_url': 'http://example.com'},
-            {'repo_url': 'http://example.com', 'edit_uri': 'edit/master'},
-            {'repo_url': 'http://example.com', 'edit_uri': '/edit/master'},
-            {'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master/'},
-            {'repo_url': 'http://example.com/foo', 'edit_uri': '/edit/master/'},
-            {'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master'},
-            {'repo_url': 'http://example.com/foo/', 'edit_uri': 'edit/master/'},
-            {'repo_url': 'http://example.com/foo', 'edit_uri': 'edit/master/'},
-            {'repo_url': 'http://example.com', 'edit_uri': '?query=edit/master'},
-            {'repo_url': 'http://example.com/', 'edit_uri': '?query=edit/master/'},
-            {'repo_url': 'http://example.com', 'edit_uri': '#edit/master'},
-            {'repo_url': 'http://example.com/', 'edit_uri': '#edit/master/'},
-            {'repo_url': 'http://example.com', 'edit_uri': ''},  # Set to blank value
-            {
-                # Nothing defined
-            },
-        ]
-
-        expected = [
-            'http://github.com/mkdocs/mkdocs/edit/master/docs/testing.md',
-            'https://github.com/mkdocs/mkdocs/edit/master/docs/testing.md',
-            None,
-            'http://example.com/edit/master/testing.md',
-            'http://example.com/edit/master/testing.md',
-            'http://example.com/edit/master/testing.md',
-            'http://example.com/edit/master/testing.md',
-            'http://example.com/edit/master/testing.md',
-            'http://example.com/foo/edit/master/testing.md',
-            'http://example.com/foo/edit/master/testing.md',
-            'http://example.com?query=edit/master/testing.md',
-            'http://example.com/?query=edit/master/testing.md',
-            'http://example.com#edit/master/testing.md',
-            'http://example.com/#edit/master/testing.md',
-            None,
-            None,
-        ]
-
-        for i, c in enumerate(configs):
-            cfg = load_config(**c)
-            fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
-            pg = Page('Foo', fl, cfg)
-            self.assertEqual(pg.url, 'testing/')
-            self.assertEqual(pg.edit_url, expected[i])
+        for case in [
+            dict(
+                config={'repo_url': 'http://github.com/mkdocs/mkdocs'},
+                edit_url='http://github.com/mkdocs/mkdocs/edit/master/docs/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'https://github.com/mkdocs/mkdocs/'},
+                edit_url='https://github.com/mkdocs/mkdocs/edit/master/docs/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com'},
+                edit_url=None,
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': 'edit/master'},
+                edit_url='http://example.com/edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': '/edit/master'},
+                edit_url='http://example.com/edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master/'},
+                edit_url='http://example.com/edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo', 'edit_uri': '/edit/master/'},
+                edit_url='http://example.com/edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master'},
+                edit_url='http://example.com/edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo/', 'edit_uri': 'edit/master/'},
+                edit_url='http://example.com/foo/edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo', 'edit_uri': 'edit/master/'},
+                edit_url='http://example.com/foo/edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': '?query=edit/master'},
+                edit_url='http://example.com?query=edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/', 'edit_uri': '?query=edit/master/'},
+                edit_url='http://example.com/?query=edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': '#edit/master'},
+                edit_url='http://example.com#edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/', 'edit_uri': '#edit/master/'},
+                edit_url='http://example.com/#edit/master/testing.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': ''},  # Set to blank value
+                edit_url=None,
+            ),
+            dict(config={}, edit_url=None),  # Nothing defined
+        ]:
+            with self.subTest(case['config']):
+                cfg = load_config(**case['config'])
+                fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+                pg = Page('Foo', fl, cfg)
+                self.assertEqual(pg.url, 'testing/')
+                self.assertEqual(pg.edit_url, case['edit_url'])
 
     def test_nested_page_edit_url(self, file_src_path='sub1/non-index.md'):
-        configs = [
-            {'repo_url': 'http://github.com/mkdocs/mkdocs'},
-            {'repo_url': 'https://github.com/mkdocs/mkdocs/'},
-            {'repo_url': 'http://example.com'},
-            {'repo_url': 'http://example.com', 'edit_uri': 'edit/master'},
-            {'repo_url': 'http://example.com', 'edit_uri': '/edit/master'},
-            {'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master/'},
-            {'repo_url': 'http://example.com/foo', 'edit_uri': '/edit/master/'},
-            {'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master'},
-            {'repo_url': 'http://example.com/foo/', 'edit_uri': 'edit/master/'},
-            {'repo_url': 'http://example.com/foo', 'edit_uri': 'edit/master/'},
-            {'repo_url': 'http://example.com', 'edit_uri': '?query=edit/master'},
-            {'repo_url': 'http://example.com/', 'edit_uri': '?query=edit/master/'},
-            {'repo_url': 'http://example.com', 'edit_uri': '#edit/master'},
-            {'repo_url': 'http://example.com/', 'edit_uri': '#edit/master/'},
-        ]
-
-        expected = [
-            'http://github.com/mkdocs/mkdocs/edit/master/docs/sub1/non-index.md',
-            'https://github.com/mkdocs/mkdocs/edit/master/docs/sub1/non-index.md',
-            None,
-            'http://example.com/edit/master/sub1/non-index.md',
-            'http://example.com/edit/master/sub1/non-index.md',
-            'http://example.com/edit/master/sub1/non-index.md',
-            'http://example.com/edit/master/sub1/non-index.md',
-            'http://example.com/edit/master/sub1/non-index.md',
-            'http://example.com/foo/edit/master/sub1/non-index.md',
-            'http://example.com/foo/edit/master/sub1/non-index.md',
-            'http://example.com?query=edit/master/sub1/non-index.md',
-            'http://example.com/?query=edit/master/sub1/non-index.md',
-            'http://example.com#edit/master/sub1/non-index.md',
-            'http://example.com/#edit/master/sub1/non-index.md',
-        ]
-
-        for i, c in enumerate(configs):
-            c['docs_dir'] = self.DOCS_DIR
-            cfg = load_config(**c)
-            fl = File(file_src_path, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
-            pg = Page('Foo', fl, cfg)
-            self.assertEqual(pg.url, 'sub1/non-index/')
-            self.assertEqual(pg.edit_url, expected[i])
+        for case in [
+            dict(
+                config={'repo_url': 'http://github.com/mkdocs/mkdocs'},
+                edit_url='http://github.com/mkdocs/mkdocs/edit/master/docs/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'https://github.com/mkdocs/mkdocs/'},
+                edit_url='https://github.com/mkdocs/mkdocs/edit/master/docs/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com'},
+                edit_url=None,
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': 'edit/master'},
+                edit_url='http://example.com/edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': '/edit/master'},
+                edit_url='http://example.com/edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master/'},
+                edit_url='http://example.com/edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo', 'edit_uri': '/edit/master/'},
+                edit_url='http://example.com/edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo/', 'edit_uri': '/edit/master'},
+                edit_url='http://example.com/edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo/', 'edit_uri': 'edit/master/'},
+                edit_url='http://example.com/foo/edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/foo', 'edit_uri': 'edit/master/'},
+                edit_url='http://example.com/foo/edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': '?query=edit/master'},
+                edit_url='http://example.com?query=edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/', 'edit_uri': '?query=edit/master/'},
+                edit_url='http://example.com/?query=edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com', 'edit_uri': '#edit/master'},
+                edit_url='http://example.com#edit/master/sub1/non-index.md',
+            ),
+            dict(
+                config={'repo_url': 'http://example.com/', 'edit_uri': '#edit/master/'},
+                edit_url='http://example.com/#edit/master/sub1/non-index.md',
+            ),
+        ]:
+            with self.subTest(case['config']):
+                cfg = load_config(**case['config'], docs_dir=self.DOCS_DIR)
+                fl = File(
+                    file_src_path, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']
+                )
+                pg = Page('Foo', fl, cfg)
+                self.assertEqual(pg.url, 'sub1/non-index/')
+                self.assertEqual(pg.edit_url, case['edit_url'])
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_nested_page_edit_url_windows(self):


### PR DESCRIPTION
This allows finding which of the cases failed, otherwise the error just points to the line number.