### PR TITLE
Docs: update Markdown style

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -13,8 +13,8 @@
   // Set list indent level to 4 which Python-Markdown requires
   "MD007": { "indent": 4 },
 
-  // Exclude code block style
-  "MD046": false,
+  // Code block style
+  "MD046": { "style": "fenced" },
 
   // Allow inline HTML
   "MD033": false

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -6,12 +6,16 @@
 
 To upgrade MkDocs to the latest version, use pip:
 
-    pip install -U mkdocs
+```bash
+pip install -U mkdocs
+```
 
 You can determine your currently installed version using `mkdocs --version`:
 
-    $ mkdocs --version
-    mkdocs, version 1.0 from /path/to/mkdocs (Python 3.6)
+```console
+$ mkdocs --version
+mkdocs, version 1.0 from /path/to/mkdocs (Python 3.6)
+```
 
 ## Maintenance team
 

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -16,10 +16,6 @@ div.col-md-9 h1:first-of-type .headerlink {
     display: none;
 }
 
-code.no-highlight {
-    color: black;
-}
-
 div.admonition.block>.admonition-title {
     display: none;
 }

--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -11,7 +11,9 @@ using a plugin which comes with MkDocs, then it was installed when you installed
 MkDocs. However, to install third party plugins, you need to determine the
 appropriate package name and install it using `pip`:
 
