### PR TITLE
Modernize type annotations using `pyupgrade`

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -4,7 +4,7 @@ import gzip
 import logging
 import os
 import time
-from typing import Any, Dict, Optional, Sequence, Set, Union
+from typing import Any, Sequence
 from urllib.parse import urlsplit
 
 import jinja2
@@ -23,7 +23,7 @@ class DuplicateFilter:
     """Avoid logging duplicate messages."""
 
     def __init__(self) -> None:
-        self.msgs: Set[str] = set()
+        self.msgs: set[str] = set()
 
     def __call__(self, record: logging.LogRecord) -> bool:
         rv = record.msg not in self.msgs
@@ -37,11 +37,11 @@ log.addFilter(DuplicateFilter())
 
 def get_context(
     nav: Navigation,
-    files: Union[Sequence[File], Files],
+    files: Sequence[File] | Files,
     config: MkDocsConfig,
-    page: Optional[Page] = None,
+    page: Page | None = None,
     base_url: str = '',
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Return the template context for a given page or template.
     """

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import subprocess
-from typing import Optional, Tuple, Union
 
 import ghp_import
 from packaging import version
@@ -45,7 +44,7 @@ def _get_current_sha(repo_path) -> str:
     return sha
 
 
-def _get_remote_url(remote_name: str) -> Union[Tuple[str, str], Tuple[None, None]]:
+def _get_remote_url(remote_name: str) -> tuple[str, str] | tuple[None, None]:
     # No CNAME found.  We will use the origin URL to determine the GitHub
     # Pages location.
     remote = f"remote.{remote_name}.url"
@@ -97,7 +96,7 @@ def _check_version(branch: str) -> None:
 
 def gh_deploy(
     config: MkDocsConfig,
-    message: Optional[str] = None,
+    message: str | None = None,
     force=False,
     no_history=False,
     ignore_version=False,

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -5,7 +5,6 @@ import logging
 import shutil
 import tempfile
 from os.path import isdir, isfile, join
-from typing import Optional
 from urllib.parse import urlsplit
 
 import jinja2.exceptions
@@ -59,7 +58,7 @@ def serve(
     live_server = livereload in ('dirty', 'livereload')
     dirty = livereload == 'dirty'
 
-    def builder(config: Optional[MkDocsConfig] = None):
+    def builder(config: MkDocsConfig | None = None):
         log.info("Building documentation...")
         if config is None:
             config = get_config()
@@ -87,7 +86,7 @@ def serve(
             builder=builder, host=host, port=port, root=site_dir, mount_path=mount_path(config)
         )
 
-        def error_handler(code) -> Optional[bytes]:
+        def error_handler(code) -> bytes | None:
             if code in (404, 500):
                 error_page = join(site_dir, f'{code}.html')
                 if isfile(error_page):

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -6,19 +6,7 @@ import os
 import sys
 from collections import UserDict
 from contextlib import contextmanager
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Generic,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import IO, TYPE_CHECKING, Generic, Iterator, List, Sequence, Tuple, TypeVar, overload
 
 from yaml import YAMLError
 
@@ -36,7 +24,7 @@ T = TypeVar('T')
 
 class BaseConfigOption(Generic[T]):
     def __init__(self) -> None:
-        self.warnings: List[str] = []
+        self.warnings: list[str] = []
         self.default = None
 
     @property
@@ -129,7 +117,7 @@ class Config(UserDict):
     """
 
     _schema: PlainConfigSchema
-    config_file_path: Optional[str]
+    config_file_path: str | None
 
     def __init_subclass__(cls):
         schema = dict(getattr(cls, '_schema', ()))
@@ -153,9 +141,9 @@ class Config(UserDict):
             return LegacyConfig(*args, **kwargs)
         return super().__new__(cls)
 
-    def __init__(self, config_file_path: Optional[Union[str, bytes]] = None):
+    def __init__(self, config_file_path: str | bytes | None = None):
         super().__init__()
-        self.user_configs: List[dict] = []
+        self.user_configs: list[dict] = []
         self.set_defaults()
 
         self._schema_keys = {k for k, v in self._schema}
@@ -176,7 +164,7 @@ class Config(UserDict):
         for key, config_option in self._schema:
             self[key] = config_option.default
 
-    def _validate(self) -> Tuple[ConfigErrors, ConfigWarnings]:
+    def _validate(self) -> tuple[ConfigErrors, ConfigWarnings]:
         failed: ConfigErrors = []
         warnings: ConfigWarnings = []
 
@@ -194,7 +182,7 @@ class Config(UserDict):
 
         return failed, warnings
 
-    def _pre_validate(self) -> Tuple[ConfigErrors, ConfigWarnings]:
+    def _pre_validate(self) -> tuple[ConfigErrors, ConfigWarnings]:
         failed: ConfigErrors = []
         warnings: ConfigWarnings = []
 
@@ -208,7 +196,7 @@ class Config(UserDict):
 
         return failed, warnings
 
-    def _post_validate(self) -> Tuple[ConfigErrors, ConfigWarnings]:
+    def _post_validate(self) -> tuple[ConfigErrors, ConfigWarnings]:
         failed: ConfigErrors = []
         warnings: ConfigWarnings = []
 
@@ -222,7 +210,7 @@ class Config(UserDict):
 
         return failed, warnings
 
-    def validate(self) -> Tuple[ConfigErrors, ConfigWarnings]:
+    def validate(self) -> tuple[ConfigErrors, ConfigWarnings]:
         failed, warnings = self._pre_validate()
 
         run_failed, run_warnings = self._validate()
@@ -278,13 +266,13 @@ class LegacyConfig(Config):
     A configuration object for plugins, as just a dict without type-safe attribute access.
     """
 
-    def __init__(self, schema: PlainConfigSchema, config_file_path: Optional[str] = None):
+    def __init__(self, schema: PlainConfigSchema, config_file_path: str | None = None):
         self._schema = tuple((k, v) for k, v in schema)  # Re-create just for validation
         super().__init__(config_file_path)
 
 
 @contextmanager
-def _open_config_file(config_file: Optional[Union[str, IO]]) -> Iterator[IO]:
+def _open_config_file(config_file: str | IO | None) -> Iterator[IO]:
     """
     A context manager which yields an open file descriptor ready to be read.
 
@@ -331,7 +319,7 @@ def _open_config_file(config_file: Optional[Union[str, IO]]) -> Iterator[IO]:
             result_config_file.close()
 
 
-def load_config(config_file: Optional[Union[str, IO]] = None, **kwargs) -> MkDocsConfig:
+def load_config(config_file: str | IO | None = None, **kwargs) -> MkDocsConfig:
     """
     Load the configuration for a given file object or name
 

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, List
 
 from mkdocs import utils
 from mkdocs.config import base
@@ -83,7 +83,7 @@ class SearchPlugin(BasePlugin[_PluginConfig]):
         "Create search index instance for later use."
         self.search_index = SearchIndex(**self.config)
 
-    def on_page_context(self, context: Dict[str, Any], **kwargs) -> None:
+    def on_page_context(self, context: dict[str, Any], **kwargs) -> None:
         "Add page to search index."
         self.search_index.add_entry_from_context(context['page'])
 

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -6,7 +6,6 @@ import os
 import re
 import subprocess
 from html.parser import HTMLParser
-from typing import List, Optional, Tuple
 
 from mkdocs.structure.pages import Page
 from mkdocs.structure.toc import AnchorLink, TableOfContents
@@ -28,10 +27,10 @@ class SearchIndex:
     """
 
     def __init__(self, **config) -> None:
-        self._entries: List[dict] = []
+        self._entries: list[dict] = []
         self.config = config
 
-    def _find_toc_by_id(self, toc, id_: Optional[str]) -> Optional[AnchorLink]:
+    def _find_toc_by_id(self, toc, id_: str | None) -> AnchorLink | None:
         """
         Given a table of contents and HTML ID, iterate through
         and return the matched item in the TOC.
@@ -44,7 +43,7 @@ class SearchIndex:
                 return toc_item_r
         return None
 
-    def _add_entry(self, title: Optional[str], text: str, loc: str) -> None:
+    def _add_entry(self, title: str | None, text: str, loc: str) -> None:
         """
         A simple wrapper to add an entry, dropping bad characters.
         """
@@ -148,9 +147,9 @@ class ContentSection:
 
     def __init__(
         self,
-        text: Optional[List[str]] = None,
-        id_: Optional[str] = None,
-        title: Optional[str] = None,
+        text: list[str] | None = None,
+        id_: str | None = None,
+        title: str | None = None,
     ) -> None:
         self.text = text or []
         self.id = id_
@@ -173,12 +172,12 @@ class ContentParser(HTMLParser):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.data: List[ContentSection] = []
-        self.section: Optional[ContentSection] = None
+        self.data: list[ContentSection] = []
+        self.section: ContentSection | None = None
         self.is_header_tag = False
-        self._stripped_html: List[str] = []
+        self._stripped_html: list[str] = []
 
-    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         """Called at the start of every HTML tag."""
 
         # We only care about the opening tag for headings.

--- a/mkdocs/localization.py
+++ b/mkdocs/localization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional, Sequence
+from typing import Sequence
 
 import jinja2
 from jinja2.ext import Extension, InternationalizationExtension
@@ -63,8 +63,8 @@ def install_translations(
 
 def _get_merged_translations(
     theme_dirs: Sequence[str], locales_dir: str, locale: Locale
-) -> Optional[Translations]:
-    merged_translations: Optional[Translations] = None
+) -> Translations | None:
+    merged_translations: Translations | None = None
 
     log.debug(f"Looking for translations for locale '{locale}'")
     if locale.territory:

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -6,20 +6,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    MutableMapping,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, Generic, MutableMapping, TypeVar, overload
 
 if sys.version_info >= (3, 10):
     from importlib.metadata import EntryPoint, entry_points
@@ -47,7 +34,7 @@ if TYPE_CHECKING:
 log = logging.getLogger('mkdocs.plugins')
 
 
-def get_plugins() -> Dict[str, EntryPoint]:
+def get_plugins() -> dict[str, EntryPoint]:
     """Return a dict of all installed Plugins as {name: EntryPoint}."""
 
     plugins = entry_points(group='mkdocs.plugins')
@@ -73,14 +60,14 @@ class BasePlugin(Generic[SomeConfig]):
     All plugins should subclass this class.
     """
 
-    config_class: Type[SomeConfig] = LegacyConfig  # type: ignore[assignment]
+    config_class: type[SomeConfig] = LegacyConfig  # type: ignore[assignment]
     config_scheme: PlainConfigSchema = ()
     config: SomeConfig = {}  # type: ignore[assignment]
 
     supports_multiple_instances: bool = False
     """Set to true in subclasses to declare support for adding the same plugin multiple times."""
 
-    def __class_getitem__(cls, config_class: Type[Config]):
+    def __class_getitem__(cls, config_class: type[Config]):
         """Eliminates the need to write `config_class = FooConfig` when subclassing BasePlugin[FooConfig]"""
         name = f'{cls.__name__}[{config_class.__name__}]'
         return type(name, (cls,), dict(config_class=config_class))
@@ -94,8 +81,8 @@ class BasePlugin(Generic[SomeConfig]):
             cls.config_scheme = cls.config_class._schema  # For compatibility.
 
     def load_config(
-        self, options: Dict[str, Any], config_file_path: Optional[str] = None
-    ) -> Tuple[ConfigErrors, ConfigWarnings]:
+        self, options: dict[str, Any], config_file_path: str | None = None
+    ) -> tuple[ConfigErrors, ConfigWarnings]:
         """Load config from a dict of options. Returns a tuple of (errors, warnings)."""
 
         if self.config_class is LegacyConfig:
