### PR TITLE
Refactor in preparation for ConfigOption schemas rework

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -138,16 +138,14 @@ class ListOfItems(BaseConfigOption):
 
 class ConfigItems(ListOfItems):
     """
-    Config Items Option
+    Deprecated: Use `ListOfItems(SubConfig(...))` instead of `ConfigItems(...)`.
 
     Validates a list of mappings that all must match the same set of
     options.
     """
 
-    def __init__(
-        self, *config_options: PlainConfigSchemaItem, required: bool = False, validate: bool = False
-    ):
-        super().__init__(SubConfig(*config_options, validate=validate))
+    def __init__(self, *config_options: PlainConfigSchemaItem, required: bool = False):
+        super().__init__(SubConfig(*config_options))
         self.required = required
 
 

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from mkdocs.config import base, config_options
+from mkdocs.config import base
+from mkdocs.config import config_options as c
 
 
 def get_schema() -> base.PlainConfigSchema:
@@ -11,117 +12,117 @@ def get_schema() -> base.PlainConfigSchema:
 # depend on others. So, if config option A depends on B, then A should be
 # listed higher in the schema.
 class _MkDocsConfig:
-    config_file_path = config_options.Type(str)
+    config_file_path = c.Type(str)
     """Reserved for internal use, stores the mkdocs.yml config file."""
 
-    site_name = config_options.Type(str, required=True)
+    site_name = c.Type(str, required=True)
     """The title to use for the documentation."""
 
-    nav = config_options.Nav()
+    nav = c.Nav()
     """Defines the structure of the navigation."""
-    pages = config_options.Deprecated(removed=True, moved_to='nav')
+    pages = c.Deprecated(removed=True, moved_to='nav')
 
-    site_url = config_options.URL(is_dir=True)
+    site_url = c.URL(is_dir=True)
     """The full URL to where the documentation will be hosted."""
 
-    site_description = config_options.Type(str)
+    site_description = c.Type(str)
     """A description for the documentation project that will be added to the
     HTML meta tags."""
-    site_author = config_options.Type(str)
+    site_author = c.Type(str)
     """The name of the author to add to the HTML meta tags."""
 
-    theme = config_options.Theme(default='mkdocs')
+    theme = c.Theme(default='mkdocs')
     """The MkDocs theme for the documentation."""
 
-    docs_dir = config_options.DocsDir(default='docs', exists=True)
+    docs_dir = c.DocsDir(default='docs', exists=True)
     """The directory containing the documentation markdown."""
 
-    site_dir = config_options.SiteDir(default='site')
+    site_dir = c.SiteDir(default='site')
     """The directory where the site will be built to"""
 
-    copyright = config_options.Type(str)
+    copyright = c.Type(str)
     """A copyright notice to add to the footer of documentation."""
 
