### PR TITLE
Change back to non-static event methods, but delete the defs

### DIFF
--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -60,9 +60,8 @@ class BasePlugin:
 
     # Global events
 
-    @staticmethod
     def on_serve(
-        server: LiveReloadServer, config: Config, builder: Callable
+        self, server: LiveReloadServer, config: Config, builder: Callable
     ) -> Optional[LiveReloadServer]:
         """
         The `serve` event is only called when the `serve` command is used during
@@ -80,8 +79,7 @@ class BasePlugin:
         """
         return server
 
-    @staticmethod
-    def on_config(config: Config) -> Optional[Config]:
+    def on_config(self, config: Config) -> Optional[Config]:
         """
         The `config` event is the first event called on build and is run immediately
         after the user configuration is loaded and validated. Any alterations to the
@@ -95,8 +93,7 @@ class BasePlugin:
         """
         return config
 
-    @staticmethod
-    def on_pre_build(config: Config) -> None:
+    def on_pre_build(self, config: Config) -> None:
         """
         The `pre_build` event does not alter any variables. Use this event to call
         pre-build scripts.
@@ -105,8 +102,7 @@ class BasePlugin:
             config: global configuration object
         """
 
-    @staticmethod
-    def on_files(files: Files, config: Config) -> Optional[Files]:
+    def on_files(self, files: Files, config: Config) -> Optional[Files]:
         """
         The `files` event is called after the files collection is populated from the
         `docs_dir`. Use this event to add, remove, or alter files in the
@@ -123,8 +119,7 @@ class BasePlugin:
         """
         return files
 
-    @staticmethod
-    def on_nav(nav: Navigation, config: Config, files: Files) -> Optional[Navigation]:
+    def on_nav(self, nav: Navigation, config: Config, files: Files) -> Optional[Navigation]:
         """
         The `nav` event is called after the site navigation is created and can
         be used to alter the site navigation.
@@ -139,9 +134,8 @@ class BasePlugin:
         """
         return nav
 
-    @staticmethod
     def on_env(
-        env: jinja2.Environment, config: Config, files: Files
+        self, env: jinja2.Environment, config: Config, files: Files
     ) -> Optional[jinja2.Environment]:
         """
         The `env` event is called after the Jinja template environment is created
@@ -158,8 +152,7 @@ class BasePlugin:
         """
         return env
 
-    @staticmethod
-    def on_post_build(config: Config) -> None:
+    def on_post_build(self, config: Config) -> None:
         """
         The `post_build` event does not alter any variables. Use this event to call
         post-build scripts.
@@ -168,8 +161,7 @@ class BasePlugin:
             config: global configuration object
         """
 
-    @staticmethod
-    def on_build_error(error: Exception) -> None:
+    def on_build_error(self, error: Exception) -> None:
         """
         The `build_error` event is called after an exception of any kind
         is caught by MkDocs during the build process.
@@ -183,9 +175,8 @@ class BasePlugin:
 
     # Template events
 
-    @staticmethod
     def on_pre_template(
-        template: jinja2.Template, template_name: str, config: Config
+        self, template: jinja2.Template, template_name: str, config: Config
     ) -> Optional[jinja2.Template]:
         """
         The `pre_template` event is called immediately after the subject template is
@@ -201,9 +192,8 @@ class BasePlugin:
         """
         return template
 
-    @staticmethod
     def on_template_context(
-        context: Dict[str, Any], template_name: str, config: Config
+        self, context: Dict[str, Any], template_name: str, config: Config
     ) -> Optional[Dict[str, Any]]:
         """
         The `template_context` event is called immediately after the context is created
@@ -220,8 +210,7 @@ class BasePlugin:
         """
         return context
 
-    @staticmethod
-    def on_post_template(output_content: str, template_name: str, config: Config) -> str:
+    def on_post_template(self, output_content: str, template_name: str, config: Config) -> str:
         """
         The `post_template` event is called after the template is rendered, but before
         it is written to disc and can be used to alter the output of the template.
@@ -240,8 +229,7 @@ class BasePlugin:
 
     # Page events
 
-    @staticmethod
-    def on_pre_page(page: Page, config: Config, files: Files) -> Optional[Page]:
+    def on_pre_page(self, page: Page, config: Config, files: Files) -> Optional[Page]:
         """
         The `pre_page` event is called before any actions are taken on the subject
         page and can be used to alter the `Page` instance.
@@ -256,8 +244,7 @@ class BasePlugin:
         """
         return page
 