@@ -145,7 +132,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     def on_serve(
         self, server: LiveReloadServer, *, config: MkDocsConfig, builder: Callable
-    ) -> Optional[LiveReloadServer]:
+    ) -> LiveReloadServer | None:
         """
         The `serve` event is only called when the `serve` command is used during
         development. It runs only once, after the first build finishes.
@@ -165,7 +152,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     # Global events
 
-    def on_config(self, config: MkDocsConfig) -> Optional[Config]:
+    def on_config(self, config: MkDocsConfig) -> Config | None:
         """
         The `config` event is the first event called on build and is run immediately
         after the user configuration is loaded and validated. Any alterations to the
@@ -188,7 +175,7 @@ class BasePlugin(Generic[SomeConfig]):
             config: global configuration object
         """
 
-    def on_files(self, files: Files, *, config: MkDocsConfig) -> Optional[Files]:
+    def on_files(self, files: Files, *, config: MkDocsConfig) -> Files | None:
         """
         The `files` event is called after the files collection is populated from the
         `docs_dir`. Use this event to add, remove, or alter files in the
@@ -205,9 +192,7 @@ class BasePlugin(Generic[SomeConfig]):
         """
         return files
 
-    def on_nav(
-        self, nav: Navigation, *, config: MkDocsConfig, files: Files
-    ) -> Optional[Navigation]:
+    def on_nav(self, nav: Navigation, *, config: MkDocsConfig, files: Files) -> Navigation | None:
         """
         The `nav` event is called after the site navigation is created and can
         be used to alter the site navigation.