-    google_analytics = config_options.Deprecated(
+    google_analytics = c.Deprecated(
         message=(
             'The configuration option {} has been deprecated and '
             'will be removed in a future release of MkDocs. See the '
             'options available on your theme for an alternative.'
         ),
-        option_type=config_options.Type(list, length=2),
+        option_type=c.Type(list, length=2),
     )
     """set of values for Google analytics containing the account IO and domain
     this should look like, ['UA-27795084-5', 'mkdocs.org']"""
 
-    dev_addr = config_options.IpAddress(default='127.0.0.1:8000')
+    dev_addr = c.IpAddress(default='127.0.0.1:8000')
     """The address on which to serve the live reloading docs server."""
 
-    use_directory_urls = config_options.Type(bool, default=True)
+    use_directory_urls = c.Type(bool, default=True)
     """If `True`, use `<page_name>/index.hmtl` style files with hyperlinks to
     the directory.If `False`, use `<page_name>.html style file with
     hyperlinks to the file.
     True generates nicer URLs, but False is useful if browsing the output on
     a filesystem."""
 
-    repo_url = config_options.URL()
+    repo_url = c.URL()
     """Specify a link to the project source repo to be included
     in the documentation pages."""
 
-    repo_name = config_options.RepoName('repo_url')
+    repo_name = c.RepoName('repo_url')
     """A name to use for the link to the project source repo.
     Default, If repo_url is unset then None, otherwise
     "GitHub", "Bitbucket" or "GitLab" for known url or Hostname
     for unknown urls."""
 
-    edit_uri_template = config_options.EditURITemplate('edit_uri')
-    edit_uri = config_options.EditURI('repo_url')
+    edit_uri_template = c.EditURITemplate('edit_uri')
+    edit_uri = c.EditURI('repo_url')
     """Specify a URI to the docs dir in the project source repo, relative to the
     repo_url. When set, a link directly to the page in the source repo will
     be added to the generated HTML. If repo_url is not set also, this option
     is ignored."""
 
-    extra_css = config_options.Type(list, default=[])
-    extra_javascript = config_options.Type(list, default=[])
+    extra_css = c.Type(list, default=[])
+    extra_javascript = c.Type(list, default=[])
     """Specify which css or javascript files from the docs directory should be
     additionally included in the site."""
 
-    extra_templates = config_options.Type(list, default=[])
+    extra_templates = c.Type(list, default=[])
     """Similar to the above, but each template (HTML or XML) will be build with
     Jinja2 and the global context."""
 
-    markdown_extensions = config_options.MarkdownExtensions(
+    markdown_extensions = c.MarkdownExtensions(
         builtins=['toc', 'tables', 'fenced_code'], configkey='mdx_configs'
     )
     """PyMarkdown extension names."""
 
-    mdx_configs = config_options.Private()
+    mdx_configs = c.Private()
     """PyMarkdown Extension Configs. For internal use only."""
 
-    strict = config_options.Type(bool, default=False)
+    strict = c.Type(bool, default=False)
     """Enabling strict mode causes MkDocs to stop the build when a problem is
     encountered rather than display an error."""
 
-    remote_branch = config_options.Type(str, default='gh-pages')
+    remote_branch = c.Type(str, default='gh-pages')
     """The remote branch to commit to when using gh-deploy."""
 
-    remote_name = config_options.Type(str, default='origin')
+    remote_name = c.Type(str, default='origin')
     """The remote name to push to when using gh-deploy."""
 
-    extra = config_options.SubConfig()
+    extra = c.SubConfig()
     """extra is a mapping/dictionary of data that is passed to the template.
     This allows template authors to require extra configuration that not
     relevant to all themes and doesn't need to be explicitly supported by
     MkDocs itself. A good example here would be including the current
     project version."""
 
-    plugins = config_options.Plugins(default=['search'])
+    plugins = c.Plugins(default=['search'])
     """A list of plugins. Each item may contain a string name or a key value pair.
     A key value pair should be the string name (as the key) and a dict of config
     options (as the value)."""
 
-    hooks = config_options.Hooks('plugins')
+    hooks = c.Hooks('plugins')
     """A list of filenames that will be imported as Python modules and used as
     an instance of a plugin each."""
 
-    watch = config_options.ListOfPaths(default=[])
+    watch = c.ListOfPaths(default=[])
     """A list of extra paths to watch while running `mkdocs serve`."""

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -5,7 +5,8 @@ import os
 from typing import Any, Dict
 
 from mkdocs import utils
-from mkdocs.config import base, config_options
+from mkdocs.config import base
+from mkdocs.config import config_options as c
 from mkdocs.config.base import Config
 from mkdocs.contrib.search.search_index import SearchIndex
 from mkdocs.plugins import BasePlugin
@@ -14,7 +15,7 @@ log = logging.getLogger(__name__)
 base_path = os.path.dirname(os.path.abspath(__file__))
 
 
-class LangOption(config_options.OptionallyRequired):
+class LangOption(c.OptionallyRequired):
     """Validate Language(s) provided in config are known languages."""
 
     def get_lunr_supported_lang(self, lang):
@@ -29,7 +30,7 @@ class LangOption(config_options.OptionallyRequired):
         if isinstance(value, str):
             value = [value]
         elif not isinstance(value, (list, tuple)):
-            raise config_options.ValidationError('Expected a list of language codes.')
+            raise c.ValidationError('Expected a list of language codes.')
         for lang in list(value):
             if lang != 'en':
                 lang_detected = self.get_lunr_supported_lang(lang)
@@ -47,10 +48,10 @@ class LangOption(config_options.OptionallyRequired):
 
 class _PluginConfig:
     lang = LangOption()
-    separator = config_options.Type(str, default=r'[\s\-]+')
-    min_search_length = config_options.Type(int, default=3)
-    prebuild_index = config_options.Choice((False, True, 'node', 'python'), default=False)
-    indexing = config_options.Choice(('full', 'sections', 'titles'), default='full')
+    separator = c.Type(str, default=r'[\s\-]+')
+    min_search_length = c.Type(int, default=3)
+    prebuild_index = c.Choice((False, True, 'node', 'python'), default=False)
+    indexing = c.Choice(('full', 'sections', 'titles'), default='full')
 
 
 class SearchPlugin(BasePlugin):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1252,6 +1252,8 @@ class SubConfigTest(TestCase):
         conf = self.get_config(Schema, {'option': {'cc': 'foo'}})
         self.assertEqual(conf['option'], {'cc': 'foo'})
 
+
+class ConfigItemsTest(TestCase):
     def test_subconfig_with_multiple_items(self):
         # This had a bug where subsequent items would get merged into the same dict.
         class Schema:
@@ -1270,13 +1272,13 @@ class SubConfigTest(TestCase):
         )
         self.assertEqual(conf['the_items'], [{'value': 'a'}, {'value': 'b'}])
 
-
-class ConfigItemsTest(TestCase):
     def test_optional(self):
         class Schema:
-            sub = c.ConfigItems(
-                ('opt', c.Type(int)),
-                validate=True,
+            sub = c.ListOfItems(
+                c.SubConfig(
+                    ('opt', c.Type(int)),
+                    validate=True,
+                )
             )
 
         conf = self.get_config(Schema, {})
@@ -1295,9 +1297,11 @@ class ConfigItemsTest(TestCase):
 
     def test_required(self):
         class Schema:
-            sub = c.ConfigItems(
-                ('opt', c.Type(int, required=True)),
-                validate=True,
+            sub = c.ListOfItems(
+                c.SubConfig(
+                    ('opt', c.Type(int, required=True)),
+                    validate=True,
+                )
             )
 
         conf = self.get_config(Schema, {})

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -5,7 +5,8 @@ import unittest
 
 import mkdocs
 from mkdocs import config
-from mkdocs.config import config_options, defaults
+from mkdocs.config import config_options as c
+from mkdocs.config import defaults
 from mkdocs.config.base import ValidationError
 from mkdocs.exceptions import ConfigurationError
 from mkdocs.localization import parse_locale
@@ -20,9 +21,9 @@ class ConfigTests(unittest.TestCase):
             config.load_config(config_file='bad_filename.yaml')
 
     def test_missing_site_name(self):
-        c = config.Config(schema=DEFAULT_SCHEMA)
-        c.load_dict({})
-        errors, warnings = c.validate()
+        conf = config.Config(schema=DEFAULT_SCHEMA)
+        conf.load_dict({})
+        errors, warnings = conf.validate()
         self.assertEqual(
             errors, [('site_name', ValidationError("Required configuration not provided."))]
         )
@@ -205,14 +206,14 @@ class ConfigTests(unittest.TestCase):
 
         for config_contents, result in zip(configs, results):
             with self.subTest(config_contents):
-                c = config.Config(schema=(('theme', config_options.Theme(default='mkdocs')),))
-                c.load_dict(config_contents)
-                errors, warnings = c.validate()
+                conf = config.Config(schema=(('theme', c.Theme(default='mkdocs')),))
+                conf.load_dict(config_contents)
+                errors, warnings = conf.validate()
                 self.assertEqual(errors, [])
                 self.assertEqual(warnings, [])
-                self.assertEqual(c['theme'].dirs, result['dirs'])
-                self.assertEqual(c['theme'].static_templates, set(result['static_templates']))
-                self.assertEqual({k: c['theme'][k] for k in iter(c['theme'])}, result['vars'])
+                self.assertEqual(conf['theme'].dirs, result['dirs'])
+                self.assertEqual(conf['theme'].static_templates, set(result['static_templates']))
+                self.assertEqual({k: conf['theme'][k] for k in iter(conf['theme'])}, result['vars'])
 
     def test_empty_nav(self):
         conf = config.Config(schema=DEFAULT_SCHEMA)
@@ -250,26 +251,25 @@ class ConfigTests(unittest.TestCase):
             {'docs_dir': 'docs', 'site_dir': 'docs'},
         )
 
-        conf = {
+        cfg = {
             'config_file_path': j(os.path.abspath('..'), 'mkdocs.yml'),
         }
 
         for test_config in test_configs:
             with self.subTest(test_config):
-                patch = conf.copy()
-                patch.update(test_config)
+                patch = {**cfg, **test_config}
 
                 # Same as the default schema, but don't verify the docs_dir exists.
-                c = config.Config(
+                conf = config.Config(
                     schema=(
-                        ('docs_dir', config_options.Dir(default='docs')),
-                        ('site_dir', config_options.SiteDir(default='site')),
-                        ('config_file_path', config_options.Type(str)),
+                        ('docs_dir', c.Dir(default='docs')),
+                        ('site_dir', c.SiteDir(default='site')),
+                        ('config_file_path', c.Type(str)),
                     )
                 )
-                c.load_dict(patch)
+                conf.load_dict(patch)
 
-                errors, warnings = c.validate()
+                errors, warnings = conf.validate()
 
                 self.assertEqual(len(errors), 1)
                 self.assertEqual(warnings, [])

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -7,16 +7,17 @@ from unittest import mock
 
 from mkdocs import config, plugins
 from mkdocs.commands import build
-from mkdocs.config import base, config_options
+from mkdocs.config import base
+from mkdocs.config import config_options as c
 from mkdocs.config.base import ValidationError
 from mkdocs.exceptions import Abort, BuildError, PluginError
 from mkdocs.tests.base import load_config
 
 
 class _DummyPluginConfig:
-    foo = config_options.Type(str, default='default foo')
-    bar = config_options.Type(int, default=0)
-    dir = config_options.Dir(exists=False)
+    foo = c.Type(str, default='default foo')
+    bar = c.Type(int, default=0)
+    dir = c.Dir(exists=False)
 
 
 class DummyPlugin(plugins.BasePlugin):
@@ -295,7 +296,7 @@ MockEntryPoint.configure_mock(**{'name': 'sample', 'load.return_value': DummyPlu
 class TestPluginConfig(unittest.TestCase):
     def test_plugin_config_without_options(self, mock_class):
         cfg = {'plugins': ['sample']}
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         cfg['plugins'] = option.validate(cfg['plugins'])
 
         self.assertIsInstance(cfg['plugins'], plugins.PluginCollection)
@@ -319,7 +320,7 @@ class TestPluginConfig(unittest.TestCase):
                 }
             ],
         }
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         cfg['plugins'] = option.validate(cfg['plugins'])
 
         self.assertIsInstance(cfg['plugins'], plugins.PluginCollection)
@@ -341,7 +342,7 @@ class TestPluginConfig(unittest.TestCase):
                 },
             },
         }
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         cfg['plugins'] = option.validate(cfg['plugins'])
 
         self.assertIsInstance(cfg['plugins'], plugins.PluginCollection)
