### PR TITLE
Fix deprecated field in setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
> The license_file parameter is deprecated, use license_files instead.
