### PR TITLE
Add hooks to `sys.modules` because some Python features rely on this

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1057,6 +1057,7 @@ class Hooks(BaseConfigOption[List[types.ModuleType]]):
         if spec is None:
             raise ValidationError(f"Cannot import path '{path}' as a Python module")
         module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
         if spec.loader is None:
             raise ValidationError(f"Cannot import path '{path}' as a Python module")
         spec.loader.exec_module(module)


### PR DESCRIPTION
* Fixes #3141