@@ -356,7 +357,7 @@ class TestPluginConfig(unittest.TestCase):
 
     def test_plugin_config_empty_list_with_empty_default(self, mock_class):
         cfg = {'plugins': []}
-        option = config.config_options.Plugins(default=[])
+        option = c.Plugins(default=[])
         cfg['plugins'] = option.validate(cfg['plugins'])
 
         self.assertIsInstance(cfg['plugins'], plugins.PluginCollection)
@@ -365,7 +366,7 @@ class TestPluginConfig(unittest.TestCase):
     def test_plugin_config_empty_list_with_default(self, mock_class):
         # Default is ignored
         cfg = {'plugins': []}
-        option = config.config_options.Plugins(default=['sample'])
+        option = c.Plugins(default=['sample'])
         cfg['plugins'] = option.validate(cfg['plugins'])
 
         self.assertIsInstance(cfg['plugins'], plugins.PluginCollection)
@@ -373,7 +374,7 @@ class TestPluginConfig(unittest.TestCase):
 
     def test_plugin_config_none_with_empty_default(self, mock_class):
         cfg = {'plugins': None}
-        option = config.config_options.Plugins(default=[])
+        option = c.Plugins(default=[])
         cfg['plugins'] = option.validate(cfg['plugins'])
 
         self.assertIsInstance(cfg['plugins'], plugins.PluginCollection)
