### PR TITLE
Support theme-namespaced plugin loading

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -919,21 +919,23 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
     initializing the plugin class.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, theme_key: t.Optional[str] = None, **kwargs) -> None:
         super().__init__(**kwargs)
         self.installed_plugins = plugins.get_plugins()
-        self.config_file_path: t.Optional[str] = None
+        self.theme_key = theme_key
+        self._config: t.Optional[Config] = None
         self.plugin_cache: Dict[str, plugins.BasePlugin] = {}
 
-    def pre_validation(self, config: Config, key_name: str):
-        self.config_file_path = config.config_file_path
+    def pre_validation(self, config, key_name):
+        self._config = config
 
     def run_validation(self, value: object) -> plugins.PluginCollection:
         if not isinstance(value, (list, tuple, dict)):
             raise ValidationError('Invalid Plugins configuration. Expected a list or dict.')
         self.plugins = plugins.PluginCollection()
         for name, cfg in self._parse_configs(value):
-            self.plugins[name] = self.load_plugin(name, cfg)
+            name, plugin = self.load_plugin_with_namespace(name, cfg)
+            self.plugins[name] = plugin
         return self.plugins
 
     @classmethod
@@ -955,6 +957,21 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
                 if not isinstance(name, str):
                     raise ValidationError(f"'{name}' is not a valid plugin name.")
                 yield name, cfg
+
+    def load_plugin_with_namespace(self, name: str, config) -> Tuple[str, plugins.BasePlugin]:
+        if ':' in name:  # It's already specified with a namespace.
+            # Special case: allow to explicitly skip namespaced loading:
+            if name.startswith(':'):
+                name = name[1:]
+        else:
+            # Attempt to load with prepended namespace for the current theme.
+            if self.theme_key and self._config:
+                current_theme = self._config[self.theme_key].name
+                if current_theme:
+                    expanded_name = f'{current_theme}:{name}'
+                    if expanded_name in self.installed_plugins:
+                        name = expanded_name
+        return (name, self.load_plugin(name, config))
 
     def load_plugin(self, name: str, config) -> plugins.BasePlugin:
         if name not in self.installed_plugins:
@@ -979,7 +996,9 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
             if hasattr(plugin, 'on_startup') or hasattr(plugin, 'on_shutdown'):
                 self.plugin_cache[name] = plugin
 
-        errors, warnings = plugin.load_config(config, self.config_file_path)
+        errors, warnings = plugin.load_config(
+            config, self._config.config_file_path if self._config else None
+        )
         self.warnings.extend(f"Plugin '{name}' value: '{x}'. Warning: {y}" for x, y in warnings)
         errors_message = '\n'.join(f"Plugin '{name}' value: '{x}'. Error: {y}" for x, y in errors)
         if errors_message:

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -117,7 +117,7 @@ class MkDocsConfig(base.Config):
     MkDocs itself. A good example here would be including the current
     project version."""
 
-    plugins = c.Plugins(default=['search'])
+    plugins = c.Plugins(theme_key='theme', default=['search'])
     """A list of plugins. Each item may contain a string name or a key value pair.
     A key value pair should be the string name (as the key) and a dict of config
     options (as the value)."""


### PR DESCRIPTION
This is mainly aimed at 'material' theme which also ships plugins with it. It will be able to ship plugins under the name e.g. 'material:search' and it will ensure the following effects:

* If the current theme is 'material', the plugin 'material:search' will always be preferred over 'search'.
* If the current theme *isn't* 'material', the only way to use this plugin is by specifying `plugins: [material:search]`.

One can also specify `plugins: [':search']` instead of `plugins: ['search']` to definitely avoid the theme-namespaced plugin.

Previously:
* #2591

@squidfunk 