-    pip install mkdocs-foo-plugin
+```bash
+pip install mkdocs-foo-plugin
+```
 
 Once a plugin has been successfully installed, it is ready to use. It just needs
 to be [enabled](#using-plugins) in the configuration file. The [MkDocs Plugins]
@@ -75,12 +77,14 @@ All `BasePlugin` subclasses contain the following attributes:
 
     For example, the following `config_scheme` defines three configuration options: `foo`, which accepts a string; `bar`, which accepts an integer; and `baz`, which accepts a boolean value.
 
-        class MyPlugin(mkdocs.plugins.BasePlugin):
-            config_scheme = (
-                ('foo', mkdocs.config.config_options.Type(str, default='a default value')),
-                ('bar', mkdocs.config.config_options.Type(int, default=0)),
-                ('baz', mkdocs.config.config_options.Type(bool, default=True))
-            )
+    ```python
+    class MyPlugin(mkdocs.plugins.BasePlugin):
+        config_scheme = (
+            ('foo', mkdocs.config.config_options.Type(str, default='a default value')),
+            ('bar', mkdocs.config.config_options.Type(int, default=0)),
+            ('baz', mkdocs.config.config_options.Type(bool, default=True))
+        )
+    ```
 
     When the user's configuration is loaded, the above scheme will be used to
     validate the configuration and fill in any defaults for settings not
@@ -97,9 +101,11 @@ All `BasePlugin` subclasses contain the following attributes:
     the `load_config` method after configuration validation has completed. Use
     this attribute to access options provided by the user.
 
-        def on_pre_build(self, config, **kwargs):
-            if self.config['bool_option']:
-                # implement "bool_option" functionality here...
+    ```python
+    def on_pre_build(self, config, **kwargs):
+        if self.config['bool_option']:
+            # implement "bool_option" functionality here...
+    ```
 
 All `BasePlugin` subclasses contain the following method(s):
 
@@ -129,10 +135,12 @@ All `BasePlugin` subclasses contain the following method(s):
     For example, the following event would add an additional static_template to
     the theme config:
 
-        class MyPlugin(BasePlugin):
-            def on_config(self, config, **kwargs):
-                config['theme'].static_templates.add('my_template.html')
-                return config
+    ```python
+    class MyPlugin(BasePlugin):
+        def on_config(self, config, **kwargs):
+            config['theme'].static_templates.add('my_template.html')
+            return config
+    ```
 
 ### Events
 

--- a/docs/dev-guide/themes.md
+++ b/docs/dev-guide/themes.md
@@ -885,21 +885,29 @@ special options which alters its behavior:
 > `Locale.territory` attributes and will resolve as a string from within a
 > template. Therefore, the following will work fine:
 >
->     <html lang="{ config.theme.locale }">
+> ```html
+> <html lang="{ config.theme.locale }">
+> ```
 >
 > If the locale was set to `fr_CA` (Canadian French), then the above template
 > would render as:
 >
->     <html lang="fr_CA">
+> ```html
+> <html lang="fr_CA">
+> ```
 >
 > If you did not want the territory attribute to be included, then reference
 > the `language` attribute directly:
 >
->     <html lang="{ config.theme.locale.language }">
+> ```html
+> <html lang="{ config.theme.locale.language }">
+> ```
 >
 > That would render as:
 >
->     <html lang="fr">
+> ```html
+> <html lang="fr">
+> ```
 >
 > #### static_templates
 >
@@ -927,7 +935,7 @@ the setup.py.
 Most Python packages, including MkDocs, are distributed on PyPI. To do this,
 you should run the following command.
 
-```no-highlight
+```bash
 python setup.py register
 ```
 

--- a/docs/dev-guide/themes.md
+++ b/docs/dev-guide/themes.md
@@ -27,7 +27,7 @@ option to the path of the directory containing `main.html`. The path should be
 relative to the configuration file. For example, given this example project
 layout:
 
-```no-highlight
+```text
 mkdocs.yml
 docs/
     index.md
@@ -326,7 +326,7 @@ for a page.
 
 In this example we define a `source` property above the page title:
 
-```no-highlight
+```text
 source: generics.py
         mixins.py
 
@@ -764,7 +764,7 @@ directory called `MANIFEST.in` and `setup.py` beside the theme directory which
 contains an empty `__init__.py` file, a theme configuration file
 (`mkdocs_theme.yml`), and your template and media files.
 
-```no-highlight
+```text
 .
 |-- MANIFEST.in
 |-- theme_name
@@ -778,7 +778,7 @@ contains an empty `__init__.py` file, a theme configuration file
 The `MANIFEST.in` file should contain the following contents but with
 theme_name updated and any extra file extensions added to the include.
 
-```no-highlight
+```text
 recursive-include theme_name *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
@@ -1166,7 +1166,7 @@ translations, it only makes use of the binary `mo` files(s) for the specified
 locale. Therefore, when [packaging a theme], you would need to make the
 following addition to your `MANIFEST.in` file:
 
-``` no-highlight
+```text
 recursive-include theme_name *.mo
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ as you work on it. Make sure you're in the same directory as the `mkdocs.yml`
 configuration file, and then start the server by running the `mkdocs serve`
 command:
 
-```bash
+```console
 $ mkdocs serve
 INFO    -  Building documentation...
 INFO    -  Cleaning site directory
@@ -156,7 +156,7 @@ mkdocs build
 This will create a new directory, named `site`. Take a look inside the
 directory:
 
-```bash
+```console
 $ ls site
 about  fonts  index.html  license  search.html
 css    img    js          mkdocs   sitemap.xml

--- a/docs/user-guide/choosing-your-theme.md
+++ b/docs/user-guide/choosing-your-theme.md
@@ -36,12 +36,14 @@ supports the following options:
 *   __`hljs_languages`__: By default, highlight.js only supports 23 common
     languages. List additional languages here to include support for them.
 
-        theme:
-            name: mkdocs
-            highlightjs: true
-            hljs_languages:
-                - yaml
-                - rust
+    ```yaml
+    theme:
+        name: mkdocs
+        highlightjs: true
+        hljs_languages:
+            - yaml
+            - rust
+    ```
 
 *   __`analytics`__: Defines configuration options for an analytics service.
     Currently, only Google Analytics v4 is supported via the `gtag` option.
@@ -51,23 +53,27 @@ supports the following options:
     [Set up Analytics for a website and/or app (GA4)][setup-GA4] or to
     [Upgrade to a Google Analytics 4 property][upgrade-GA4].
 
-            theme:
-                name: mkdocs
-                analytics:
-                    gtag: G-ABC123
+        ```yaml
+        theme:
+            name: mkdocs
+            analytics:
+                gtag: G-ABC123
+        ```
 
         When set to the default (`null`) Google Analytics is disabled for the
         site.
 
 *   __`shortcuts`__: Defines keyboard shortcut keys.
 
-        theme:
-            name: mkdocs
-            shortcuts:
-                help: 191    # ?
-                next: 78     # n
-                previous: 80 # p
-                search: 83   # s
+    ```yaml
+    theme:
+        name: mkdocs
+        shortcuts:
+            help: 191    # ?
+            next: 78     # n
+            previous: 80 # p
+            search: 83   # s
+    ```
 
     All values must be numeric key codes. It is best to use keys which are
     available on all keyboards. You may use <https://keycode.info/> to determine
@@ -89,9 +95,11 @@ supports the following options:
     default, this is set to `primary` (the default), but it can also be set to
     `dark` or `light`.
 
-        theme:
-            name: mkdocs
-            nav_style: dark
+    ```yaml
+    theme:
+        name: mkdocs
+        nav_style: dark
+    ```
 
 *   __`locale`__{ #mkdocs-locale }: The locale (language/location) used to
     build the theme. If your locale is not yet supported, it will fallback
@@ -131,12 +139,14 @@ theme supports the following options:
 *   __`hljs_languages`__: By default, highlight.js only supports 23 common
     languages. List additional languages here to include support for them.
 
-        theme:
-            name: readthedocs
-            highlightjs: true
-            hljs_languages:
-                - yaml
-                - rust
+    ```yaml
+    theme:
+        name: readthedocs
+        highlightjs: true
+        hljs_languages:
+            - yaml
+            - rust
+    ```
 
 *   __`analytics`__: Defines configuration options for an analytics service.
 
@@ -145,10 +155,12 @@ theme supports the following options:
     [Set up Analytics for a website and/or app (GA4)][setup-GA4] or to
     [Upgrade to a Google Analytics 4 property][upgrade-GA4].
 
-            theme:
-                name: readthedocs
-                analytics:
-                    gtag: G-ABC123
+        ```yaml
+        theme:
+            name: readthedocs
+            analytics:
+                gtag: G-ABC123
+        ```
 
         When set to the default (`null`) Google Analytics is disabled for the
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -377,7 +377,9 @@ the root of your local file system.
 > keep the *source* files under version control. For example, if using `git`
 > you might add the following line to your `.gitignore` file:
 >
->     site/
+> ```text
+> site/
+> ```
 >
 > If you're using another source code control tool, you'll want to check its
 > documentation on how to ignore specific directories.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -164,38 +164,38 @@ And the conversion flag `!q` is available, to percent-encode the field:
 
 * `{path!q}`, e.g. `foo%2Fbar.md`
 
-Here are some suggested configurations that can be useful:
-
-GitHub Wiki:  
-(e.g. `https://github.com/project/repo/wiki/foo/bar/_edit`)
-
-```yaml
-repo_url: 'https://github.com/project/repo/wiki'
-edit_uri_template: '{path_noext}/_edit'
-```
-
-BitBucket editor:  
-(e.g. `https://bitbucket.org/project/repo/src/master/docs/foo/bar.md?mode=edit`)
-
-```yaml
-repo_url: 'https://bitbucket.org/project/repo/'
-edit_uri_template: 'src/master/docs/{path}?mode=edit'
-```
-
-GitLab Static Site Editor:  
-(e.g. `https://gitlab.com/project/repo/-/sse/master/docs%2Ffoo%2bar.md`)
-
-```yaml
-repo_url: 'https://gitlab.com/project/repo'
-edit_uri_template: '-/sse/master/docs%2F{path!q}'
-```
-
-GitLab Web IDE:  
-(e.g. `https://gitlab.com/-/ide/project/repo/edit/master/-/docs/foo/bar.md`)
-
-```yaml
-edit_uri_template: 'https://gitlab.com/-/ide/project/repo/edit/master/-/docs/{path}'
-```
+>? NOTE: **Suggested useful configurations:**
+>
+> *   GitHub Wiki:  
+>     (e.g. `https://github.com/project/repo/wiki/foo/bar/_edit`)
+>
+>     ```yaml
+>     repo_url: 'https://github.com/project/repo/wiki'
+>     edit_uri_template: '{path_noext}/_edit'
+>     ```
+>
+> *   BitBucket editor:  
+>     (e.g. `https://bitbucket.org/project/repo/src/master/docs/foo/bar.md?mode=edit`)
+>
+>     ```yaml
+>     repo_url: 'https://bitbucket.org/project/repo/'
+>     edit_uri_template: 'src/master/docs/{path}?mode=edit'
+>     ```
+>
+> *   GitLab Static Site Editor:  
+>     (e.g. `https://gitlab.com/project/repo/-/sse/master/docs%2Ffoo%2bar.md`)
+>
+>     ```yaml
+>     repo_url: 'https://gitlab.com/project/repo'
+>     edit_uri_template: '-/sse/master/docs%2F{path!q}'
+>     ```
+>
+> *   GitLab Web IDE:  
+>     (e.g. `https://gitlab.com/-/ide/project/repo/edit/master/-/docs/foo/bar.md`)
+>
+>     ```yaml
+>     edit_uri_template: 'https://gitlab.com/-/ide/project/repo/edit/master/-/docs/{path}'
+>     ```
 
 **default**: `null`
 
@@ -599,20 +599,22 @@ def on_page_markdown(markdown, **kwargs):
     return markdown.replace('a', 'z')
 ```
 
-Advanced example that produces warnings based on the Markdown content (and warnings are fatal in [strict](#strict) mode):
-
-```python
-import logging, re
-import mkdocs.plugins
-
-log = logging.getLogger('mkdocs')
-
-@mkdocs.plugins.event_priority(-50)
-def on_page_markdown(markdown, page, **kwargs):
-    path = page.file.src_uri
-    for m in re.finditer(r'\bhttp://[^) ]+', markdown):
-        log.warning(f"Documentation file '{path}' contains a non-HTTPS link: {m[0]}")
-```
+>? EXAMPLE: **Advanced example:**
+>
+> This produces warnings based on the Markdown content (and warnings are fatal in [strict](#strict) mode):
+>
+> ```python
+> import logging, re
+> import mkdocs.plugins
+>
+> log = logging.getLogger('mkdocs')
+>
+> @mkdocs.plugins.event_priority(-50)
+> def on_page_markdown(markdown, page, **kwargs):
+>     path = page.file.src_uri
+>     for m in re.finditer(r'\bhttp://[^) ]+', markdown):
+>         log.warning(f"Documentation file '{path}' contains a non-HTTPS link: {m[0]}")
+> ```
 
 This does not enable any new abilities compared to [plugins][], it only simplifies one-off usages, as these don't need to be *installed* like plugins do.
 

--- a/docs/user-guide/customizing-your-theme.md
+++ b/docs/user-guide/customizing-your-theme.md
@@ -21,7 +21,7 @@ For example, to change the color of the headers in your documentation, create
 a file called `extra.css` and place it next to the documentation Markdown. In
 that file add the following CSS.
 
-```CSS
+```css
 h1 {
   color: red;
 }
@@ -32,7 +32,9 @@ h1 {
 > to explicitly list the CSS and JavaScript files you want to include in
 > your config. To do this, add the following to your mkdocs.yml.
 >
->     extra_css: [extra.css]
+> ```yaml
+> extra_css: [extra.css]
+> ```
 
 After making these changes, they should be visible when you run
 `mkdocs serve` - if you already had this running, you should see that the CSS

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -48,7 +48,7 @@ with the GitHub account name. Therefore, you need working copies of two
 repositories on our local system. For example, consider the following file
 structure:
 
-```no-highlight
+```text
 my-project/
     mkdocs.yml
     docs/

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -171,14 +171,18 @@ settings will need to be customized in very specific ways.
     The `site_url` must be set to an empty string, which instructs MkDocs to
     build your site so that it will work with the `file://` scheme.
 
-        site_url: ""
+    ```yaml
+    site_url: ""
+    ```
 
 -   [use_directory_urls]:
 
     Set `use_directory_urls` to `false`. Otherwise, internal links between
     pages will not work properly.
 
-        use_directory_urls: false
+    ```yaml
+    use_directory_urls: false
+    ```
 
 -   [search]:
 
@@ -186,7 +190,9 @@ settings will need to be customized in very specific ways.
     search plugin which is specifically designed to work with the `file://`
     scheme. To disable all plugins, set the `plugins` setting to an empty list.
 
-        plugins: []
+    ```yaml
+    plugins: []
+    ```
 
     If you have other plugins enabled, simply ensure that `search` is not
     included in the list.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -11,7 +11,7 @@ manager, [pip], to be installed on your system.
 
 You can check if you already have these installed from the command line:
 
-```bash
+```console
 $ python --version
 Python 3.8.2
 $ pip --version
@@ -61,7 +61,7 @@ pip install mkdocs
 You should now have the `mkdocs` command installed on your system. Run `mkdocs
 --version` to check that everything worked okay.
 
-```bash
+```console
 $ mkdocs --version
 mkdocs, version 1.2.0 from /usr/local/lib/python3.8/site-packages/mkdocs (Python 3.8)
 ```

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -70,8 +70,10 @@ mkdocs, version 1.2.0 from /usr/local/lib/python3.8/site-packages/mkdocs (Python
 > If you would like manpages installed for MkDocs, the [click-man] tool can
 > generate and install them for you. Simply run the following two commands:
 >
->     pip install click-man
->     click-man --target path/to/man/pages mkdocs
+> ```bash
+> pip install click-man
+> click-man --target path/to/man/pages mkdocs
+> ```
 >
 > See the [click-man documentation] for an explanation of why manpages are
 > not automatically generated and installed by pip.
@@ -83,8 +85,10 @@ mkdocs, version 1.2.0 from /usr/local/lib/python3.8/site-packages/mkdocs (Python
 > A quick solution may be to preface every Python command with `python -m`
 > like this:
 >
->     python -m pip install mkdocs
->     python -m mkdocs
+> ```bash
+> python -m pip install mkdocs
+> python -m mkdocs
+> ```
 >
 > For a more permanent solution, you may need to edit your `PATH` environment
 > variable to include the `Scripts` directory of your Python installation.

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -14,7 +14,7 @@ the `mkdocs.yml` configuration file.
 
 The simplest project you can create will look something like this:
 
-```no-highlight
+```text
 mkdocs.yml
 docs/
     index.md
@@ -35,7 +35,7 @@ behavior.
 You can also create multi-page documentation, by creating several Markdown
 files:
 
-```no-highlight
+```text
 mkdocs.yml
 docs/
     index.md
@@ -46,7 +46,7 @@ docs/
 The file layout you use determines the URLs that are used for the generated
 pages. Given the above layout, pages would be generated for the following URLs:
 
-```no-highlight
+```text
 /
 /about/
 /license/
@@ -55,7 +55,7 @@ pages. Given the above layout, pages would be generated for the following URLs:
 You can also include your Markdown files in nested directories if that better
 suits your documentation layout.
 
-```no-highlight
+```text
 docs/
     index.md
     user-guide/getting-started.md
@@ -66,7 +66,7 @@ docs/
 Source files inside nested directories will cause pages to be generated with
 nested URLs, like so:
 
-```no-highlight
+```text
 /
 /user-guide/getting-started/
 /user-guide/configuration-options/
@@ -111,7 +111,7 @@ your navigation menu sorted differently.
 
 A minimal navigation configuration could look like this:
 
-```no-highlight
+```yaml
 nav:
     - 'index.md'
     - 'about.md'
@@ -127,7 +127,7 @@ level and with their titles inferred from the contents of the Markdown file or,
 if no title is defined within the file, of the file name. To override the title
 in the `nav` setting add a title right before the filename.
 
-```no-highlight
+```yaml
 nav:
     - Home: 'index.md'
     - About: 'about.md'
@@ -140,7 +140,7 @@ within the page itself.
 Navigation sub-sections can be created by listing related pages together under a
 section title. For example:
 
-```no-highlight
+```yaml
 nav:
     - Home: 'index.md'
     - 'User Guide':
@@ -206,7 +206,7 @@ When linking between pages in the documentation you can simply use the regular
 Markdown [linking][links] syntax, including the *relative path* to the Markdown
 document you wish to link to.
 
-```no-highlight
+```markdown
 Please see the [project license](license.md) for further details.
 ```
 
@@ -223,7 +223,7 @@ them to your production server.
 If the target documentation file is in another directory you'll need to make
 sure to include any relative directory path in the link.
 
-```no-highlight
+```markdown
 Please see the [project license](../about/license.md) for further details.
 ```
 
@@ -232,7 +232,7 @@ Markdown documents. You can use that ID to link to a section within a target
 document by using an anchor link. The generated HTML will correctly transform
 the path portion of the link, and leave the anchor portion intact.
 
-```no-highlight
+```markdown
 Please see the [project license](about.md#license) for further details.
 ```
 
@@ -313,7 +313,7 @@ For example, if your project documentation needed to include a [GitHub pages
 CNAME file] and a PNG formatted screenshot image then your file layout might
 look as follows:
 
-```no-highlight
+```text
 mkdocs.yml
 docs/
     CNAME
@@ -398,7 +398,7 @@ a document must be `---`. The meta-data ends at the first line containing an
 end deliminator (either `---` or `...`). The content between the delimiters is
 parsed as [YAML].
 
-```no-highlight
+```text
 ---
 title: My Document
 summary: A brief description of my document.
@@ -427,7 +427,7 @@ MultiMarkdown style meta-data uses a format first introduced by the
 [MultiMarkdown] project. The data consists of a series of keywords and values
 defined at the beginning of a Markdown document, like this:
 
-```no-highlight
+```text
 Title:   My Document
 Summary: A brief description of my document.
 Authors: Waylan Limberg
@@ -471,7 +471,7 @@ only useful for simple tabular data.
 
 A simple table looks like this:
 
-```no-highlight
+```markdown
 First Header | Second Header | Third Header
 ------------ | ------------- | ------------
 Content Cell | Content Cell  | Content Cell
@@ -480,7 +480,7 @@ Content Cell | Content Cell  | Content Cell
 
 If you wish, you can add a leading and tailing pipe to each line of the table:
 
-```no-highlight
+```markdown
 | First Header | Second Header | Third Header |
 | ------------ | ------------- | ------------ |
 | Content Cell | Content Cell  | Content Cell |
@@ -489,7 +489,7 @@ If you wish, you can add a leading and tailing pipe to each line of the table:
 
 Specify alignment for each column by adding colons to separator lines:
 
-```no-highlight
+```markdown
 First Header | Second Header | Third Header
 :----------- |:-------------:| -----------:
 Left         | Center        | Right
@@ -513,7 +513,7 @@ blocks without indentation.
 The first line should contain 3 or more backtick (`` ` ``) characters, and the
 last line should contain the same number of backtick characters (`` ` ``):
 
-````no-highlight
+````markdown
 ```
 Fenced code blocks are like Standard
 Markdown’s regular code blocks, except that
@@ -526,7 +526,7 @@ code block.
 With this approach, the language can optionally be specified on the first line
 after the backticks which informs any syntax highlighters of the language used:
 
-````no-highlight
+````markdown
 ```python
 def fn():
     pass

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -251,9 +251,11 @@ can set in your `mkdocs.yml` configuration file to alter the default behavior:
     link text. When set to a string, the provided string is used as the link
     text. For example, to use the hash symbol (`#`) instead, do:
 
-        markdown_extensions:
-            - toc:
-                permalink: "#"
+    ```yaml
+    markdown_extensions:
+        - toc:
+            permalink: "#"
+    ```
 
 *   **`baselevel`**
 
@@ -264,9 +266,11 @@ can set in your `mkdocs.yml` configuration file to alter the default behavior:
     text for a page should not contain any headers higher than level 2 (`<h2>`),
     do:
 
-        markdown_extensions:
-            - toc:
-                baselevel: 2
+    ```yaml
+    markdown_extensions:
+        - toc:
+            baselevel: 2
+    ```
 
     Then any headers in your document would be increased by 1. For example, the
     header `# Header` would be rendered as a level 2 header (`<h2>`) in the HTML
@@ -279,9 +283,11 @@ can set in your `mkdocs.yml` configuration file to alter the default behavior:
     Character which replaces white-space in generated IDs. If you prefer
     underscores, then do:
 
-        markdown_extensions:
-            - toc:
-                separator: "_"
+    ```yaml
+    markdown_extensions:
+        - toc:
+            separator: "_"
+    ```
 
 Note that if you would like to define multiple of the above settings, you must
 do so under a single `toc` entry in the `markdown_extensions` configuration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,10 @@ markdown_extensions:
         permalink: 
     - attr_list
     - def_list
+    - pymdownx.highlight:
+        use_pygments: false
     - pymdownx.snippets
+    - pymdownx.superfences
     - callouts
     - mdx_gh_links:
         user: mkdocs

--- a/requirements/project-min.txt
+++ b/requirements/project-min.txt
@@ -1,7 +1,7 @@
 click==7.0
 Jinja2==2.11.1
 markupsafe==2.0.1
-Markdown==3.3
+Markdown==3.3.3
 PyYAML==5.1
 watchdog==2.0.0
 ghp-import==1.0
@@ -14,7 +14,7 @@ babel==2.9.0
 
 colorama==0.4; platform_system == 'Windows'
 mdx_gh_links==0.2
-markdown-callouts==0.2
+markdown-callouts==0.3.0
 mkdocs-literate-nav==0.5.0
 mkdocs-redirects==1.0.1
 pymdown-extensions==8.0.1

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -14,7 +14,7 @@ babel>=2.9.0
 
 colorama>=0.4; platform_system == 'Windows'
 mdx_gh_links>=0.2
-markdown-callouts>=0.2
+markdown-callouts>=0.3.0
 mkdocs-literate-nav>=0.5.0
 mkdocs-redirects>=1.0.1
 pymdown-extensions>=8.0.1


### PR DESCRIPTION
- Enable `<details>` admonitions and nested codeblocks
- Enforce fenced codeblocks in our docs
- Replace instances of ```no-highlight
