### PR TITLE
URL-encode paths when serving a redirect

### DIFF
--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -15,6 +15,7 @@ import socketserver
 import string
 import threading
 import time
+import urllib.parse
 import warnings
 import wsgiref.simple_server
 from typing import Any, Callable, Dict, Optional, Tuple
@@ -248,7 +249,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
             rel_file_path = posixpath.normpath("/" + rel_file_path).lstrip("/")
             file_path = os.path.join(self.root, rel_file_path)
         elif path == "/":
-            start_response("302 Found", [("Location", self.mount_path)])
+            start_response("302 Found", [("Location", urllib.parse.quote(self.mount_path))])
             return []
         else:
             return None  # Not found
@@ -262,7 +263,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
             file = open(file_path, "rb")
         except OSError:
             if not path.endswith("/") and os.path.isfile(os.path.join(file_path, "index.html")):
-                start_response("302 Found", [("Location", path + "/")])
+                start_response("302 Found", [("Location", urllib.parse.quote(path) + "/")])
                 return []
             return None  # Not found
 

--- a/mkdocs/tests/livereload_tests.py
+++ b/mkdocs/tests/livereload_tests.py
@@ -332,13 +332,23 @@ class BuildTests(unittest.TestCase):
                 headers, _ = do_request(server, "GET /foo/index.html/")
             self.assertEqual(headers["_status"], "404 Not Found")
 
-    @tempdir({"foo/bar/index.html": "<body>aaa</body>"})
+    @tempdir(
+        {
+            "foo/bar/index.html": "<body>aaa</body>",
+            "foo/測試/index.html": "<body>bbb</body>",
+        }
+    )
     def test_redirects_to_directory(self, site_dir):
         with testing_server(site_dir, mount_path="/sub") as server:
             with self.assertLogs("mkdocs.livereload"):
                 headers, _ = do_request(server, "GET /sub/foo/bar")
             self.assertEqual(headers["_status"], "302 Found")
             self.assertEqual(headers.get("location"), "/sub/foo/bar/")
+
+            with self.assertLogs("mkdocs.livereload"):
+                headers, _ = do_request(server, "GET /sub/foo/測試")
+            self.assertEqual(headers["_status"], "302 Found")
+            self.assertEqual(headers.get("location"), "/sub/foo/%E6%B8%AC%E8%A9%A6/")
 
     @tempdir({"я.html": "<body>aaa</body>", "测试2/index.html": "<body>bbb</body>"})
     def test_serves_with_unicode_characters(self, site_dir):
@@ -471,6 +481,14 @@ class BuildTests(unittest.TestCase):
                 headers, _ = do_request(server, "GET /")
             self.assertEqual(headers["_status"], "302 Found")
             self.assertEqual(headers.get("location"), "/mount/path/")
+
+    @tempdir()
+    def test_redirects_to_unicode_mount_path(self, site_dir):
+        with testing_server(site_dir, mount_path="/mount/測試") as server:
+            with self.assertLogs("mkdocs.livereload"):
+                headers, _ = do_request(server, "GET /")
+            self.assertEqual(headers["_status"], "302 Found")
+            self.assertEqual(headers.get("location"), "/mount/%E6%B8%AC%E8%A9%A6/")
 
     @tempdir({"mkdocs.yml": "original", "mkdocs2.yml": "original"}, prefix="tmp_dir")
     @tempdir(prefix="origin_dir")

--- a/mkdocs/tests/livereload_tests.py
+++ b/mkdocs/tests/livereload_tests.py
@@ -350,6 +350,11 @@ class BuildTests(unittest.TestCase):
             self.assertEqual(headers["_status"], "302 Found")
             self.assertEqual(headers.get("location"), "/sub/foo/%E6%B8%AC%E8%A9%A6/")
 
+            with self.assertLogs("mkdocs.livereload"):
+                headers, _ = do_request(server, "GET /sub/foo/%E6%B8%AC%E8%A9%A6")
+            self.assertEqual(headers["_status"], "302 Found")
+            self.assertEqual(headers.get("location"), "/sub/foo/%E6%B8%AC%E8%A9%A6/")
+
     @tempdir({"я.html": "<body>aaa</body>", "测试2/index.html": "<body>bbb</body>"})
     def test_serves_with_unicode_characters(self, site_dir):
         with testing_server(site_dir) as server:


### PR DESCRIPTION
When the `site_url` contains utf-8 characters (e.g. http://fake.domain/測試) and uses `mkdocs server` to serve doc, visiting localhost:8000 will cause wsgi encoding error when doing 302 redirects. The error log is as follows:

```
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/wsgiref/handlers.py", line 138, in run
    self.finish_response()
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/wsgiref/handlers.py", line 185, in finish_response
    self.finish_content()
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/wsgiref/handlers.py", line 324, in finish_content
    self.send_headers()
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/wsgiref/handlers.py", line 347, in send_headers
    self._write(bytes(self.headers))
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/wsgiref/headers.py", line 142, in __bytes__
    return str(self).encode('iso-8859-1')
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 11-12: ordinal not in range(256)
```

URL encoding those 302 paths could solve this issue. A minimal reproducible `mkdocs.yaml` is as follows:

```yaml
site_name: My Docs
site_url: http://fake.domain/測試
```