### PR TITLE
Hooks feature: run plugin events from local Python files

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -23,6 +23,11 @@ code.no-highlight {
 div.admonition.block>.admonition-title {
     display: none;
 }
+div.admonition.new {
+    color: #15654a;
+    background-color: #e4f7f1;
+    border-color: #bcf1e8;
+}
 
 /* Definition List styles */
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -577,6 +577,41 @@ This alternative syntax is required if you intend to override some options via
 
 **default**: `[]` (an empty list).
 
+### hooks
+
+NEW: **New in version 1.4.**
+
+A list of paths to Python scripts (relative to `mkdocs.yml`) that are loaded and used as [plugin](#plugins) instances.
+
+For example:
+
+```yaml
+hooks:
+    - my_hooks.py
+```
+
+Then the file *my_hooks.py* can contain any [plugin event handlers](../dev-guide/plugins.md#events) (without `self`), e.g.:
+
+```python
+def on_page_markdown(markdown, **kwargs):
+    return markdown.replace('a', 'z')
+```
+
+This does not enable any new abilities compared to [plugins][], it only simplifies one-off usages, as these don't need to be *installed* like plugins do.
+
+Note that for `mkdocs serve` the hook module will *not* be reloaded on each build.
+
+You might have seen this feature in the [mkdocs-simple-hooks plugin](https://github.com/aklajnert/mkdocs-simple-hooks). If using standard method names, it can be directly replaced, e.g.:
+
+```diff
+-plugins:
+-  - mkdocs-simple-hooks:
+-      hooks:
+-        on_page_markdown: 'my_hooks:on_page_markdown'
++hooks:
++  - my_hooks.py
+```
+
 ### plugins
 
 A list of plugins (with optional configuration settings) to use when building

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -480,6 +480,8 @@ creates links that point directly to the target *file* rather than the target
 Determines how warnings are handled. Set to `true` to halt processing when a
 warning is raised. Set to `false` to print a warning and continue processing.
 
+This is also available as a command line flag: `--strict`.
+
 **default**: `false`
 
 ### dev_addr
@@ -595,6 +597,21 @@ Then the file *my_hooks.py* can contain any [plugin event handlers](../dev-guide
 ```python
 def on_page_markdown(markdown, **kwargs):
     return markdown.replace('a', 'z')
+```
+
+Advanced example that produces warnings based on the Markdown content (and warnings are fatal in [strict](#strict) mode):
+
+```python
+import logging, re
+import mkdocs.plugins
+
+log = logging.getLogger('mkdocs')
+
+@mkdocs.plugins.event_priority(-50)
+def on_page_markdown(markdown, page, **kwargs):
+    path = page.file.src_uri
+    for m in re.finditer(r'\bhttp://[^) ]+', markdown):
+        log.warning(f"Documentation file '{path}' contains a non-HTTPS link: {m[0]}")
 ```
 
 This does not enable any new abilities compared to [plugins][], it only simplifies one-off usages, as these don't need to be *installed* like plugins do.

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -119,5 +119,9 @@ class _MkDocsConfig:
     A key value pair should be the string name (as the key) and a dict of config
     options (as the value)."""
 
+    hooks = config_options.Hooks('plugins')
+    """A list of filenames that will be imported as Python modules and used as
+    an instance of a plugin each."""
+
     watch = config_options.ListOfPaths(default=[])
     """A list of extra paths to watch while running `mkdocs serve`."""

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -442,12 +442,6 @@ class PluginCollection(OrderedDict):
         )
 
     def __setitem__(self, key: str, value: BasePlugin, **kwargs) -> None:
-        if not isinstance(value, BasePlugin):
-            raise TypeError(
-                f'{self.__module__}.{self.__name__} only accepts values which'
-                f' are instances of {BasePlugin.__module__}.{BasePlugin.__name__}'
-                ' subclasses'
-            )
         super().__setitem__(key, value, **kwargs)
         # Register all of the event methods defined for this Plugin.
         for event_name in (x for x in dir(value) if x.startswith('on_')):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import mkdocs
 from mkdocs.config import base, config_options
 from mkdocs.tests.base import tempdir
-from mkdocs.utils import yaml_load
+from mkdocs.utils import write_file, yaml_load
 
 
 class UnexpectedError(Exception):
@@ -1536,3 +1536,34 @@ class MarkdownExtensionsTest(TestCase):
             {},
         )
         self.assertIsNone(conf['mdx_configs'].get('toc'))
+
+
+class TestHooks(TestCase):
+    class Schema:
+        plugins = config_options.Plugins(default=[])
+        hooks = config_options.Hooks('plugins')
+
+    @tempdir()
+    def test_hooks(self, src_dir):
+        write_file(
+            b'def on_page_markdown(markdown, **kwargs): return markdown.replace("f", "z")',
+            os.path.join(src_dir, 'hooks', 'my_hook.py'),
+        )
+        write_file(
+            b'foo foo',
+            os.path.join(src_dir, 'docs', 'index.md'),
+        )
+        conf = self.get_config(
+            self.Schema,
+            {'hooks': ['hooks/my_hook.py']},
+            config_file_path=os.path.join(src_dir, 'mkdocs.yml'),
+        )
+        self.assertIn('hooks/my_hook.py', conf['plugins'])
+        hook = conf['plugins']['hooks/my_hook.py']
+        self.assertTrue(hasattr(hook, 'on_page_markdown'))
+        self.assertEqual(
+            {**conf['plugins'].events, 'page_markdown': [hook.on_page_markdown]},
+            conf['plugins'].events,
+        )
+        self.assertEqual(hook.on_page_markdown('foo foo'), 'zoo zoo')
+        self.assertFalse(hasattr(hook, 'on_nav'))


### PR DESCRIPTION
Add a new `hooks` config to `mkdocs.yml`:

A list of paths to Python scripts (relative to `mkdocs.yml`) that are loaded and used as [plugin](https://www.mkdocs.org/dev-guide/plugins/) instances.

For example:

```yaml
hooks:
    - my_hooks.py
```

Then the file *my_hooks.py* can contain any [plugin event handlers](https://www.mkdocs.org/dev-guide/plugins/#events) (without `self`), e.g.:

```python
def on_page_markdown(markdown, **kwargs):
    return markdown.replace('a', 'z')
```

This does not enable any new abilities compared to plugins, it only simplifies one-off usages, as these don't need to be *installed* like plugins do.

Note that for `mkdocs serve` the hook module will *not* be reloaded on each build.

You might have seen this feature in the [mkdocs-simple-hooks plugin](https://github.com/aklajnert/mkdocs-simple-hooks) by @aklajnert. If using standard method names, it can be directly replaced, e.g.:

```diff
-plugins:
-  - mkdocs-simple-hooks:
-      hooks:
-        on_page_markdown: 'my_hooks:on_page_markdown'
+hooks:
+  - my_hooks.py
```
