### PR TITLE
fix: do not warn when "!include" used in mkdocs.yaml

### DIFF
--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -183,6 +183,11 @@ def get_navigation(files: Files, config: Union[MkDocsConfig, Mapping[str, Any]])
                 f"An absolute path to '{link.url}' is included in the 'nav' "
                 "configuration, which presumably points to an external resource."
             )
+        elif link.url.startswith('!include '):
+            log.debug(
+                f"'{link.url}' is included in the 'nav' "
+                "configuration, which presumably points to another valid mkdocs nav YAML."
+            )
         else:
             msg = (
                 f"A relative path to '{link.url}' is included in the 'nav' "


### PR DESCRIPTION
My `mkdocs.yaml` has

```yaml
---
nav:
- Reference:
  - Foo: foo.md
  - API: '!include ./api_mkdocs.yml'
```

Running `mkdocs build --strict` results in the warning

```
WARNING  -  A relative path to '!include ./api_mkdocs.yml' is included in the 'nav' configuration, which is not found in the documentation files
```

`api_mkdocs.yml` is present and is later included in the navigation correctly. I'd like to suppress this error for all `!include`. I'm using this library as a pre-commit hook [as implemented here](https://github.com/mkdocs/mkdocs/pull/2932). So this warning is causing my hook to fail.