@@ -382,7 +383,7 @@ class TestPluginConfig(unittest.TestCase):
     def test_plugin_config_none_with_default(self, mock_class):
         # Default is used.
         cfg = {'plugins': None}
-        option = config.config_options.Plugins(default=['sample'])
+        option = c.Plugins(default=['sample'])
         cfg['plugins'] = option.validate(cfg['plugins'])
 
         self.assertIsInstance(cfg['plugins'], plugins.PluginCollection)
@@ -397,13 +398,13 @@ class TestPluginConfig(unittest.TestCase):
 
     def test_plugin_config_uninstalled(self, mock_class):
         cfg = {'plugins': ['uninstalled']}
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         with self.assertRaises(config.base.ValidationError):
             option.validate(cfg['plugins'])
 
     def test_plugin_config_not_list(self, mock_class):
         cfg = {'plugins': 'sample'}  # should be a list
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         with self.assertRaises(config.base.ValidationError):
             option.validate(cfg['plugins'])
 
@@ -419,7 +420,7 @@ class TestPluginConfig(unittest.TestCase):
                 }
             ],
         }
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         with self.assertRaises(config.base.ValidationError):
             option.validate(cfg['plugins'])
 
@@ -427,7 +428,7 @@ class TestPluginConfig(unittest.TestCase):
         cfg = {
             'plugins': [('not a string or dict',)],
         }
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         with self.assertRaises(config.base.ValidationError):
             option.validate(cfg['plugins'])
 
@@ -439,6 +440,6 @@ class TestPluginConfig(unittest.TestCase):
                 }
             ],
         }
-        option = config.config_options.Plugins()
+        option = c.Plugins()
         with self.assertRaises(config.base.ValidationError):
             option.validate(cfg['plugins'])


### PR DESCRIPTION
* Refactor: use config_options module through a short alias 'c' 

* Refactor config_option_tests to be more consistent

* Soft-deprecate ConfigItems instead of expanding it
    This undoes the addition of the `validate` parameter from ee844242d11c028e2eea3c07e468b36f1a45b68a.
    It is OK to do because this was not released yet.
