### PR TITLE
Refactor plugin-related config options and error reporting

### DIFF
--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -51,7 +51,7 @@ class BaseConfigOption(Generic[T]):
     def default(self, value):
         self._default = value
 
-    def validate(self, value) -> T:
+    def validate(self, value: object) -> T:
         return self.run_validation(value)
 
     def reset_warnings(self) -> None:
@@ -64,7 +64,7 @@ class BaseConfigOption(Generic[T]):
         The pre-validation process method should be implemented by subclasses.
         """
 
-    def run_validation(self, value):
+    def run_validation(self, value: object):
         """
         Perform validation for a value.
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -956,18 +956,17 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
         if not isinstance(config, dict):
             raise ValidationError(f"Invalid config options for the '{name}' plugin.")
 
-        try:
-            plugin = self.plugin_cache[name]
-        except KeyError:
-            Plugin = self.installed_plugins[name].load()
+        plugin = self.plugin_cache.get(name)
+        if plugin is None:
+            plugin_cls = self.installed_plugins[name].load()
 
-            if not issubclass(Plugin, plugins.BasePlugin):
+            if not issubclass(plugin_cls, plugins.BasePlugin):
                 raise ValidationError(
-                    f'{Plugin.__module__}.{Plugin.__name__} must be a subclass of'
+                    f'{plugin_cls.__module__}.{plugin_cls.__name__} must be a subclass of'
                     f' {plugins.BasePlugin.__module__}.{plugins.BasePlugin.__name__}'
                 )
 
-            plugin = Plugin()
+            plugin = plugin_cls()
 
             if hasattr(plugin, 'on_startup') or hasattr(plugin, 'on_shutdown'):
                 self.plugin_cache[name] = plugin

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -946,7 +946,7 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
                 self.plugins[item] = self.load_plugin(item, cfg)
         return self.plugins
 
-    def load_plugin(self, name, config):
+    def load_plugin(self, name: str, config) -> plugins.BasePlugin:
         if not isinstance(name, str):
             raise ValidationError(f"'{name}' is not a valid plugin name.")
         if name not in self.installed_plugins:
@@ -972,7 +972,7 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
                 self.plugin_cache[name] = plugin
 
         errors, warnings = plugin.load_config(config, self.config_file_path)
-        self.warnings.extend(warnings)
+        self.warnings.extend(f"Plugin '{name}' value: '{x}'. Warning: {y}" for x, y in warnings)
         errors_message = '\n'.join(f"Plugin '{name}' value: '{x}'. Error: {y}" for x, y in errors)
         if errors_message:
             raise ValidationError(errors_message)

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -946,7 +946,7 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
         else:
             for item in value:
                 if isinstance(item, dict):
-                    if len(item) > 1:
+                    if len(item) != 1:
                         raise ValidationError('Invalid Plugins configuration')
                     name, cfg = item.popitem()
                 else:

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from collections import OrderedDict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -14,6 +13,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    MutableMapping,
     Optional,
     Tuple,
     Type,
@@ -461,7 +461,7 @@ def event_priority(priority: float) -> Callable[[T], T]:
     return decorator
 
 
