### PR TITLE
New `exclude_docs` config: gitignore-like patterns of files to exclude

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
-max-line-length = 119
-extend-ignore = E203
+extend-ignore = E501, E203

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -310,7 +310,7 @@ exclude_docs: |
 
 This follows the [.gitignore pattern format](https://git-scm.com/docs/gitignore#_pattern_format).
 
-Note that `mkdocs serve` does *not* follow this setting and instead displays excluded documents but with a "DRAFT" mark.
+Note that `mkdocs serve` does *not* follow this setting and instead displays excluded documents but with a "DRAFT" mark. To prevent this effect, you can run `mkdocs serve --clean`.
 
 The following defaults are always implicitly prepended - to exclude dot-files (and directories) as well as the top-level `templates` directory:
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -310,6 +310,8 @@ exclude_docs: |
 
 This follows the [.gitignore pattern format](https://git-scm.com/docs/gitignore#_pattern_format).
 
+Note that `mkdocs serve` does *not* follow this setting and instead displays excluded documents but with a "DRAFT" mark.
+
 The following defaults are always implicitly prepended - to exclude dot-files (and directories) as well as the top-level `templates` directory:
 
 ```yaml
@@ -326,6 +328,31 @@ Otherwise you could for example opt only certain dot-files back into the site:
 exclude_docs: |
     !.assets  # Don't exclude '.assets' although all other '.*' are excluded
 ```
+
+### not_in_nav
+
+NEW: **New in version 1.5.**
+
+NOTE: This option does *not* actually exclude anything from the nav.
+
+If you want to include some docs into the site but intentionally exclude them from the nav, normally MkDocs warns about this.
+
+Adding such patterns of files (relative to [`docs_dir`](#docs_dir)) into the `not_in_nav` config will prevent such warnings.
+
+Example:
+
+```yaml
+nav:
+    - Foo: foo.md
+    - Bar: bar.md
+
+not_in_nav: |
+    /private.md
+```
+
+As the previous option, this follows the .gitignore pattern format.
+
+NOTE: Adding a given file to [`exclude_docs`](#exclude_docs) takes precedence over and implies `not_in_nav`.
 
 ## Build directories
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -291,6 +291,42 @@ server root and effectively points to `https://example.com/bugs/`. Of course, th
 list of all the Markdown files found within the `docs_dir` and its
 sub-directories. Index files will always be listed first within a sub-section.
 
+### exclude_docs
+
+NEW: **New in version 1.5.**
+
+This config defines patterns of files (under [`docs_dir`](#docs_dir)) to not be picked up into the built site.
+
+Example:
+
+```yaml
+exclude_docs: |
+    api-config.json    # A file with this name anywhere.
+    drafts/            # A "drafts" directory anywhere.
+    /requirements.txt  # Top-level "docs/requirements.txt".
+    *.py               # Any file with this extension anywhere.
+    !/foo/example.py   # But keep this particular file.
+```
+
+This follows the [.gitignore pattern format](https://git-scm.com/docs/gitignore#_pattern_format).
+
+The following defaults are always implicitly prepended - to exclude dot-files (and directories) as well as the top-level `templates` directory:
+
+```yaml
+exclude_docs: |
+    .*
+    /templates/
+```
+
+So, in order to really start this config fresh, you'd need to specify a negated version of these entries first.
+
+Otherwise you could for example opt only certain dot-files back into the site:
+
+```yaml
+exclude_docs: |
+    !.assets  # Don't exclude '.assets' although all other '.*' are excluded
+```
+
 ## Build directories
 
 ### theme

--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -27,10 +27,7 @@ extensions may be used for your Markdown source files: `markdown`, `mdown`,
 directory will be rendered in the built site regardless of any settings.
 
 NOTE:
-Files and directories with names which begin with a dot (for example:
-`.foo.md` or `.bar/baz.md`) are ignored by MkDocs, which matches the
-behavior of most web servers. There is no option to override this
-behavior.
+Files and directories with names which begin with a dot (for example: `.foo.md` or `.bar/baz.md`) are ignored by MkDocs. This can be overridden with the [`exclude_docs` config](configuration.md#exclude_docs).
 
 You can also create multi-page documentation, by creating several Markdown
 files:

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -111,8 +111,9 @@ site_dir_help = "The directory to output the result of the documentation build."
 use_directory_urls_help = "Use directory URLs when building pages (the default)."
 reload_help = "Enable the live reloading in the development server (this is the default)"
 no_reload_help = "Disable the live reloading in the development server."
-dirty_reload_help = (
-    "Enable the live reloading in the development server, but only re-build files that have changed"
+serve_dirty_help = "Only re-build files that have changed."
+serve_clean_help = (
+    "Build the site without any effects of `mkdocs serve` - pure `mkdocs build`, then serve."
 )
 commit_message_help = (
     "A commit message to use when committing to the "
@@ -201,7 +202,7 @@ PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-@click.group(context_settings={'help_option_names': ['-h', '--help']})
+@click.group(context_settings=dict(help_option_names=['-h', '--help'], max_content_width=120))
 @click.version_option(
     __version__,
     '-V',
@@ -217,21 +218,23 @@ def cli():
 
 @cli.command(name="serve")
 @click.option('-a', '--dev-addr', help=dev_addr_help, metavar='<IP:PORT>')
-@click.option('--livereload', 'livereload', flag_value='livereload', help=reload_help, default=True)
+@click.option('--livereload', 'livereload', flag_value='livereload', default=True, hidden=True)
 @click.option('--no-livereload', 'livereload', flag_value='no-livereload', help=no_reload_help)
-@click.option('--dirtyreload', 'livereload', flag_value='dirty', help=dirty_reload_help)
+@click.option('--dirtyreload', 'build_type', flag_value='dirty', hidden=True)
+@click.option('--dirty', 'build_type', flag_value='dirty', help=serve_dirty_help)
+@click.option('-c', '--clean', 'build_type', flag_value='clean', help=serve_clean_help)
 @click.option('--watch-theme', help=watch_theme_help, is_flag=True)
 @click.option(
     '-w', '--watch', help=watch_help, type=click.Path(exists=True), multiple=True, default=[]
 )
 @common_config_options
 @common_options
-def serve_command(dev_addr, livereload, watch, **kwargs):
+def serve_command(**kwargs):
     """Run the builtin development server"""
     from mkdocs.commands import serve
 
     _enable_warnings()
-    serve.serve(dev_addr=dev_addr, livereload=livereload, watch=watch, **kwargs)
+    serve.serve(**kwargs)
 
 
 @cli.command(name="build")

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -46,6 +46,10 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
 
 
 def _enable_warnings():
+    from mkdocs.commands import build
+
+    build.log.addFilter(utils.DuplicateFilter())
+
     warnings.simplefilter('module', DeprecationWarning)
     warnings.showwarning = _showwarning
 

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -17,22 +17,9 @@ from mkdocs.exceptions import Abort, BuildError
 from mkdocs.structure.files import File, Files, InclusionLevel, _set_exclusions, get_files
 from mkdocs.structure.nav import Navigation, get_navigation
 from mkdocs.structure.pages import Page
-
-
-class DuplicateFilter:
-    """Avoid logging duplicate messages."""
-
-    def __init__(self) -> None:
-        self.msgs: set[str] = set()
-
-    def __call__(self, record: logging.LogRecord) -> bool:
-        rv = record.msg not in self.msgs
-        self.msgs.add(record.msg)
-        return rv
-
+from mkdocs.utils import DuplicateFilter  # noqa - legacy re-export
 
 log = logging.getLogger(__name__)
-log.addFilter(DuplicateFilter())
 
 
 def get_context(

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -28,6 +28,8 @@ from urllib.parse import quote as urlquote
 from urllib.parse import urlsplit, urlunsplit
 
 import markdown
+import pathspec
+import pathspec.gitignore
 
 from mkdocs import plugins, theme, utils
 from mkdocs.config.base import (
@@ -1061,3 +1063,15 @@ class Hooks(BaseConfigOption[List[types.ModuleType]]):
         plugins = config[self.plugins_key]
         for name, hook in config[key_name].items():
             plugins[name] = hook
+
+
+class PathSpec(BaseConfigOption[pathspec.gitignore.GitIgnoreSpec]):
+    """A path pattern based on gitignore-like syntax."""
+
+    def run_validation(self, value: object) -> pathspec.gitignore.GitIgnoreSpec:
+        if not isinstance(value, str):
+            raise ValidationError(f'Expected a multiline string, but a {type(value)} was given.')
+        try:
+            return pathspec.gitignore.GitIgnoreSpec.from_lines(lines=value.splitlines())
+        except ValueError as e:
+            raise ValidationError(str(e))

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -26,6 +26,9 @@ class MkDocsConfig(base.Config):
     """Defines the structure of the navigation."""
     pages = c.Deprecated(removed=True, moved_to='nav')
 
+    exclude_docs = c.Optional(c.PathSpec())
+    """Gitignore-like patterns of files (relative to docs dir) to exclude from the site."""
+
     site_url = c.Optional(c.URL(is_dir=True))
     """The full URL to where the documentation will be hosted."""
 

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -29,6 +29,9 @@ class MkDocsConfig(base.Config):
     exclude_docs = c.Optional(c.PathSpec())
     """Gitignore-like patterns of files (relative to docs dir) to exclude from the site."""
 
+    not_in_nav = c.Optional(c.PathSpec())
+    """Gitignore-like patterns of files (relative to docs dir) that are not intended to be in the nav."""
+
     site_url = c.Optional(c.URL(is_dir=True))
     """The full URL to where the documentation will be hosted."""
 

--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -70,7 +70,6 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
         mount_path: str = "/",
         polling_interval: float = 0.5,
         shutdown_delay: float = 0.25,
-        **kwargs,
     ) -> None:
         self.builder = builder
         self.server_name = host
@@ -88,7 +87,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
         # To allow custom error pages.
         self.error_handler: Callable[[int], bytes | None] = lambda code: None
 
-        super().__init__((host, port), _Handler, **kwargs)
+        super().__init__((host, port), _Handler, bind_and_activate=False)
         self.set_app(self.serve_request)
 
         self._wanted_epoch = _timestamp()  # The version of the site that started building.
@@ -151,15 +150,21 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
             self.observer.unschedule(self._watch_refs.pop(path))
 
     def serve(self):
-        self.observer.start()
+        try:
+            self.server_bind()
+            self.server_activate()
 
-        paths_str = ", ".join(f"'{_try_relativize_path(path)}'" for path in self._watched_paths)
-        log.info(f"Watching paths for changes: {paths_str}")
+            self.observer.start()
 
-        log.info(f"Serving on {self.url}")
-        self.serve_thread.start()
+            paths_str = ", ".join(f"'{_try_relativize_path(path)}'" for path in self._watched_paths)
+            log.info(f"Watching paths for changes: {paths_str}")
 
-        self._build_loop()
+            log.info(f"Serving on {self.url}")
+            self.serve_thread.start()
+
+            self._build_loop()
+        finally:
+            self.server_close()
 
     def _build_loop(self):
         while True:

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -110,7 +110,7 @@ class BasePlugin(Generic[SomeConfig]):
 
         Parameters:
             command: the command that MkDocs was invoked with, e.g. "serve" for `mkdocs serve`.
-            dirty: whether `--dirtyreload` or `--dirty` flags were passed.
+            dirty: whether `--dirty` flag was passed.
         """
 
     def on_shutdown(self) -> None:

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -27,7 +27,6 @@ class Files:
     def __init__(self, files: list[File]) -> None:
         self._files = files
         self._src_uris: dict[str, File] | None = None
-        self._documentation_pages: Sequence[File] | None = None
 
     def __iter__(self) -> Iterator[File]:
         """Iterate over the files within."""
@@ -60,12 +59,12 @@ class Files:
 
     def append(self, file: File) -> None:
         """Append file to Files collection."""
-        self._src_uris = self._documentation_pages = None
+        self._src_uris = None
         self._files.append(file)
 
     def remove(self, file: File) -> None:
         """Remove file from Files collection."""
-        self._src_uris = self._documentation_pages = None
+        self._src_uris = None
         self._files.remove(file)
 
     def copy_static_files(self, dirty: bool = False) -> None:
@@ -76,9 +75,7 @@ class Files:
 
     def documentation_pages(self) -> Sequence[File]:
         """Return iterable of all Markdown page file objects."""
-        if self._documentation_pages is None:
-            self._documentation_pages = [file for file in self if file.is_documentation_page()]
-        return self._documentation_pages
+        return [file for file in self if file.is_documentation_page()]
 
     def static_pages(self) -> Sequence[File]:
         """Return iterable of all static page file objects."""

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import fnmatch
 import logging
 import os
@@ -7,7 +8,7 @@ import posixpath
 import shutil
 import warnings
 from pathlib import PurePath
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, Sequence
 from urllib.parse import quote as urlquote
 
 import jinja2.environment
@@ -23,6 +24,32 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+class InclusionLevel(enum.Enum):
+    Excluded = -2
+    """The file is excluded from the final site, but will still be populated during `mkdocs serve`."""
+    NotInNav = -1
+    """The file is part of the site, but doesn't produce nav warnings."""
+    Undefined = 0
+    """Still needs to be computed based on the config. If the config doesn't kick in, acts the same as `included`."""
+    Included = 1
+    """The file is part of the site. Documentation pages that are omitted from the nav will produce warnings."""
+
+    def all(self):
+        return True
+
+    def is_included(self):
+        return self.value > self.Excluded.value
+
+    def is_excluded(self):
+        return self.value <= self.Excluded.value
+
+    def is_in_nav(self):
+        return self.value > self.NotInNav.value
+
+    def is_not_in_nav(self):
+        return self.value <= self.NotInNav.value
 
 
 class Files:
@@ -71,15 +98,22 @@ class Files:
         self._src_uris = None
         self._files.remove(file)
 
-    def copy_static_files(self, dirty: bool = False) -> None:
+    def copy_static_files(
+        self,
+        dirty: bool = False,
+        *,
+        inclusion: Callable[[InclusionLevel], bool] = InclusionLevel.is_included,
+    ) -> None:
         """Copy static files from source to destination."""
         for file in self:
-            if not file.is_documentation_page():
+            if not file.is_documentation_page() and inclusion(file.inclusion):
                 file.copy_file(dirty)
 
-    def documentation_pages(self) -> Sequence[File]:
+    def documentation_pages(
+        self, *, inclusion: Callable[[InclusionLevel], bool] = InclusionLevel.is_included
+    ) -> Sequence[File]:
         """Return iterable of all Markdown page file objects."""
-        return [file for file in self if file.is_documentation_page()]
+        return [file for file in self if file.is_documentation_page() and inclusion(file.inclusion)]
 
     def static_pages(self) -> Sequence[File]:
         """Return iterable of all static page file objects."""
@@ -156,6 +190,9 @@ class File:
     url: str
     """The URI of the destination file relative to the destination directory as a string."""
 
+    inclusion: InclusionLevel
+    """Whether the file will be excluded from the built site."""
+
     @property
     def src_path(self) -> str:
         """Same as `src_uri` (and synchronized with it) but will use backslashes on Windows. Discouraged."""
@@ -184,6 +221,7 @@ class File:
         use_directory_urls: bool,
         *,
         dest_uri: str | None = None,
+        inclusion: InclusionLevel = InclusionLevel.Undefined,
     ) -> None:
         self.page = None
         self.src_path = path
@@ -194,6 +232,7 @@ class File:
         self.url = self._get_url(use_directory_urls)
         self.abs_src_path = os.path.normpath(os.path.join(src_dir, self.src_uri))
         self.abs_dest_path = os.path.normpath(os.path.join(dest_dir, self.dest_uri))
+        self.inclusion = inclusion
 
     def __eq__(self, other) -> bool:
         return (
@@ -280,16 +319,32 @@ class File:
 _default_exclude = pathspec.gitignore.GitIgnoreSpec.from_lines(['.*', '/templates/'])
 
 
+def _set_exclusions(files: Iterable[File], config: MkDocsConfig | Mapping[str, Any]) -> None:
+    """Re-calculate which files are excluded, based on the patterns in the config."""
+    exclude: pathspec.gitignore.GitIgnoreSpec | None = config.get('exclude_docs')
+    exclude = _default_exclude + exclude if exclude else _default_exclude
+    nav_exclude: pathspec.gitignore.GitIgnoreSpec | None = config.get('not_in_nav')
+
+    for file in files:
+        if file.inclusion == InclusionLevel.Undefined:
+            if exclude.match_file(file.src_uri):
+                file.inclusion = InclusionLevel.Excluded
+            elif nav_exclude and nav_exclude.match_file(file.src_uri):
+                file.inclusion = InclusionLevel.NotInNav
+            else:
+                file.inclusion = InclusionLevel.Included
+
+
 def get_files(config: MkDocsConfig | Mapping[str, Any]) -> Files:
     """Walk the `docs_dir` and return a Files collection."""
-    exclude = config.get('exclude_docs')
-    exclude = _default_exclude + exclude if exclude else _default_exclude
-    files = []
+    files: list[File] = []
+    conflicting_files: list[tuple[File, File]] = []
     for source_dir, dirnames, filenames in os.walk(config['docs_dir'], followlinks=True):
         relative_dir = os.path.relpath(source_dir, config['docs_dir'])
         dirnames.sort()
         filenames.sort(key=_file_sort_key)
 
+        files_by_dest: dict[str, File] = {}
         for filename in filenames:
             file = File(
                 os.path.join(relative_dir, filename),
@@ -297,26 +352,31 @@ def get_files(config: MkDocsConfig | Mapping[str, Any]) -> Files:
                 config['site_dir'],
                 config['use_directory_urls'],
             )
-            # Skip any excluded files
-            if exclude.match_file(file.src_uri):
-                continue
-            # Skip README.md if an index file also exists in dir
-            if filename == 'README.md' and 'index.md' in filenames:
-                log.warning(
-                    f"Excluding '{file.src_uri}' from the site because "
-                    f"it conflicts with 'index.md' in the same directory."
-                )
-                continue
+            # Skip README.md if an index file also exists in dir (part 1)
+            prev_file = files_by_dest.setdefault(file.dest_uri, file)
+            if prev_file is not file:
+                conflicting_files.append((prev_file, file))
             files.append(file)
+            prev_file = file
+
+    _set_exclusions(files, config)
+    # Skip README.md if an index file also exists in dir (part 2)
+    for a, b in conflicting_files:
+        if b.inclusion.is_included():
+            if a.inclusion.is_included():
+                log.warning(
+                    f"Excluding '{a.src_uri}' from the site because it conflicts with '{b.src_uri}'."
+                )
+            files.remove(a)
+        else:
+            files.remove(b)
 
     return Files(files)
 
 
 def _file_sort_key(f: str):
     """Always sort `index` or `README` as first filename in list."""
-    if os.path.splitext(f)[0] in ('index', 'README'):
-        return (0,)
-    return (1, f)
+    return (os.path.splitext(f)[0] not in ('index', 'README'), f)
 
 
 def _sort_files(filenames: Iterable[str]) -> list[str]:

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -330,6 +330,11 @@ class _RelativePathTreeprocessor(Treeprocessor):
                 f"'{target_uri}' which is not found in the documentation files."
             )
             return url
+        if target_file.inclusion.is_excluded():
+            log.info(
+                f"Documentation file '{self.file.src_uri}' contains a link to "
+                f"'{target_uri}' which is excluded from the built site."
+            )
         path = target_file.url_relative_to(self.file)
         components = (scheme, netloc, path, query, fragment)
         return urlunsplit(components)

--- a/mkdocs/tests/base.py
+++ b/mkdocs/tests/base.py
@@ -34,6 +34,8 @@ def load_config(**cfg) -> MkDocsConfig:
     if 'docs_dir' not in cfg:
         # Point to an actual dir to avoid a 'does not exist' error on validation.
         cfg['docs_dir'] = os.path.join(path_base, 'docs')
+    if 'plugins' not in cfg:
+        cfg['plugins'] = []
     conf = MkDocsConfig(config_file_path=cfg['config_file_path'])
     conf.load_dict(cfg)
 
@@ -123,20 +125,8 @@ class PathAssertionMixin:
             msg = self._formatMessage(None, f"The path '{path}' is not a file that exists")
             raise self.failureException(msg)
 
-    def assertPathNotFile(self, *parts):
-        path = os.path.join(*parts)
-        if os.path.isfile(path):
-            msg = self._formatMessage(None, f"The path '{path}' is a file that exists")
-            raise self.failureException(msg)
-
     def assertPathIsDir(self, *parts):
         path = os.path.join(*parts)
         if not os.path.isdir(path):
             msg = self._formatMessage(None, f"The path '{path}' is not a directory that exists")
-            raise self.failureException(msg)
-
-    def assertPathNotDir(self, *parts):
-        path = os.path.join(*parts)
-        if os.path.isfile(path):
-            msg = self._formatMessage(None, f"The path '{path}' is a directory that exists")
             raise self.failureException(msg)

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -22,6 +22,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -53,6 +54,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr='0.0.0.0:80',
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -69,6 +71,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=True,
             theme=None,
@@ -87,6 +90,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme='readthedocs',
@@ -105,6 +109,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -123,6 +128,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -139,6 +145,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -155,6 +162,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='no-livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme=None,
@@ -165,12 +173,13 @@ class CLITests(unittest.TestCase):
 
     @mock.patch('mkdocs.commands.serve.serve', autospec=True)
     def test_serve_dirtyreload(self, mock_serve):
-        result = self.runner.invoke(cli.cli, ["serve", '--dirtyreload'], catch_exceptions=False)
+        result = self.runner.invoke(cli.cli, ["serve", '--dirty'], catch_exceptions=False)
 
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
-            livereload='dirty',
+            livereload='livereload',
+            build_type='dirty',
             config_file=None,
             strict=None,
             theme=None,
@@ -187,6 +196,7 @@ class CLITests(unittest.TestCase):
         mock_serve.assert_called_once_with(
             dev_addr=None,
             livereload='livereload',
+            build_type=None,
             config_file=None,
             strict=None,
             theme=None,

--- a/mkdocs/tests/livereload_tests.py
+++ b/mkdocs/tests/livereload_tests.py
@@ -38,7 +38,6 @@ def testing_server(root, builder=lambda: None, mount_path="/"):
             root=root,
             mount_path=mount_path,
             polling_interval=0.2,
-            bind_and_activate=False,
         )
         server.setup_environ()
     server.observer.start()

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -265,27 +265,27 @@ class TestPluginCollection(unittest.TestCase):
                 build_errors.append(error)
 
         cfg = load_config(site_dir=site_dir)
-        cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='pre_page')
+        cfg.plugins['errorplugin'] = PluginRaisingError(error_on='pre_page')
         with self.assertLogs('mkdocs', level='ERROR'):
             self.assertRaises(Abort, build.build, cfg)
 
         cfg = load_config(site_dir=site_dir)
-        cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='page_markdown')
+        cfg.plugins['errorplugin'] = PluginRaisingError(error_on='page_markdown')
         with self.assertLogs('mkdocs', level='ERROR'):
             self.assertRaises(Abort, build.build, cfg)
 
         cfg = load_config(site_dir=site_dir)
-        cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='page_content')
+        cfg.plugins['errorplugin'] = PluginRaisingError(error_on='page_content')
         with self.assertLogs('mkdocs', level='ERROR'):
             self.assertRaises(Abort, build.build, cfg)
 
         cfg = load_config(site_dir=site_dir)
-        cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='post_page')
+        cfg.plugins['errorplugin'] = PluginRaisingError(error_on='post_page')
         with self.assertLogs('mkdocs', level='ERROR'):
             self.assertRaises(ValueError, build.build, cfg)
 
         cfg = load_config(site_dir=site_dir)
-        cfg['plugins']['errorplugin'] = PluginRaisingError(error_on='')
+        cfg.plugins['errorplugin'] = PluginRaisingError(error_on='')
         build.build(cfg)
 
         self.assertEqual(len(build_errors), 4)

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -476,8 +476,8 @@ class SearchIndexTests(unittest.TestCase):
                 self.assertEqual(errors, [])
                 self.assertEqual(warnings, [])
 
-                base_cfg = load_config()
-                base_cfg['plugins']['search'].config.indexing = option
+                base_cfg = load_config(plugins=['search'])
+                base_cfg.plugins['search'].config.indexing = option
 
                 pages = [
                     test_page('Home', 'index.md', base_cfg),

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 from unittest import mock
 
-from mkdocs.structure.files import File, Files, _filter_paths, _sort_files, get_files
+from mkdocs.structure.files import File, Files, _sort_files, get_files
 from mkdocs.tests.base import PathAssertionMixin, load_config, tempdir
 
 
@@ -427,34 +427,6 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
             os.path.normpath(os.path.join(ddir, 'favicon.ico')),
         )
 
-    def test_filter_paths(self):
-        # Root level file
-        self.assertFalse(_filter_paths('foo.md', 'foo.md', False, ['bar.md']))
-        self.assertTrue(_filter_paths('foo.md', 'foo.md', False, ['foo.md']))
-
-        # Nested file
-        self.assertFalse(_filter_paths('foo.md', 'baz/foo.md', False, ['bar.md']))
-        self.assertTrue(_filter_paths('foo.md', 'baz/foo.md', False, ['foo.md']))
-
-        # Wildcard
-        self.assertFalse(_filter_paths('foo.md', 'foo.md', False, ['*.txt']))
-        self.assertTrue(_filter_paths('foo.md', 'foo.md', False, ['*.md']))
-
-        # Root level dir
-        self.assertFalse(_filter_paths('bar', 'bar', True, ['/baz']))
-        self.assertFalse(_filter_paths('bar', 'bar', True, ['/baz/']))
-        self.assertTrue(_filter_paths('bar', 'bar', True, ['/bar']))
-        self.assertTrue(_filter_paths('bar', 'bar', True, ['/bar/']))
-
-        # Nested dir
-        self.assertFalse(_filter_paths('bar', 'foo/bar', True, ['/bar']))
-        self.assertFalse(_filter_paths('bar', 'foo/bar', True, ['/bar/']))
-        self.assertTrue(_filter_paths('bar', 'foo/bar', True, ['bar/']))
-
-        # Files that look like dirs (no extension). Note that `is_dir` is `False`.
-        self.assertFalse(_filter_paths('bar', 'bar', False, ['bar/']))
-        self.assertFalse(_filter_paths('bar', 'foo/bar', False, ['bar/']))
-
     def test_get_relative_url_use_directory_urls(self):
         to_files = [
             'index.md',
@@ -661,7 +633,6 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         files = get_files(config)
         expected = ['index.md', 'bar.css', 'bar.html', 'bar.jpg', 'bar.js', 'bar.md', 'readme.md']
         self.assertIsInstance(files, Files)
-        self.assertEqual(len(files), len(expected))
         self.assertEqual([f.src_path for f in files], expected)
 
     @tempdir(
@@ -675,7 +646,6 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         files = get_files(config)
         expected = ['README.md', 'foo.md']
         self.assertIsInstance(files, Files)
-        self.assertEqual(len(files), len(expected))
         self.assertEqual([f.src_path for f in files], expected)
 
     @tempdir(
@@ -691,11 +661,11 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
             files = get_files(config)
         self.assertRegex(
             '\n'.join(cm.output),
-            r"^WARNING:mkdocs.structure.files:Both index.md and README.md found. Skipping README.md .+$",
+            r"^WARNING:mkdocs.structure.files:"
+            r"Excluding 'README.md' from the site because it conflicts with 'index.md' in the same directory.$",
         )
         expected = ['index.md', 'foo.md']
         self.assertIsInstance(files, Files)
-        self.assertEqual(len(files), len(expected))
         self.assertEqual([f.src_path for f in files], expected)
 
     @tempdir()

--- a/mkdocs/tests/structure/nav_tests.py
+++ b/mkdocs/tests/structure/nav_tests.py
@@ -159,9 +159,9 @@ class SiteNavigationTests(unittest.TestCase):
             cm.output,
             [
                 "WARNING:mkdocs.structure.nav:A relative path to 'missing.html' is included "
-                "in the 'nav' configuration, which is not found in the documentation files",
+                "in the 'nav' configuration, which is not found in the documentation files.",
                 "WARNING:mkdocs.structure.nav:A relative path to 'example.com' is included "
-                "in the 'nav' configuration, which is not found in the documentation files",
+                "in the 'nav' configuration, which is not found in the documentation files.",
             ],
         )
         self.assertEqual(str(site_navigation).strip(), expected)

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -442,6 +442,18 @@ def nest_paths(paths):
     return nested
 
 
+class DuplicateFilter:
+    """Avoid logging duplicate messages."""
+
+    def __init__(self) -> None:
+        self.msgs: set[str] = set()
+
+    def __call__(self, record: logging.LogRecord) -> bool:
+        rv = record.msg not in self.msgs
+        self.msgs.add(record.msg)
+        return rv
+
+
 class CountHandler(logging.NullHandler):
     """Counts all logged messages >= level."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "typing_extensions >=3.10; python_version < '3.8'",
     "packaging >=20.5",
     "mergedeep >=1.3.4",
+    "pathspec >=0.11.1",
     "colorama >=0.4; platform_system == 'Windows'",
 ]
 [project.optional-dependencies]
@@ -63,6 +64,7 @@ min-versions = [
     "typing_extensions ==3.10; python_version < '3.8'",
     "packaging ==20.5",
     "mergedeep ==1.3.4",
+    "pathspec ==0.11.1",
     "colorama ==0.4; platform_system == 'Windows'",
     "babel ==2.9.0",
 ]


### PR DESCRIPTION
These files will not be picked up into the `Files` collection and as such, also the final built site.

Also adds the ability to *un*-ignore the files that MkDocs forcibly ignores.

* Closes #2139
* Closes #2316
* Closes #2185
* Closes #1888
* Closes #3110