### PR TITLE
add pre-commit-hook configuration to this repo

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,3 +7,4 @@
   pass_filenames: false
   types_or: [markdown, yaml]
   files: ((^|/)mkdocs\.ya?ml$)|(^docs/)
+  minimum_pre_commit_version: 2.9.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: mkdocs-build
+  name: mkdocs build
+  description: tests if your documentation builds successfully.
+  language: python
+  entry: mkdocs build
+  require_serial: true
+  pass_filenames: false
+  types_or: [markdown, yaml]
+  files: ((^|/)mkdocs\.ya?ml$)|(^docs/)


### PR DESCRIPTION
I don't know if this feature interest you, so its a draft for now. I also didn't add documentation for now unitll I have feedback if this is desirable:

I implemented a `pre-commit` hook for this repository ([see her for more info](https://pre-commit.com)). This allows users to easiely integrate the `mkdocs build` command into their workflow. It will run on any commit that has changes to relevant files (`mkdocs.yml` or any markdown file insode `docs/`) and will stop the commit if the build process fails.

It also makes it easy to have invalid PRs fail the ci-workflow with a single simple workflow, instead of having to create a extra step manually to run `mkdocs`.

All a user needs to to is to install `pre-commit` (most likly already the case) and add this to his `pre-commit-config.yaml`:

```yaml
  - repo: https://github.com/Cube707/mkdocs  # only for temporary testing
    # repo: https://github.com/mkdocs/mkdocs  # this will be the real URL 
    rev: 878df16  # will be a github-Tag marking a release
    hooks:
      - id: mkdocs-build
```

---

if this feature is accabtabel, this is to be discussed:

- [ ] add documentation (where would be the appropriate place? maybe `docs/deploying-your-docs.md#pre-commit`?)
- [ ] once merged, do we want to add this to [the list on precommit.com](https://pre-commit.com/hooks.html)?