### PR TITLE
Correct capitalisation of "GitHub Pages"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ configuration file. Start by reading the [introductory tutorial], then check the
         <h3 class="card-title">Host anywhere</h3>
         <p class="card-text">
             MkDocs builds completely static HTML sites that you can host on
-            GitHub pages, Amazon S3, or <a
+            GitHub Pages, Amazon S3, or <a
             href="user-guide/deploying-your-docs/">anywhere</a> else you
             choose.
         </p>

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -309,7 +309,7 @@ As well as the Markdown source files, you can also include other file types in
 your documentation, which will be copied across when generating your
 documentation site. These might include images and other media.
 
-For example, if your project documentation needed to include a [GitHub pages
+For example, if your project documentation needed to include a [GitHub Pages
 CNAME file] and a PNG formatted screenshot image then your file layout might
 look as follows:
 
@@ -338,7 +338,7 @@ Cupcake indexer is a snazzy new project for indexing small cakes.
 Your image will now be embedded when you build the documentation, and should
 also be previewed if you're working on the documentation with a Markdown editor.
 
-[GitHub pages CNAME file]: https://help.github.com/articles/using-a-custom-domain-with-github-pages/
+[GitHub Pages CNAME file]: https://help.github.com/articles/using-a-custom-domain-with-github-pages/
 
 #### Linking from raw HTML
 

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -47,7 +47,7 @@ def _get_current_sha(repo_path) -> str:
 
 def _get_remote_url(remote_name: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     # No CNAME found.  We will use the origin URL to determine the GitHub
-    # pages location.
+    # Pages location.
     remote = f"remote.{remote_name}.url"
     proc = subprocess.Popen(
         ["git", "config", "--get", remote],
@@ -140,9 +140,9 @@ def gh_deploy(
         raise Abort('Deployment Aborted!')
 
     cname_file = os.path.join(config.site_dir, 'CNAME')
-    # Does this repository have a CNAME set for GitHub pages?
+    # Does this repository have a CNAME set for GitHub Pages?
     if os.path.isfile(cname_file):
-        # This GitHub pages repository has a CNAME configured.
+        # This GitHub Pages repository has a CNAME configured.
         with open(cname_file) as f:
             cname_host = f.read().strip()
         log.info(


### PR DESCRIPTION
To be consistent with GitHub's usage, and the use in MkDocs' documentation elsewhere.