### PR TITLE
Un-pin upper version of Python-Markdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.7"
 dependencies = [
     "click >=7.0",
     "Jinja2 >=2.11.1",
-    "Markdown >=3.2.1, <3.4",
+    "Markdown >=3.2.1",
     "PyYAML >=5.1",
     "watchdog >=2.0",
     "ghp-import >=1.0",


### PR DESCRIPTION
* Closes #3214
* Reverts #2893

Perhaps it is time to let the hell break loose in the next release. A few projects probably still remain broken with the new version of Markdown, but this indiscriminate pinning might even be the worse tradeoff.
