### PR TITLE
Copy warning about ignored default plugins in Using plugins section

### DIFF
--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -31,6 +31,16 @@ plugins:
     - search
 ```
 
+If the plugins config setting is defined in the mkdocs.yml config file,
+then any defaults (such as search) are ignored and you need to explicitly
+re-enable the defaults if you would like to continue using them:
+
+```yaml
+plugins:
+    - search
+    - your_other_plugin
+```
+
 Some plugins may provide configuration options of their own. If you would like
 to set any configuration options, then you can nest a key/value mapping
 (`option_name: option value`) of any options that a given plugin supports. Note


### PR DESCRIPTION
Closes https://github.com/mkdocs/mkdocs/pull/2319.

It's totally acceptable that we think this is just redundant, and risks to diverge at some point. I'll gladly close both PRs in that case.