### PR TITLE
[Docs] Fix indents in the example code

### DIFF
--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -239,7 +239,7 @@ class MyPlugin(BasePlugin):
 > ```python
 > def on_config(self, config: MkDocsConfig):
 >     config.theme.static_templates.add('my_template.html')
->         return config
+>     return config
 > ```
 
 ### Events


### PR DESCRIPTION
> **Note**: This is a trivial typo, please see file changes for details.

The example was introduced in #2962. ([a4c1bb](https://github.com/mkdocs/mkdocs/commit/a4c1bb14dc42457a96ecaf11e450845d0c2d1dfe#diff-62543f71a205c3af3b9d2c99760cd073ac9b9dce3baaf0e66bbcebe651a59eedR173-R177) to be specific)

No idea why it wasn't aligned.