### PR TITLE
Add CLI reference page, auto-generated from Click

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -15,6 +15,7 @@ bar at the top of the page to move through the documentation in order.
 - [Customizing Your Theme](customizing-your-theme.md)
 - [Localizing Your Theme](localizing-your-theme.md)
 - [Configuration](configuration.md)
+- [Command Line Interface](cli.md)
 - [Deploying Your Docs](deploying-your-docs.md)
 
 [Getting Started]: ../getting-started.md

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -1,0 +1,8 @@
+# Command Line Interface
+
+::: mkdocs-click
+    :module: mkdocs.__main__
+    :command: cli
+    :prog_name: mkdocs
+    :style: table
+    :list_subcommands: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ markdown_extensions:
     - mdx_gh_links:
         user: mkdocs
         repo: mkdocs
+    - mkdocs-click
 
 copyright: Copyright &copy; 2014 <a href="https://twitter.com/_tomchristie">Tom Christie</a>, Maintained by the <a href="/about/release-notes/#maintenance-team">MkDocs Team</a>.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ dependencies = [
     "mkdocs-redirects >=1.0.1",
     "pymdown-extensions >=8.0.1",
     "mkdocstrings-python >=0.7.1",
+    "mkdocs-click >=0.8.0",
 ]
 
 [tool.black]


### PR DESCRIPTION
Preview: https://oprypin.github.io/mkdocs/user-guide/cli/

Closes #837
