### PR TITLE
Let plugins choose the priority order of their events

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -60,6 +60,11 @@ body.homepage>div.container>div.row>div.col-md-9 {
 
 /* mkdocstrings */
 
+.doc-object {
+    padding-left: 10px;
+    border-left: 4px solid rgba(230, 230, 230);
+}
+
 .doc-contents .field-body p:first-of-type {
     display: inline;
 }

--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -295,6 +295,16 @@ page events are called after the [post_template] event and before the
         show_root_heading: false
         show_root_toc_entry: false
 
+### Event Priorities
+
+For each event type, corresponding methods of plugins are called in the order that the plugins appear in the `plugins` [config][].
+
+Since MkDocs 1.4, plugins can choose to set a priority value for their events. Events with higher priority are called first. Events without a chosen priority get a default of 0. Events that have the same priority are ordered as they appear in the config.
+
+::: mkdocs.plugins.event_priority
+    options:
+      show_root_heading: true
+
 ### Handling Errors
 
 MkDocs defines four error types:

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -285,6 +285,22 @@ class UtilsTests(unittest.TestCase):
             [1, 2, 3, 4, 5, 6, 7, 8],
         )
 
+    def test_insort(self):
+        a = [1, 2, 3]
+        utils.insort(a, 5)
+        self.assertEqual(a, [1, 2, 3, 5])
+        utils.insort(a, -1)
+        self.assertEqual(a, [-1, 1, 2, 3, 5])
+        utils.insort(a, 2)
+        self.assertEqual(a, [-1, 1, 2, 2, 3, 5])
+        utils.insort(a, 4)
+        self.assertEqual(a, [-1, 1, 2, 2, 3, 4, 5])
+
+    def test_insort_key(self):
+        a = [(1, 'a'), (1, 'b'), (2, 'c')]
+        utils.insort(a, (1, 'a'), key=lambda v: v[0])
+        self.assertEqual(a, [(1, 'a'), (1, 'b'), (1, 'a'), (2, 'c')])
+
     def test_get_themes(self):
         themes = utils.get_theme_names()
         self.assertIn('mkdocs', themes)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -17,7 +17,18 @@ import warnings
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import PurePath
-from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    MutableSequence,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 from urllib.parse import urlsplit
 
 if sys.version_info >= (3, 10):
@@ -33,6 +44,8 @@ from mkdocs import exceptions
 
 if TYPE_CHECKING:
     from mkdocs.structure.pages import Page
+
+T = TypeVar('T')
 
 log = logging.getLogger(__name__)
 
@@ -130,6 +143,18 @@ def get_build_date() -> str:
 def reduce_list(data_set: Iterable[str]) -> List[str]:
     """Reduce duplicate items in a list and preserve order"""
     return list(dict.fromkeys(data_set))
+
+
+if sys.version_info >= (3, 10):
+    from bisect import insort
+else:
+
+    def insort(a: MutableSequence[T], x: T, *, key=lambda v: v) -> None:
+        kx = key(x)
+        i = len(a)
+        while i > 0 and kx < key(a[i - 1]):
+            i -= 1
+        a.insert(i, x)
 
 
 def copy_file(source_path: str, output_path: str) -> None:


### PR DESCRIPTION
Add a decorator that sets a priority value for plugins' events.
Events with higher priority are called first.
Events without a chosen priority get a default of 0.
Events that have the same priority are ordered as they appear in the config.

Recommended priority values:
`100` "first", `50` "early", `0` "default", `-50` "late", `-100` "last".
As different plugins discover more precise relations to each other, the values should be further tweaked.

```python
@plugins.event_priority(-100)  # Wishing to run this after all other plugins' `on_files` events.
def on_files(self, files, config, **kwargs):
    ...
```