-class PluginCollection(OrderedDict):
+class PluginCollection(dict, MutableMapping[str, BasePlugin]):
     """
     A collection of plugins.
 
@@ -480,8 +480,11 @@ class PluginCollection(OrderedDict):
             self.events[event_name], method, key=lambda m: -getattr(m, 'mkdocs_priority', 0)
         )
 
-    def __setitem__(self, key: str, value: BasePlugin, **kwargs) -> None:
-        super().__setitem__(key, value, **kwargs)
+    def __getitem__(self, key: str) -> BasePlugin:
+        return super().__getitem__(key)
+
+    def __setitem__(self, key: str, value: BasePlugin) -> None:
+        super().__setitem__(key, value)
         # Register all of the event methods defined for this Plugin.
         for event_name in (x for x in dir(value) if x.startswith('on_')):
             method = getattr(value, event_name, None)

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -976,9 +976,7 @@ class ThemeTest(TestCase):
         class Schema:
             option = c.Theme()
 
-        with self.expect_error(
-            option="At least one of 'option.name' or 'option.custom_dir' must be defined."
-        ):
+        with self.expect_error(option="At least one of 'name' or 'custom_dir' must be defined."):
             self.get_config(Schema, {'option': config})
 
     def test_theme_config_missing_name(self):
@@ -1028,9 +1026,7 @@ class ThemeTest(TestCase):
         class Schema:
             theme = c.Theme()
 
-        with self.expect_error(
-            theme="At least one of 'theme.name' or 'theme.custom_dir' must be defined."
-        ):
+        with self.expect_error(theme="At least one of 'name' or 'custom_dir' must be defined."):
             self.get_config(Schema, config)
 
     @tempdir()
@@ -1046,9 +1042,7 @@ class ThemeTest(TestCase):
         class Schema:
             theme = c.Theme()
 
-        with self.expect_error(
-            theme=f"The path set in theme.custom_dir ('{path}') does not exist."
-        ):
+        with self.expect_error(theme=f"The path set in custom_dir ('{path}') does not exist."):
             self.get_config(Schema, config)
 
     def test_post_validation_locale_none(self):
@@ -1062,7 +1056,7 @@ class ThemeTest(TestCase):
         class Schema:
             theme = c.Theme()
 
-        with self.expect_error(theme="'theme.locale' must be a string."):
+        with self.expect_error(theme="'locale' must be a string."):
             self.get_config(Schema, config)
 
     def test_post_validation_locale_invalid_type(self):
@@ -1076,7 +1070,7 @@ class ThemeTest(TestCase):
         class Schema:
             theme = c.Theme()
 
-        with self.expect_error(theme="'theme.locale' must be a string."):
+        with self.expect_error(theme="'locale' must be a string."):
             self.get_config(Schema, config)
 
     def test_post_validation_locale(self):

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -35,7 +35,7 @@ class TestCase(unittest.TestCase):
         self,
         schema: type,
         cfg: Dict[str, Any],
-        warnings={},
+        warnings: Dict[str, str] = {},
         config_file_path=None,
     ):
         config = base.LegacyConfig(base.get_schema(schema), config_file_path=config_file_path)
@@ -460,7 +460,7 @@ class URLTest(TestCase):
         class Schema:
             option = c.URL()
 
-        with self.expect_error(option="Unable to parse the URL."):
+        with self.expect_error(option="Expected a string, got <class 'int'>"):
             self.get_config(Schema, {'option': 1})
 
 
@@ -1235,7 +1235,7 @@ class SubConfigTest(TestCase):
         conf = self.get_config(
             Schema,
             {'option': {'unknown': 0}},
-            warnings=dict(option=('unknown', 'Unrecognised configuration name: unknown')),
+            warnings=dict(option="Sub-option 'unknown': Unrecognised configuration name: unknown"),
         )
         self.assertEqual(conf['option'], {"unknown": 0})
 
@@ -1592,7 +1592,7 @@ class MarkdownExtensionsTest(TestCase):
         self.assertIsNone(conf['mdx_configs'].get('toc'))
 
 
-class TestHooks(TestCase):
+class HooksTest(TestCase):
     class Schema:
         plugins = c.Plugins(default=[])
         hooks = c.Hooks('plugins')

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1011,9 +1011,7 @@ class ThemeTest(TestCase):
         class Schema(Config):
             option = c.Theme()
 
-        with self.expect_error(
-            option="At least one of 'option.name' or 'option.custom_dir' must be defined."
-        ):
+        with self.expect_error(option="At least one of 'name' or 'custom_dir' must be defined."):
             self.get_config(Schema, {'option': config})
 
     def test_theme_config_missing_name(self) -> None:
@@ -1063,9 +1061,7 @@ class ThemeTest(TestCase):
         class Schema(Config):
             theme = c.Theme()
 
-        with self.expect_error(
-            theme="At least one of 'theme.name' or 'theme.custom_dir' must be defined."
-        ):
+        with self.expect_error(theme="At least one of 'name' or 'custom_dir' must be defined."):
             self.get_config(Schema, config)
 
     @tempdir()
@@ -1081,9 +1077,7 @@ class ThemeTest(TestCase):
         class Schema(Config):
             theme = c.Theme()
 
-        with self.expect_error(
-            theme=f"The path set in theme.custom_dir ('{path}') does not exist."
-        ):
+        with self.expect_error(theme=f"The path set in custom_dir ('{path}') does not exist."):
             self.get_config(Schema, config)
 
     def test_post_validation_locale_none(self) -> None:
@@ -1097,7 +1091,7 @@ class ThemeTest(TestCase):
         class Schema(Config):
             theme = c.Theme()
 
-        with self.expect_error(theme="'theme.locale' must be a string."):
+        with self.expect_error(theme="'locale' must be a string."):
             self.get_config(Schema, config)
 
     def test_post_validation_locale_invalid_type(self) -> None:
@@ -1111,7 +1105,7 @@ class ThemeTest(TestCase):
         class Schema(Config):
             theme = c.Theme()
 
-        with self.expect_error(theme="'theme.locale' must be a string."):
+        with self.expect_error(theme="'locale' must be a string."):
             self.get_config(Schema, config)
 
     def test_post_validation_locale(self) -> None:

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1812,6 +1812,14 @@ class PluginsTest(TestCase):
         with self.expect_error(plugins="Invalid Plugins configuration"):
             self.get_config(Schema, cfg)
 
+        cfg = {
+            'plugins': [
+                {},
+            ],
+        }
+        with self.expect_error(plugins="Invalid Plugins configuration"):
+            self.get_config(Schema, cfg)
+
     def test_plugin_config_not_string_or_dict(self, mock_class) -> None:
         class Schema(Config):
             plugins = c.Plugins()


### PR DESCRIPTION
- Refactor Theme config option to use mainly run_validation
- Expand plugin testing
- Tighten warnings and type annotations in config_options
- Refactor plugin_cache usage to avoid nested exception
- Also tighten warnings of plugin configs
- Refactor `load_plugin` usage
- Better guard an edge case in plugin config