@@ -224,7 +209,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     def on_env(
         self, env: jinja2.Environment, *, config: MkDocsConfig, files: Files
-    ) -> Optional[jinja2.Environment]:
+    ) -> jinja2.Environment | None:
         """
         The `env` event is called after the Jinja template environment is created
         and can be used to alter the
@@ -265,7 +250,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     def on_pre_template(
         self, template: jinja2.Template, *, template_name: str, config: MkDocsConfig
-    ) -> Optional[jinja2.Template]:
+    ) -> jinja2.Template | None:
         """
         The `pre_template` event is called immediately after the subject template is
         loaded and can be used to alter the template.
@@ -281,8 +266,8 @@ class BasePlugin(Generic[SomeConfig]):
         return template
 
     def on_template_context(
-        self, context: Dict[str, Any], *, template_name: str, config: MkDocsConfig
-    ) -> Optional[Dict[str, Any]]:
+        self, context: dict[str, Any], *, template_name: str, config: MkDocsConfig
+    ) -> dict[str, Any] | None:
         """
         The `template_context` event is called immediately after the context is created
         for the subject template and can be used to alter the context for that specific
@@ -300,7 +285,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     def on_post_template(
         self, output_content: str, *, template_name: str, config: MkDocsConfig
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         The `post_template` event is called after the template is rendered, but before
         it is written to disc and can be used to alter the output of the template.
@@ -319,7 +304,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     # Page events
 
-    def on_pre_page(self, page: Page, *, config: MkDocsConfig, files: Files) -> Optional[Page]:
+    def on_pre_page(self, page: Page, *, config: MkDocsConfig, files: Files) -> Page | None:
         """
         The `pre_page` event is called before any actions are taken on the subject
         page and can be used to alter the `Page` instance.
