### PR TITLE
Link to Best-of-MkDocs instead of Plugins wiki in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you need help with MkDocs, do not hesitate to get in contact with us!
 
 -   For questions and high-level discussions, use **[Discussions]** on GitHub.
     -   For small questions, a good alternative is the **[Chat room]** on
-        Gitter/Matrix (**new!**)
+        Gitter/Matrix.
 -   To report a bug or make a feature request, open an **[Issue]** on GitHub.
 
 Please note that we may only provide
@@ -44,8 +44,7 @@ Make sure to stick around to answer some questions as well!
 
 - [Official Documentation][mkdocs]
 - [Latest Release Notes][release-notes]
-- [MkDocs Wiki][wiki] (Third-party themes, recipes, plugins and more)
-- [Best-of-MkDocs][best-of] (Curated list of themes, plugins and more)
+- [Best-of-MkDocs][best-of] (Third-party themes, recipes, plugins and more)
 
 ## Contributing to MkDocs
 
@@ -71,10 +70,9 @@ discussion forums is expected to follow the [PyPA Code of Conduct].
 [Discussions]: https://github.com/mkdocs/mkdocs/discussions
 [Chat room]: https://gitter.im/mkdocs/community
 [release-notes]: https://www.mkdocs.org/about/release-notes/
-[wiki]: https://github.com/mkdocs/mkdocs/wiki
 [Contributing Guide]: https://www.mkdocs.org/about/contributing/
 [PyPA Code of Conduct]: https://www.pypa.io/en/latest/code-of-conduct/
-[best-of]: https://github.com/pawamoy/best-of-mkdocs
+[best-of]: https://github.com/mkdocs/best-of-mkdocs
 
 ## License
 

--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -16,8 +16,8 @@ pip install mkdocs-foo-plugin
 ```
 
 Once a plugin has been successfully installed, it is ready to use. It just needs
-to be [enabled](#using-plugins) in the configuration file. The [MkDocs Plugins]
-wiki page has a growing list of plugins that you can install and use.
+to be [enabled](#using-plugins) in the configuration file. The [Best-of-MkDocs]
+page has a large list of plugins that you can install and use.
 
 ## Using Plugins
 
@@ -519,5 +519,5 @@ tell MkDocs to use it via the config.
 [post_template]: #on_post_template
 [static_templates]: ../user-guide/configuration.md#static_templates
 [Template Events]: #template-events
-[MkDocs Plugins]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins
+[Best-of-MkDocs]: https://github.com/mkdocs/best-of-mkdocs
 [on_build_error]: #on_build_error

--- a/docs/dev-guide/themes.md
+++ b/docs/dev-guide/themes.md
@@ -6,8 +6,8 @@ A guide to creating and distributing custom themes.
 
 NOTE:
 If you are looking for existing third party themes, they are listed in the
-MkDocs [community wiki]. If you want to share a theme you create, you
-should list it on the Wiki.
+[community wiki] page and [Best-of-MkDocs]. If you want to share a theme you create, you
+should list it there.
 
 When creating a new theme, you can either follow the steps in this guide to
 create one from scratch or you can download the `mkdocs-basic-theme` as a
@@ -16,6 +16,7 @@ this base theme on [GitHub][basic theme]**. It contains detailed comments in
 the code to describe the different features and their usage.
 
 [community wiki]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
+[Best-of-MkDocs]: https://github.com/mkdocs/best-of-mkdocs#-theming
 [basic theme]: https://github.com/mkdocs/mkdocs-basic-theme
 
 ## Creating a custom theme

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,15 +27,14 @@ configuration file. Start by reading the [introductory tutorial], then check the
       <div class="card-body">
         <h3 class="card-title">Great themes available</h3>
         <p class="card-text">
-            There's a stack of good looking <a
-            href="user-guide/choosing-your-theme">themes</a> available for
-            MkDocs. Choose between the built in themes: <a
-            href="user-guide/choosing-your-theme/#mkdocs">mkdocs</a> and <a
-            href="user-guide/choosing-your-theme/#readthedocs">readthedocs</a>,
-            select one of the third-party themes listed on the <a
-            href="https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes">MkDocs
-            Themes</a> wiki page, or <a href="dev-guide/themes/">build your
-            own</a>.
+            There's a stack of good looking <a href="user-guide/choosing-your-theme">themes</a> available for MkDocs.
+            Choose between the built in themes:
+            <a href="user-guide/choosing-your-theme/#mkdocs">mkdocs</a> and
+            <a href="user-guide/choosing-your-theme/#readthedocs">readthedocs</a>,
+            select one of the third-party themes
+            (on the <a href="https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes">MkDocs Themes</a> wiki page
+            as well as <a href="https://github.com/mkdocs/best-of-mkdocs#-theming">Best-of-MkDocs</a>),
+            or <a href="dev-guide/themes/">build your own</a>.
         </p>
       </div>
     </div>

--- a/docs/user-guide/choosing-your-theme.md
+++ b/docs/user-guide/choosing-your-theme.md
@@ -218,8 +218,7 @@ theme supports the following options:
 
 ## Third Party Themes
 
-A list of third party themes can be found in the MkDocs [community wiki]. If you
-have created your own, please feel free to add it to the list.
+A list of third party themes can be found at the [community wiki] page and [Best-of-MkDocs]. If you have created your own, please add them there.
 
 [third party themes]: #third-party-themes
 [theme]: configuration.md#theme
@@ -230,4 +229,5 @@ have created your own, please feel free to add it to the list.
 [upgrade-GA4]: https://support.google.com/analytics/answer/9744165?hl=en&ref_topic=9303319
 [Read the Docs]: https://readthedocs.org/
 [community wiki]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
+[Best-of-MkDocs]: https://github.com/mkdocs/best-of-mkdocs#-theming
 [localizing your theme]: localizing-your-theme.md

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -575,7 +575,7 @@ This alternative syntax is required if you intend to override some options via
 > which are available out-of-the-box. For a list of configuration options
 > available for a given extension, see the documentation for that extension.
 >
-> You may also install and use various [third party extensions][3rd]. Consult
+> You may also install and use various third party extensions ([Python-Markdown wiki], [Best-of-MkDocs]). Consult
 > the documentation provided by those extensions for installation instructions
 > and available configuration options.
 
@@ -963,7 +963,8 @@ path based options in the primary configuration file only.
 [pymkd]: https://python-markdown.github.io/
 [smarty]: https://python-markdown.github.io/extensions/smarty/
 [exts]: https://python-markdown.github.io/extensions/
-[3rd]: https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions
+[Python-Markdown wiki]: https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions
+[Best-of-MkDocs]: https://github.com/mkdocs/best-of-mkdocs
 [configuring pages and navigation]: writing-your-docs.md#configure-pages-and-navigation
 [theme_dir]: customizing-your-theme.md#using-the-theme_dir
 [choosing your theme]: choosing-your-theme.md


### PR DESCRIPTION
* From https://github.com/mkdocs/mkdocs/discussions/2823

https://github.com/mkdocs/best-of-mkdocs
