### PR TITLE
fix MarkdownExtensions type annotation

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -833,7 +833,7 @@ class Private(BaseConfigOption):
             raise ValidationError('For internal use only.')
 
 
-class MarkdownExtensions(OptionallyRequired[List[str]]):
+class MarkdownExtensions(OptionallyRequired[list[str] | dict[str, Any], list[dict[str, Any]]]):
     """
     Markdown Extensions Config Option
 


### PR DESCRIPTION
based on the validation function any of the following are possible:

- `list[str]`
- `dict[str, Any]`
- `list[dict[str, Any]]`