### PR TITLE
Add support for using .mjs files in extra_javascript

### DIFF
--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -311,7 +311,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
     def _guess_type(cls, path):
         # MkDocs only ensures a few common types (as seen in livereload_tests.py::test_mime_types).
         # Other uncommon types will not be accepted.
-        if path.endswith((".js", ".JS")):
+        if path.endswith((".js", ".JS", ".mjs", ".MJS")):
             return "application/javascript"
         if path.endswith(".gz"):
             return "application/gzip"

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -269,7 +269,7 @@ class File:
 
     def is_javascript(self) -> bool:
         """Return True if file is a JavaScript file."""
-        return self.src_uri.endswith(('.js', '.javascript'))
+        return self.src_uri.endswith(('.js', '.javascript', '.mjs'))
 
     def is_css(self) -> bool:
         """Return True if file is a CSS file."""

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -366,16 +366,17 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
             File('foo/bar.html', '/path/to/docs', '/path/to/site', use_directory_urls=True),
             File('foo/bar.jpg', '/path/to/docs', '/path/to/site', use_directory_urls=True),
             File('foo/bar.js', '/path/to/docs', '/path/to/site', use_directory_urls=True),
+            File('foo/bar.mjs', '/path/to/docs', '/path/to/site', use_directory_urls=True),
             File('foo/bar.css', '/path/to/docs', '/path/to/site', use_directory_urls=True),
         ]
         files = Files(fs)
         self.assertEqual([f for f in files], fs)
-        self.assertEqual(len(files), 6)
+        self.assertEqual(len(files), 7)
         self.assertEqual(files.documentation_pages(), [fs[0], fs[1]])
         self.assertEqual(files.static_pages(), [fs[2]])
-        self.assertEqual(files.media_files(), [fs[3], fs[4], fs[5]])
-        self.assertEqual(files.javascript_files(), [fs[4]])
-        self.assertEqual(files.css_files(), [fs[5]])
+        self.assertEqual(files.media_files(), [fs[3], fs[4], fs[5], fs[6]])
+        self.assertEqual(files.javascript_files(), [fs[4], fs[5]])
+        self.assertEqual(files.css_files(), [fs[6]])
         self.assertEqual(files.get_file_from_path('foo/bar.jpg'), fs[3])
         self.assertEqual(files.get_file_from_path('foo/bar.jpg'), fs[3])
         self.assertEqual(files.get_file_from_path('missing.jpg'), None)
@@ -383,7 +384,7 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         extra_file = File('extra.md', '/path/to/docs', '/path/to/site', use_directory_urls=True)
         self.assertFalse(extra_file.src_uri in files.src_uris)
         files.append(extra_file)
-        self.assertEqual(len(files), 7)
+        self.assertEqual(len(files), 8)
         self.assertTrue(extra_file.src_uri in files.src_uris)
         self.assertEqual(files.documentation_pages(), [fs[0], fs[1], extra_file])
         files.remove(fs[1])

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -198,7 +198,11 @@
         </script>
         <script src="{{ 'js/base.js'|url }}" defer></script>
         {%- for path in extra_javascript %}
-        <script src="{{ path }}" defer></script>
+          {% if path.endswith(".mjs") %}
+            <script type="module" src="{{ path }}" defer></script>
+          {% else %}
+            <script src="{{ path }}" defer></script>
+          {% endif %}
         {%- endfor %}
       {%- endblock %}
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -172,7 +172,11 @@
     <script src="{{ 'js/theme_extra.js'|url }}" defer></script>
     <script src="{{ 'js/theme.js'|url }}" defer></script>
     {%- for path in extra_javascript %}
-      <script src="{{ path }}" defer></script>
+      {% if path.endswith(".mjs") %}
+        <script type="module" src="{{ path }}" defer></script>
+      {% else %}
+        <script src="{{ path }}" defer></script>
+      {% endif %}
     {%- endfor %}
     <script defer>
         window.onload = function () {


### PR DESCRIPTION
Fixes #3164. I've already added support for `.mjs` in Material for MkDocs in https://github.com/squidfunk/mkdocs-material/commit/530f84416e50e517991b6f1cd44ce8192421bce0. MkDocs doesn't complain when `.mjs` is used, but with the PR proposed here, those files are properly treated as JavaScript files, which some plugins may rely on. Once this is merged, I'll update the built-in plugins (.e.g the [`privacy` plugin](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#built-in-privacy-plugin)).

I've also adapted the built-in themes.