### PR TITLE
Enforce that imports are under `if TYPE_CHECKING` if possible

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 119
-extend-ignore = E203
+extend-ignore = E203, TC004

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -4,7 +4,7 @@ import gzip
 import logging
 import os
 import time
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 from urllib.parse import urlsplit
 
 import jinja2
@@ -12,11 +12,13 @@ from jinja2.exceptions import TemplateNotFound
 
 import mkdocs
 from mkdocs import utils
-from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.exceptions import Abort, BuildError
 from mkdocs.structure.files import File, Files, get_files
 from mkdocs.structure.nav import Navigation, get_navigation
-from mkdocs.structure.pages import Page
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.structure.pages import Page
 
 
 class DuplicateFilter:

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -4,13 +4,16 @@ import logging
 import os
 import re
 import subprocess
+from typing import TYPE_CHECKING
 
 import ghp_import
 from packaging import version
 
 import mkdocs
-from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.exceptions import Abort
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -5,15 +5,18 @@ import logging
 import shutil
 import tempfile
 from os.path import isdir, isfile, join
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 import jinja2.exceptions
 
 from mkdocs.commands.build import build
 from mkdocs.config import load_config
-from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.exceptions import Abort
 from mkdocs.livereload import LiveReloadServer
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
 
 log = logging.getLogger(__name__)
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -7,7 +7,6 @@ import string
 import sys
 import traceback
 import types
-import typing as t
 import warnings
 from collections import Counter, UserString
 from typing import (
@@ -1036,7 +1035,7 @@ class Hooks(BaseConfigOption[List[types.ModuleType]]):
     def run_validation(self, value: object) -> Mapping[str, Any]:
         paths = self._base_option.validate(value)
         self.warnings.extend(self._base_option.warnings)
-        value = t.cast(List[str], value)
+        assert isinstance(value, list)
 
         hooks = {}
         for name, path in zip(value, paths):

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, List
+from typing import TYPE_CHECKING, Any, List
 
 from mkdocs import utils
 from mkdocs.config import base
 from mkdocs.config import config_options as c
-from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.contrib.search.search_index import SearchIndex
 from mkdocs.plugins import BasePlugin
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
 
 log = logging.getLogger(__name__)
 base_path = os.path.dirname(os.path.abspath(__file__))

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -6,9 +6,11 @@ import os
 import re
 import subprocess
 from html.parser import HTMLParser
+from typing import TYPE_CHECKING
 
-from mkdocs.structure.pages import Page
-from mkdocs.structure.toc import AnchorLink, TableOfContents
+if TYPE_CHECKING:
+    from mkdocs.structure.pages import Page
+    from mkdocs.structure.toc import AnchorLink, TableOfContents
 
 try:
     from lunr import lunr

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -13,22 +13,23 @@ if sys.version_info >= (3, 10):
 else:
     from importlib_metadata import EntryPoint, entry_points
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 import jinja2.environment
 
 from mkdocs import utils
 from mkdocs.config.base import Config, ConfigErrors, ConfigWarnings, LegacyConfig, PlainConfigSchema
-from mkdocs.livereload import LiveReloadServer
-from mkdocs.structure.files import Files
-from mkdocs.structure.nav import Navigation
-from mkdocs.structure.pages import Page
 
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.livereload import LiveReloadServer
+    from mkdocs.structure.files import Files
+    from mkdocs.structure.nav import Navigation
+    from mkdocs.structure.pages import Page
 
 
 log = logging.getLogger('mkdocs.plugins')

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -4,12 +4,12 @@ import logging
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, TypeVar
 from urllib.parse import urlsplit
 
-from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 from mkdocs.utils import nest_paths
 
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.structure.files import Files
 
 
 log = logging.getLogger(__name__)

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -8,7 +8,6 @@ import warnings
 from typing import TYPE_CHECKING, Any, Callable, Mapping, MutableMapping
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urljoin, urlsplit, urlunsplit
-from xml.etree import ElementTree as etree
 
 import markdown
 import markdown.extensions
@@ -16,12 +15,14 @@ import markdown.postprocessors
 import markdown.treeprocessors
 from markdown.util import AMP_SUBSTITUTE
 
-from mkdocs.structure.files import File, Files
 from mkdocs.structure.toc import get_toc
 from mkdocs.utils import get_build_date, get_markdown_title, meta, weak_property
 
 if TYPE_CHECKING:
+    from xml.etree import ElementTree as etree
+
     from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.structure.files import File, Files
     from mkdocs.structure.nav import Section
     from mkdocs.structure.toc import TableOfContents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ dependencies = [
     "watchdog >=2.0",
     "ghp-import >=1.0",
     "pyyaml_env_tag >=0.1",
-    "importlib_metadata >=4.3; python_version < '3.10'",
-    "typing_extensions >=3.10; python_version < '3.8'",
+    "importlib-metadata >=4.3; python_version < '3.10'",
+    "typing-extensions >=3.10; python_version < '3.8'",
     "packaging >=20.5",
     "mergedeep >=1.3.4",
     "colorama >=0.4; platform_system == 'Windows'",
@@ -59,8 +59,8 @@ min-versions = [
     "watchdog ==2.0",
     "ghp-import ==1.0",
     "pyyaml_env_tag ==0.1",
-    "importlib_metadata ==4.3; python_version < '3.10'",
-    "typing_extensions ==3.10; python_version < '3.8'",
+    "importlib-metadata ==4.3; python_version < '3.10'",
+    "typing-extensions ==3.10; python_version < '3.8'",
     "packaging ==20.5",
     "mergedeep ==1.3.4",
     "colorama ==0.4; platform_system == 'Windows'",
@@ -156,6 +156,7 @@ dependencies = [
     "black",
     "isort",
     "flake8",
+    "flake8-type-checking",
 ]
 [tool.hatch.envs.style.scripts]
 lint = [


### PR DESCRIPTION
I realized that actually `livereload` gets imported even as part of `mkdocs build`, this prevents it.

Ref https://github.com/mkdocs/mkdocs/pull/3219#issuecomment-1545960511 @pawamoy