### PR TITLE
Update admonition styles in MkDocs theme

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -24,6 +24,17 @@ div.admonition.block>.admonition-title {
     display: none;
 }
 
+.admonition.new, details.new {
+    color: #15654a;
+    background-color: #edfff9;
+    border-color: #bcf1e8;
+}
+.admonition.example, details.example {
+    color: #353579;
+    background-color: #f0f1ff;
+    border-color: #d8dcf0;
+}
+
 /* Definition List styles */
 
 dd {

--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -140,7 +140,7 @@ There are three kinds of events: [Global Events], [Page Events] and
 [Template Events].
 
 <details class="card">
-  <summary class="card-header">
+  <summary>
     See a diagram with relations between all the plugin events
   </summary>
   <div class="card-body">

--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -215,7 +215,7 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
 
 
 
-.admonition {
+.admonition, details {
     padding: 15px;
     margin-bottom: 20px;
     border: 1px solid transparent;
@@ -223,27 +223,31 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     text-align: left;
 }
 
-.admonition.note { /* csslint allow: adjoining-classes */
-    color: #3a87ad;
-    background-color: #d9edf7;
+.admonition.note, details.note { /* csslint allow: adjoining-classes */
+    color: #2e6b89;
+    background-color: #e2f0f7;
     border-color: #bce8f1;
 }
 
-.admonition.warning { /* csslint allow: adjoining-classes */
-    color: #c09853;
-    background-color: #fcf8e3;
+.admonition.warning, details.warning { /* csslint allow: adjoining-classes */
+    color: #7a6032;
+    background-color: #fffae5;
     border-color: #fbeed5;
 }
 
-.admonition.danger { /* csslint allow: adjoining-classes */
-    color: #b94a48;
-    background-color: #f2dede;
+.admonition.danger, details.danger { /* csslint allow: adjoining-classes */
+    color: #7f3130;
+    background-color: #fde3e3;
     border-color: #eed3d7;
 }
 
-.admonition-title {
+.admonition-title, summary {
     font-weight: bold;
     text-align: left;
+}
+
+.admonition>p:last-child, details>p:last-child {
+    margin-bottom: 0;
 }
 
 @media (max-width: 991.98px) {


### PR DESCRIPTION
* Apply admonition styles also to `<details>` tags

* Remove extraneous margin at the bottom of admonition blocks

* Increase contrast of default admonitions
  ![mkdocs-colors](https://user-images.githubusercontent.com/371383/190920492-c375eff4-317a-4a07-aa30-0915740351b1.gif)

* Add some admonition styles (only for use on MkDocs' site for now)
  ![mkdocs-colors-2](https://user-images.githubusercontent.com/371383/190920487-c2e5bf72-4441-49a1-a64e-654a8c8c4073.png)
