### PR TITLE
increase version range for Markdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.7"
 dependencies = [
     "click >=7.0",
     "Jinja2 >=2.11.1",
-    "Markdown >=3.2.1, <3.4",
+    "Markdown >=3.2.1, <=3.4.1",
     "PyYAML >=5.1",
     "watchdog >=2.0",
     "ghp-import >=1.0",


### PR DESCRIPTION
Currently I am trying bump the version of mkdocs for nixpkgs (NixOS/nixpkgs/pull/203592). 

The version of the `Markdown` package on [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs) is slightly higher (v3.4.1) than the dependency range allows. 

Is it possible to increase it by one minor version? 

Currently I increase this range via patch file. I can tell that it works, at least for my documentation project.