@@ -334,7 +319,7 @@ class BasePlugin(Generic[SomeConfig]):
         """
         return page
 
-    def on_page_read_source(self, *, page: Page, config: MkDocsConfig) -> Optional[str]:
+    def on_page_read_source(self, *, page: Page, config: MkDocsConfig) -> str | None:
         """
         The `on_page_read_source` event can replace the default mechanism to read
         the contents of a page's source from the filesystem.
@@ -351,7 +336,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     def on_page_markdown(
         self, markdown: str, *, page: Page, config: MkDocsConfig, files: Files
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         The `page_markdown` event is called after the page's markdown is loaded
         from file and can be used to alter the Markdown source text. The meta-
@@ -370,7 +355,7 @@ class BasePlugin(Generic[SomeConfig]):
 
     def on_page_content(
         self, html: str, *, page: Page, config: MkDocsConfig, files: Files
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         The `page_content` event is called after the Markdown text is rendered to
         HTML (but before being passed to a template) and can be used to alter the
@@ -388,8 +373,8 @@ class BasePlugin(Generic[SomeConfig]):
         return html
 
     def on_page_context(
-        self, context: Dict[str, Any], *, page: Page, config: MkDocsConfig, nav: Navigation
-    ) -> Optional[Dict[str, Any]]:
+        self, context: dict[str, Any], *, page: Page, config: MkDocsConfig, nav: Navigation
+    ) -> dict[str, Any] | None:
         """
         The `page_context` event is called after the context for a page is created
         and can be used to alter the context for that specific page only.
@@ -405,7 +390,7 @@ class BasePlugin(Generic[SomeConfig]):
         """
         return context
 
-    def on_post_page(self, output: str, *, page: Page, config: MkDocsConfig) -> Optional[str]:
+    def on_post_page(self, output: str, *, page: Page, config: MkDocsConfig) -> str | None:
         """
         The `post_page` event is called after the template is rendered, but
         before it is written to disc and can be used to alter the output of the
@@ -475,7 +460,7 @@ class PluginCollection(dict, MutableMapping[str, BasePlugin]):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.events: Dict[str, List[Callable]] = {k: [] for k in EVENTS}
+        self.events: dict[str, list[Callable]] = {k: [] for k in EVENTS}
 
     def _register_event(self, event_name: str, method: Callable) -> None:
         """Register a method for an event."""

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -6,18 +6,7 @@ import os
 import posixpath
 import shutil
 from pathlib import PurePath
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Sequence
 from urllib.parse import quote as urlquote
 
 import jinja2.environment
@@ -35,10 +24,10 @@ log = logging.getLogger(__name__)
 class Files:
     """A collection of [File][mkdocs.structure.files.File] objects."""
 
-    def __init__(self, files: List[File]) -> None:
+    def __init__(self, files: list[File]) -> None:
         self._files = files
-        self._src_uris: Optional[Dict[str, File]] = None
-        self._documentation_pages: Optional[Sequence[File]] = None
+        self._src_uris: dict[str, File] | None = None
+        self._documentation_pages: Sequence[File] | None = None
 
     def __iter__(self) -> Iterator[File]:
         """Iterate over the files within."""
@@ -53,19 +42,19 @@ class Files:
         return PurePath(path).as_posix() in self.src_uris
 
     @property
-    def src_paths(self) -> Dict[str, File]:
+    def src_paths(self) -> dict[str, File]:
         """Soft-deprecated, prefer `src_uris`."""
         return {file.src_path: file for file in self._files}
 
     @property
-    def src_uris(self) -> Dict[str, File]:
+    def src_uris(self) -> dict[str, File]:
         """A mapping containing every file, with the keys being their
         [`src_uri`][mkdocs.structure.files.File.src_uri]."""
         if self._src_uris is None:
             self._src_uris = {file.src_uri: file for file in self._files}
         return self._src_uris
 
-    def get_file_from_path(self, path: str) -> Optional[File]:
+    def get_file_from_path(self, path: str) -> File | None:
         """Return a File instance with File.src_uri equal to path."""
         return self.src_uris.get(PurePath(path).as_posix())
 
@@ -184,7 +173,7 @@ class File:
     def dest_path(self, value):
         self.dest_uri = PurePath(value).as_posix()
 
-    page: Optional[Page]
+    page: Page | None
 
     def __init__(
         self,
@@ -193,7 +182,7 @@ class File:
         dest_dir: str,
         use_directory_urls: bool,
         *,
-        dest_uri: Optional[str] = None,
+        dest_uri: str | None = None,
     ) -> None:
         self.page = None
         self.src_path = path
@@ -246,7 +235,7 @@ class File:
             url = (dirname or '.') + '/'
         return urlquote(url)
 
-    def url_relative_to(self, other: Union[File, str]) -> str:
+    def url_relative_to(self, other: File | str) -> str:
         """Return url for file relative to other file."""
         return utils.get_relative_url(self.url, other.url if isinstance(other, File) else other)
 
@@ -287,7 +276,7 @@ class File:
         return self.src_uri.endswith('.css')
 
 
-def get_files(config: Union[MkDocsConfig, Mapping[str, Any]]) -> Files:
+def get_files(config: MkDocsConfig | Mapping[str, Any]) -> Files:
     """Walk the `docs_dir` and return a Files collection."""
     files = []
     exclude = ['.*', '/templates']
@@ -320,7 +309,7 @@ def get_files(config: Union[MkDocsConfig, Mapping[str, Any]]) -> Files:
     return Files(files)
 
 
-def _sort_files(filenames: Iterable[str]) -> List[str]:
+def _sort_files(filenames: Iterable[str]) -> list[str]:
     """Always sort `index` or `README` as first filename in list."""
 
     def key(f):

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Iterator, List, Mapping, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Iterator, Mapping, TypeVar
 from urllib.parse import urlsplit
 
 from mkdocs.structure.files import Files
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 class Navigation:
-    def __init__(self, items: List[Union[Page, Section, Link]], pages: List[Page]) -> None:
+    def __init__(self, items: list[Page | Section | Link], pages: list[Page]) -> None:
         self.items = items  # Nested List with full navigation of Sections, Pages, and Links.
         self.pages = pages  # Flat List of subset of Pages in nav, in order.
 
@@ -26,16 +26,16 @@ class Navigation:
                 self.homepage = page
                 break
 
-    homepage: Optional[Page]
+    homepage: Page | None
     """The [page][mkdocs.structure.pages.Page] object for the homepage of the site."""
 
-    pages: List[Page]
+    pages: list[Page]
     """A flat list of all [page][mkdocs.structure.pages.Page] objects contained in the navigation."""
 
     def __repr__(self):
         return '\n'.join(item._indent_print() for item in self)
 
-    def __iter__(self) -> Iterator[Union[Page, Section, Link]]:
+    def __iter__(self) -> Iterator[Page | Section | Link]:
         return iter(self.items)
 
     def __len__(self) -> int:
@@ -43,7 +43,7 @@ class Navigation:
 
 
 class Section:
-    def __init__(self, title: str, children: List[Union[Page, Section, Link]]) -> None:
+    def __init__(self, title: str, children: list[Page | Section | Link]) -> None:
         self.title = title
         self.children = children
 
@@ -56,10 +56,10 @@ class Section:
     title: str
     """The title of the section."""
 
-    parent: Optional[Section]
+    parent: Section | None
     """The immediate parent of the section or `None` if the section is at the top level."""
 
-    children: List[Union[Page, Section, Link]]
+    children: list[Page | Section | Link]
     """An iterable of all child navigation objects. Children may include nested sections, pages and links."""
 
     @property
@@ -117,7 +117,7 @@ class Link:
     """The URL that the link points to. The URL should always be an absolute URLs and
     should not need to have `base_url` prepended."""
 
-    parent: Optional[Section]
+    parent: Section | None
     """The immediate parent of the link. `None` if the link is at the top level."""
 
     children: None = None
@@ -145,7 +145,7 @@ class Link:
         return '{}{}'.format('    ' * depth, repr(self))
 
 
-def get_navigation(files: Files, config: Union[MkDocsConfig, Mapping[str, Any]]) -> Navigation:
+def get_navigation(files: Files, config: MkDocsConfig | Mapping[str, Any]) -> Navigation:
     """Build site navigation from config and files."""
     nav_config = config['nav'] or nest_paths(f.src_uri for f in files.documentation_pages())
     items = _data_to_navigation(nav_config, files, config)
@@ -192,7 +192,7 @@ def get_navigation(files: Files, config: Union[MkDocsConfig, Mapping[str, Any]])
     return Navigation(items, pages)
 
 
-def _data_to_navigation(data, files: Files, config: Union[MkDocsConfig, Mapping[str, Any]]):
+def _data_to_navigation(data, files: Files, config: MkDocsConfig | Mapping[str, Any]):
     if isinstance(data, dict):
         return [
             _data_to_navigation((key, value), files, config)
@@ -217,7 +217,7 @@ def _data_to_navigation(data, files: Files, config: Union[MkDocsConfig, Mapping[
 T = TypeVar('T')
 
 
-def _get_by_type(nav, t: Type[T]) -> List[T]:
+def _get_by_type(nav, t: type[T]) -> list[T]:
     ret = []
     for item in nav:
         if isinstance(item, t):
@@ -235,7 +235,7 @@ def _add_parent_links(nav) -> None:
             _add_parent_links(item.children)
 
 
-def _add_previous_and_next_links(pages: List[Page]) -> None:
+def _add_previous_and_next_links(pages: list[Page]) -> None:
     bookended = [None, *pages, None]
     zipped = zip(bookended[:-2], pages, bookended[2:])
     for page0, page1, page2 in zipped:

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import posixpath
-from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from xml.etree.ElementTree import Element
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 
 class Page:
     def __init__(
-        self, title: Optional[str], file: File, config: Union[MkDocsConfig, Mapping[str, Any]]
+        self, title: str | None, file: File, config: MkDocsConfig | Mapping[str, Any]
     ) -> None:
         file.page = self
         self.file = file
@@ -69,13 +69,13 @@ class Page:
     def _indent_print(self, depth=0):
         return '{}{}'.format('    ' * depth, repr(self))
 
-    title: Optional[str]
+    title: str | None
     """Contains the Title for the current page."""
 
-    markdown: Optional[str]
+    markdown: str | None
     """The original Markdown content from the file."""
 
-    content: Optional[str]
+    content: str | None
     """The rendered Markdown as HTML, this is the contents of the documentation."""
 
     toc: TableOfContents
@@ -96,13 +96,13 @@ class Page:
     file: File
     """The documentation [`File`][mkdocs.structure.files.File] that the page is being rendered from."""
 
-    abs_url: Optional[str]
+    abs_url: str | None
     """The absolute URL of the page from the server root as determined by the value
     assigned to the [site_url][] configuration setting. The value includes any
     subdirectory included in the `site_url`, but not the domain. [base_url][] should
     not be used with this variable."""
 
-    canonical_url: Optional[str]
+    canonical_url: str | None
     """The full, canonical URL to the current page as determined by the value assigned
     to the [site_url][] configuration setting. The value includes the domain and any
     subdirectory included in the `site_url`. [base_url][] should not be used with this
@@ -128,7 +128,7 @@ class Page:
     def is_top_level(self) -> bool:
         return self.parent is None
 
-    edit_url: Optional[str]
+    edit_url: str | None
     """The full URL to the source page in the source repository. Typically used to
     provide a link to edit the source page. [base_url][] should not be used with this
     variable."""
@@ -138,17 +138,17 @@ class Page:
         """Evaluates to `True` for the homepage of the site and `False` for all other pages."""
         return self.is_top_level and self.is_index and self.file.url in ('.', './', 'index.html')
 
-    previous_page: Optional[Page]
+    previous_page: Page | None
     """The [page][mkdocs.structure.pages.Page] object for the previous page or `None`.
     The value will be `None` if the current page is the first item in the site navigation
     or if the current page is not included in the navigation at all."""
 
-    next_page: Optional[Page]
+    next_page: Page | None
     """The [page][mkdocs.structure.pages.Page] object for the next page or `None`.
     The value will be `None` if the current page is the last item in the site navigation
     or if the current page is not included in the navigation at all."""
 
-    parent: Optional[Section]
+    parent: Section | None
     """The immediate parent of the page in the site navigation. `None` if the
     page is at the top level."""
 
@@ -170,7 +170,7 @@ class Page:
             return []
         return [self.parent] + self.parent.ancestors
 
-    def _set_canonical_url(self, base: Optional[str]) -> None:
+    def _set_canonical_url(self, base: str | None) -> None:
         if base:
             if not base.endswith('/'):
                 base += '/'
@@ -182,9 +182,9 @@ class Page:
 
     def _set_edit_url(
         self,
-        repo_url: Optional[str],
-        edit_uri: Optional[str] = None,
-        edit_uri_template: Optional[str] = None,
+        repo_url: str | None,
+        edit_uri: str | None = None,
+        edit_uri_template: str | None = None,
     ) -> None:
         if edit_uri or edit_uri_template:
             src_uri = self.file.src_uri

--- a/mkdocs/structure/toc.py
+++ b/mkdocs/structure/toc.py
@@ -7,7 +7,7 @@ maintain compatibility with older versions of MkDocs.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 
 def get_toc(toc_tokens: list) -> TableOfContents:
@@ -56,7 +56,7 @@ class AnchorLink:
     level: int
     """The zero-based level of the item."""
 
-    children: List[AnchorLink]
+    children: list[AnchorLink]
     """An iterable of any child items."""
 
     def __str__(self):
@@ -70,7 +70,7 @@ class AnchorLink:
         return ret
 
 
-def _parse_toc_token(token: Dict[str, Any]) -> AnchorLink:
+def _parse_toc_token(token: dict[str, Any]) -> AnchorLink:
     anchor = AnchorLink(token['name'], token['id'], token['level'])
     for i in token['children']:
         anchor.children.append(_parse_toc_token(i))

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import os
 import textwrap

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import copy
 import io
@@ -6,7 +8,7 @@ import re
 import sys
 import textwrap
 import unittest
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import patch
 
 import mkdocs
@@ -34,8 +36,8 @@ class TestCase(unittest.TestCase):
     def get_config(
         self,
         schema: type,
-        cfg: Dict[str, Any],
-        warnings: Dict[str, str] = {},
+        cfg: dict[str, Any],
+        warnings: dict[str, str] = {},
         config_file_path=None,
     ):
         config = base.LegacyConfig(base.get_schema(schema), config_file_path=config_file_path)

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import copy
 import io
@@ -6,7 +8,7 @@ import re
 import sys
 import textwrap
 import unittest
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, List, Optional, TypeVar
 from unittest.mock import patch
 
 if TYPE_CHECKING:
@@ -45,9 +47,9 @@ class TestCase(unittest.TestCase):
 
     def get_config(
         self,
-        config_class: Type[SomeConfig],
-        cfg: Dict[str, Any],
-        warnings: Dict[str, str] = {},
+        config_class: type[SomeConfig],
+        cfg: dict[str, Any],
+        warnings: dict[str, str] = {},
         config_file_path=None,
     ) -> SomeConfig:
         config = config_class(config_file_path=config_file_path)
@@ -1829,7 +1831,7 @@ class PluginsTest(TestCase):
             theme = c.Theme(default='mkdocs')
             plugins = c.Plugins(theme_key='theme')
 
-        test_cfgs: List[Dict[str, Any]] = [
+        test_cfgs: list[dict[str, Any]] = [
             {
                 'theme': 'readthedocs',
                 'plugins': [{'sub_plugin': {}}, {'sample2': {}}, {'sub_plugin': {}}, 'sample2'],
@@ -1859,7 +1861,7 @@ class PluginsTest(TestCase):
         class Schema(Config):
             plugins = c.Plugins(default=[])
 
-        cfg: Dict[str, Any] = {'plugins': []}
+        cfg: dict[str, Any] = {'plugins': []}
         conf = self.get_config(Schema, cfg)
 
         self.assertIsInstance(conf.plugins, PluginCollection)
@@ -1870,7 +1872,7 @@ class PluginsTest(TestCase):
             plugins = c.Plugins(default=['sample'])
 
         # Default is ignored
-        cfg: Dict[str, Any] = {'plugins': []}
+        cfg: dict[str, Any] = {'plugins': []}
         conf = self.get_config(Schema, cfg)
 
         self.assertIsInstance(conf.plugins, PluginCollection)

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import annotations
 
 import os
 import unittest

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
 import jinja2
 
@@ -29,7 +29,7 @@ class Theme:
 
     """
 
-    def __init__(self, name: Optional[str] = None, **user_config) -> None:
+    def __init__(self, name: str | None = None, **user_config) -> None:
         self.name = name
         self._vars = {'name': name, 'locale': 'en'}
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -17,21 +17,7 @@ import warnings
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import PurePath
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Any,
-    Collection,
-    Dict,
-    Iterable,
-    List,
-    MutableSequence,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import IO, TYPE_CHECKING, Any, Collection, Iterable, MutableSequence, TypeVar
 from urllib.parse import urlsplit
 
 if sys.version_info >= (3, 10):
@@ -77,7 +63,7 @@ def get_yaml_loader(loader=yaml.Loader):
     return Loader
 
 
-def yaml_load(source: Union[IO, str], loader: Optional[Type[yaml.Loader]] = None) -> Dict[str, Any]:
+def yaml_load(source: IO | str, loader: type[yaml.Loader] | None = None) -> dict[str, Any]:
     """Return dict of source YAML file using loader, recursively deep merging inherited parent."""
     Loader = loader or get_yaml_loader()
     result = yaml.load(source, Loader=Loader)
@@ -145,7 +131,7 @@ def get_build_date() -> str:
     return get_build_datetime().strftime('%Y-%m-%d')
 
 
-def reduce_list(data_set: Iterable[T]) -> List[T]:
+def reduce_list(data_set: Iterable[T]) -> list[T]:
     """Reduce duplicate items in a list and preserve order"""
     return list(dict.fromkeys(data_set))
 
@@ -260,7 +246,7 @@ def is_error_template(path: str) -> bool:
 
 
 @functools.lru_cache(maxsize=None)
-def _norm_parts(path: str) -> List[str]:
+def _norm_parts(path: str) -> list[str]:
     if not path.startswith('/'):
         path = '/' + path
     path = posixpath.normpath(path)[1:]
@@ -295,7 +281,7 @@ def get_relative_url(url: str, other: str) -> str:
     return relurl + '/' if url.endswith('/') else relurl
 
 
-def normalize_url(path: str, page: Optional[Page] = None, base: str = '') -> str:
+def normalize_url(path: str, page: Page | None = None, base: str = '') -> str:
     """Return a URL relative to the given page or using the base."""
     path, relative_level = _get_norm_url(path)
     if relative_level == -1:
@@ -310,7 +296,7 @@ def normalize_url(path: str, page: Optional[Page] = None, base: str = '') -> str
 
 
 @functools.lru_cache(maxsize=None)
-def _get_norm_url(path: str) -> Tuple[str, int]:
+def _get_norm_url(path: str) -> tuple[str, int]:
     if not path:
         path = '.'
     elif '\\' in path:
@@ -333,8 +319,8 @@ def _get_norm_url(path: str) -> Tuple[str, int]:
 
 
 def create_media_urls(
-    path_list: Iterable[str], page: Optional[Page] = None, base: str = ''
-) -> List[str]:
+    path_list: Iterable[str], page: Page | None = None, base: str = ''
+) -> list[str]:
     """
     Return a list of URLs relative to the given page or using the base.
     """
@@ -353,11 +339,11 @@ def get_theme_dir(name: str) -> str:
     return os.path.dirname(os.path.abspath(theme.load().__file__))
 
 
-def get_themes() -> Dict[str, EntryPoint]:
+def get_themes() -> dict[str, EntryPoint]:
     """Return a dict of all installed themes as {name: EntryPoint}."""
 
-    themes: Dict[str, EntryPoint] = {}
-    eps: Dict[EntryPoint, None] = dict.fromkeys(entry_points(group='mkdocs.themes'))
+    themes: dict[str, EntryPoint] = {}
+    eps: dict[EntryPoint, None] = dict.fromkeys(entry_points(group='mkdocs.themes'))
     builtins = {ep.name for ep in eps if ep.dist is not None and ep.dist.name == 'mkdocs'}
 
     for theme in eps:
@@ -398,7 +384,7 @@ def dirname_to_title(dirname: str) -> str:
     return title
 
 
-def get_markdown_title(markdown_src: str) -> Optional[str]:
+def get_markdown_title(markdown_src: str) -> str | None:
     """
     Get the title of a Markdown document. The title in this case is considered
     to be a H1 that occurs before any other content in the document.
@@ -460,7 +446,7 @@ class CountHandler(logging.NullHandler):
     """Counts all logged messages >= level."""
 
     def __init__(self, **kwargs) -> None:
-        self.counts: Dict[int, int] = defaultdict(int)
+        self.counts: dict[int, int] = defaultdict(int)
         super().__init__(**kwargs)
 
     def handle(self, record):
@@ -470,7 +456,7 @@ class CountHandler(logging.NullHandler):
             self.counts[record.levelno] += 1
         return rv
 
-    def get_counts(self) -> List[Tuple[str, int]]:
+    def get_counts(self) -> list[tuple[str, int]]:
         return [(logging.getLevelName(k), v) for k, v in sorted(self.counts.items(), reverse=True)]
 
 

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -35,7 +35,7 @@ Extracts, parses and transforms MultiMarkdown style data from documents.
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import yaml
 
@@ -53,7 +53,7 @@ META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
 META_MORE_RE = re.compile(r'^([ ]{4}|\t)(\s*)(?P<value>.*)')
 
 
-def get_data(doc: str) -> Tuple[str, Dict[str, Any]]:
+def get_data(doc: str) -> tuple[str, dict[str, Any]]:
     """
     Extract meta-data from a text document.
 


### PR DESCRIPTION
* https://peps.python.org/pep-0563/ - Postponed Evaluation of Annotations
* https://peps.python.org/pep-0585/ - Type Hinting Generics In Standard Collections
* https://peps.python.org/pep-0604/ - Allow writing union types as `X | Y`