-    @staticmethod
-    def on_page_read_source(page: Page, config: Config) -> Optional[str]:
+    def on_page_read_source(self, page: Page, config: Config) -> Optional[str]:
         """
         The `on_page_read_source` event can replace the default mechanism to read
         the contents of a page's source from the filesystem.
@@ -272,8 +259,9 @@ class BasePlugin:
         """
         return None
 
-    @staticmethod
-    def on_page_markdown(markdown: str, page: Page, config: Config, files: Files) -> Optional[str]:
+    def on_page_markdown(
+        self, markdown: str, page: Page, config: Config, files: Files
+    ) -> Optional[str]:
         """
         The `page_markdown` event is called after the page's markdown is loaded
         from file and can be used to alter the Markdown source text. The meta-
@@ -290,8 +278,7 @@ class BasePlugin:
         """
         return markdown
 
-    @staticmethod
-    def on_page_content(html: str, page: Page, config: Config, files: Files) -> Optional[str]:
+    def on_page_content(self, html: str, page: Page, config: Config, files: Files) -> Optional[str]:
         """
         The `page_content` event is called after the Markdown text is rendered to
         HTML (but before being passed to a template) and can be used to alter the
@@ -308,9 +295,8 @@ class BasePlugin:
         """
         return html
 
-    @staticmethod
     def on_page_context(
-        context: Dict[str, Any], page: Page, config: Config, nav: Navigation
+        self, context: Dict[str, Any], page: Page, config: Config, nav: Navigation
     ) -> Optional[Dict[str, Any]]:
         """
         The `page_context` event is called after the context for a page is created
@@ -327,8 +313,7 @@ class BasePlugin:
         """
         return context
 
-    @staticmethod
-    def on_post_page(output: str, page: Page, config: Config) -> str:
+    def on_post_page(self, output: str, page: Page, config: Config) -> str:
         """
         The `post_page` event is called after the template is rendered, but
         before it is written to disc and can be used to alter the output of the
@@ -346,7 +331,12 @@ class BasePlugin:
         return output
 
 
-EVENTS = tuple(k[3:] for k in dir(BasePlugin) if k.startswith('on_'))
+EVENTS = tuple(k[3:] for k in BasePlugin.__dict__ if k.startswith("on_"))
+
+# The above definitions were just for docs and type checking, we don't actually want them.
+for k in EVENTS:
+    delattr(BasePlugin, 'on_' + k)
+
 
 T = TypeVar('T')
 
@@ -378,8 +368,8 @@ class PluginCollection(OrderedDict):
         super().__setitem__(key, value, **kwargs)
         # Register all of the event methods defined for this Plugin.
         for event_name in (x for x in dir(value) if x.startswith('on_')):
-            method = getattr(value, event_name)
-            if callable(method) and method is not getattr(BasePlugin, event_name):
+            method = getattr(value, event_name, None)
+            if callable(method):
                 self._register_event(event_name[3:], method)
 
     @overload

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, Iterator, List, Optional, Union
+from typing import Iterator, List, Optional, Union
 from urllib.parse import urlsplit
 
 from mkdocs.config.base import Config
@@ -54,7 +54,7 @@ class Section:
     parent: Optional['Section']
     """The immediate parent of the section or `None` if the section is at the top level."""
 
-    children: Iterable[Union[Page, 'Section', 'Link']]
+    children: List[Union[Page, 'Section', 'Link']]
     """An iterable of all child navigation objects. Children may include nested sections, pages and links."""
 
     @property

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -83,6 +83,33 @@ class TestPluginClass(unittest.TestCase):
 
 
 class TestPluginCollection(unittest.TestCase):
+    def test_correct_events_registered(self):
+        collection = plugins.PluginCollection()
+        plugin = DummyPlugin()
+        collection['foo'] = plugin
+        self.assertEqual(
+            collection.events,
+            {
+                'serve': [],
+                'config': [],
+                'pre_build': [plugin.on_pre_build],
+                'files': [],
+                'nav': [plugin.on_nav],
+                'env': [],
+                'post_build': [],
+                'build_error': [],
+                'pre_template': [],
+                'template_context': [],
+                'post_template': [],
+                'pre_page': [plugin.on_pre_page],
+                'page_read_source': [plugin.on_page_read_source],
+                'page_markdown': [],
+                'page_content': [],
+                'page_context': [],
+                'post_page': [],
+            },
+        )
+
     def test_set_plugin_on_collection(self):
         collection = plugins.PluginCollection()
         plugin = DummyPlugin()


### PR DESCRIPTION
Another followup to #2937

mypy requires the methods to be non-static to be able to understand their overrides.

I just didn't want to deal with the `<bound method ...>` stuff and had to make them static previously. Instead now I actually delete all those methods right after defining them. The trick passes for both mkdocstrings and mypy
