### PR TITLE
Extract page title from Setext-style headers

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -382,7 +382,7 @@ specific page. The following keys are supported:
 
     1. A title defined in the [nav] configuration setting for a document.
     2. A title defined in the `title` meta-data key of a document.
-    3. A level 1 Markdown header on the first line of the document body. Please note that [Setext-style] headers are not supported.
+    3. A level 1 Markdown header on the first line of the document body.
     4. The filename of a document.
 
     Upon finding a title for a page, MkDoc does not continue checking any

--- a/mkdocs/tests/integration/setext/docs/setext-headers.md
+++ b/mkdocs/tests/integration/setext/docs/setext-headers.md
@@ -1,0 +1,17 @@
+Welcome to MkDocs
+=================
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+Commands
+--------
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs help` - Print this help message.
+
+Project layout
+--------------
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/mkdocs/tests/integration/setext/mkdocs.yml
+++ b/mkdocs/tests/integration/setext/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: MyTest
+
+nav:
+    - 'setext-headers.md'
+
+site_author: "Tom Christie & Dougal Matthews"

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -16,6 +16,10 @@ class PageTests(unittest.TestCase):
         os.path.abspath(os.path.dirname(__file__)), '../integration/subpages/docs'
     )
 
+    SETEXT_DOCS_DIR = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), '../integration/setext/docs'
+    )
+
     def test_homepage(self):
         cfg = load_config(docs_dir=self.DOCS_DIR)
         fl = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
@@ -277,7 +281,7 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.title, 'Page Title')
         self.assertEqual(pg.toc, [])
 
-    def test_page_title_from_markdown(self):
+    def test_page_title_from_atx_markdown(self):
         cfg = load_config()
         fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
         pg = Page(None, fl, cfg)
@@ -294,6 +298,30 @@ class PageTests(unittest.TestCase):
         self.assertFalse(pg.is_section)
         self.assertTrue(pg.is_top_level)
         self.assertTrue(pg.markdown.startswith('# Welcome to MkDocs\n'))
+        self.assertEqual(pg.meta, {})
+        self.assertEqual(pg.next_page, None)
+        self.assertEqual(pg.parent, None)
+        self.assertEqual(pg.previous_page, None)
+        self.assertEqual(pg.title, 'Welcome to MkDocs')
+        self.assertEqual(pg.toc, [])
+
+    def test_page_title_from_setext_markdown(self):
+        cfg = load_config(docs_dir=self.SETEXT_DOCS_DIR)
+        fl = File('setext-headers.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        pg = Page(None, fl, cfg)
+        pg.read_source(cfg)
+        self.assertEqual(pg.url, 'setext-headers/')
+        self.assertEqual(pg.abs_url, None)
+        self.assertEqual(pg.canonical_url, None)
+        self.assertEqual(pg.edit_url, None)
+        self.assertEqual(pg.file, fl)
+        self.assertEqual(pg.content, None)
+        self.assertFalse(pg.is_homepage)
+        self.assertFalse(pg.is_index)
+        self.assertTrue(pg.is_page)
+        self.assertFalse(pg.is_section)
+        self.assertTrue(pg.is_top_level)
+        self.assertTrue(pg.markdown.startswith('Welcome to MkDocs\n=='))
         self.assertEqual(pg.meta, {})
         self.assertEqual(pg.next_page, None)
         self.assertEqual(pg.parent, None)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -393,7 +393,7 @@ def get_markdown_title(markdown_src: str) -> Optional[str]:
     non-whitespace content. If it is a title, return that, otherwise return
     None.
     """
-    lines = markdown_src.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+    lines = markdown_src.splitlines()
     while lines:
         line = lines.pop(0).strip()
         if not line.strip():

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -396,11 +396,22 @@ def get_markdown_title(markdown_src: str) -> Optional[str]:
     lines = markdown_src.splitlines()
     while lines:
         line = lines.pop(0).strip()
-        if not line.strip():
+        if not line:
             continue
-        if not line.startswith('# '):
+
+        if line.startswith('# '):
+            return line.lstrip('# ')
+
+        try:
+            next_line = lines.pop(0)
+        except IndexError:
+            # Was last line in the document
             return None
-        return line.lstrip('# ')
+
+        if next_line.startswith('='):
+            return line
+        else:
+            return None
     return None
 
 


### PR DESCRIPTION
I've read Issues #1886 and #1826 and understand the reasoning for them being closed. This change is limited to the same logic as atx headers. Only the first line can be a title, and it must be an h1 header. It just adds improved support for the Markdown spec.