### PR TITLE
Support `<script type="module">` and other attributes

### DIFF
--- a/docs/dev-guide/api.md
+++ b/docs/dev-guide/api.md
@@ -14,6 +14,11 @@ NOTE: The main entry point to the API is through [Events](plugins.md#events) tha
     options:
       show_root_heading: true
 
+::: mkdocs.utils.templates.TemplateContext
+    options:
+      show_root_heading: true
+      show_if_no_docstring: true
+
 ::: mkdocs.livereload.LiveReloadServer
     options:
       show_root_heading: true

--- a/docs/dev-guide/themes.md
+++ b/docs/dev-guide/themes.md
@@ -614,7 +614,7 @@ returned relative to the page object. Otherwise, the URL is returned with
 
 ### tojson
 
-Safety convert a Python object to a value in a JavaScript script.
+Safely convert a Python object to a value in a JavaScript script.
 
 ```django
 <script>
@@ -649,7 +649,7 @@ JavaScript is able to properly load the search scripts and make relative links
 to the search results from the current page.
 
 ```django
-<script>var base_url = '{{ base_url }}';</script>
+<script>var base_url = {{ base_url|tojson }};</script>
 ```
 
 With properly configured settings, the following HTML in a template  will add a

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -416,7 +416,7 @@ extra_javascript:
         # Config keys only supported since MkDocs 1.5:
   - path: explicitly_as_module.mjs # <script src="explicitly_as_module.mjs" type="module"></script>
     type: module
-  - path: deferred_plain.js        # <script src="deferred_plain.js" deferred></script>
+  - path: deferred_plain.js        # <script src="deferred_plain.js" defer></script>
     defer: true
   - path: scripts/async_module.mjs # <script src="scripts/async_module.mjs" type="module" async></script>
     type: module

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -386,24 +386,53 @@ the root of your local file system.
 
 ### extra_css
 
-Set a list of CSS files in your `docs_dir` to be included by the theme. For
-example, the following example will include the extra.css file within the
-css subdirectory in your [docs_dir](#docs_dir).
+Set a list of CSS files (relative to `docs_dir`) to be included by the theme, typically as `<link>` tags.
+
+Example:
 
 ```yaml
 extra_css:
-    - css/extra.css
-    - css/second_extra.css
+  - css/extra.css
+  - css/second_extra.css
 ```
 
 **default**: `[]` (an empty list).
 
 ### extra_javascript
 
-Set a list of JavaScript files in your `docs_dir` to be included by the theme.
-See the example in [extra_css] for usage.
+Set a list of JavaScript files in your `docs_dir` to be included by the theme, as `<script>` tags.
+
+> NEW: **Changed in version 1.5:**
+>
+> Older versions of MkDocs supported only a plain list of strings, but now several additional config keys are available: `type`, `async`, `defer`.
+
+See the examples and what they produce:
+
+```yaml
+extra_javascript:
+  - some_plain_javascript.js       # <script src="some_plain_javascript.js"></script>
+        # New behavior in MkDocs 1.5:
+  - implicitly_as_module.mjs       # <script src="implicitly_as_module.mjs" type="module"></script>
+        # Config keys only supported since MkDocs 1.5:
+  - path: explicitly_as_module.mjs # <script src="explicitly_as_module.mjs" type="module"></script>
+    type: module
+  - path: deferred_plain.js        # <script src="deferred_plain.js" deferred></script>
+    defer: true
+  - path: scripts/async_module.mjs # <script src="scripts/async_module.mjs" type="module" async></script>
+    type: module
+    async: true
+```
+
+So, each item can be either:
+
+* a plain string, or
+* a mapping that has the required `path` key and 3 optional keys `type` (string), `async` (boolean), `defer` (boolean).
+
+Only the plain string variant detects the `.mjs` extension and adds `type="module"`, otherwise `type: module` must be written out regardless of extension.
 
 **default**: `[]` (an empty list).
+
+NOTE: `*.js` and `*.css` files, just like any other type of file, are always copied from `docs_dir` into the site's deployed copy, regardless if they're linked to the pages via the above configs or not.
 
 ### extra_templates
 

--- a/docs/user-guide/customizing-your-theme.md
+++ b/docs/user-guide/customizing-your-theme.md
@@ -18,7 +18,7 @@ need to include either CSS or JavaScript files within your [documentation
 directory].
 
 For example, to change the color of the headers in your documentation, create
-a file called `extra.css` and place it next to the documentation Markdown. In
+a file called (for example) `style.css` and place it next to the documentation Markdown. In
 that file add the following CSS.
 
 ```css
@@ -27,14 +27,12 @@ h1 {
 }
 ```
 
-> NOTE:
-> If you are deploying your documentation with [ReadTheDocs], you will need
-> to explicitly list the CSS and JavaScript files you want to include in
-> your config. To do this, add the following to your mkdocs.yml.
->
-> ```yaml
-> extra_css: [extra.css]
-> ```
+Then you need to add it to `mkdocs.yml`:
+
+```yaml
+extra_css:
+  - style.css
+```
 
 After making these changes, they should be visible when you run
 `mkdocs serve` - if you already had this running, you should see that the CSS
@@ -218,7 +216,6 @@ any additional CSS files included in the `custom_dir`.
 [extra_css]: ./configuration.md#extra_css
 [extra_javascript]: ./configuration.md#extra_javascript
 [documentation directory]: ./configuration.md#docs_dir
-[ReadTheDocs]: ./deploying-your-docs.md#readthedocs
 [custom_dir]: ./configuration.md#custom_dir
 [name]: ./configuration.md#name
 [mkdocs]: ./choosing-your-theme.md#mkdocs

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -51,9 +51,10 @@ def get_context(
     if page is not None:
         base_url = utils.get_relative_url('.', page.url)
 
-    extra_javascript = utils.create_media_urls(config.extra_javascript, page, base_url)
-
-    extra_css = utils.create_media_urls(config.extra_css, page, base_url)
+    extra_javascript = [
+        utils.normalize_url(str(script), page, base_url) for script in config.extra_javascript
+    ]
+    extra_css = [utils.normalize_url(path, page, base_url) for path in config.extra_css]
 
     if isinstance(files, Files):
         files = files.documentation_pages()

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -4,7 +4,7 @@ import gzip
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Sequence
 from urllib.parse import urlsplit
 
 import jinja2
@@ -15,6 +15,7 @@ from mkdocs import utils
 from mkdocs.exceptions import Abort, BuildError
 from mkdocs.structure.files import File, Files, get_files
 from mkdocs.structure.nav import Navigation, get_navigation
+from mkdocs.utils import templates
 
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
@@ -43,7 +44,7 @@ def get_context(
     config: MkDocsConfig,
     page: Page | None = None,
     base_url: str = '',
-) -> dict[str, Any]:
+) -> templates.TemplateContext:
     """
     Return the template context for a given page or template.
     """
@@ -57,17 +58,17 @@ def get_context(
     if isinstance(files, Files):
         files = files.documentation_pages()
 
-    return {
-        'nav': nav,
-        'pages': files,
-        'base_url': base_url,
-        'extra_css': extra_css,
-        'extra_javascript': extra_javascript,
-        'mkdocs_version': mkdocs.__version__,
-        'build_date_utc': utils.get_build_datetime(),
-        'config': config,
-        'page': page,
-    }
+    return templates.TemplateContext(
+        nav=nav,
+        pages=files,
+        base_url=base_url,
+        extra_css=extra_css,
+        extra_javascript=extra_javascript,
+        mkdocs_version=mkdocs.__version__,
+        build_date_utc=utils.get_build_datetime(),
+        config=config,
+        page=page,
+    )
 
 
 def _build_template(

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -69,6 +69,8 @@ class BaseConfigOption(Generic[T]):
         """
 
     def __set_name__(self, owner, name):
+        if name.endswith('_') and not name.startswith('_'):
+            name = name[:-1]
         self._name = name
 
     @overload
@@ -123,7 +125,7 @@ class Config(UserDict):
         schema = dict(getattr(cls, '_schema', ()))
         for attr_name, attr in cls.__dict__.items():
             if isinstance(attr, BaseConfigOption):
-                schema[attr_name] = attr
+                schema[getattr(attr, '_name', attr_name)] = attr
         cls._schema = tuple(schema.items())
 
         for attr_name, attr in cls._schema:

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -234,9 +234,8 @@ class Config(UserDict):
 
         if not isinstance(patch, dict):
             raise exceptions.ConfigurationError(
-                "The configuration is invalid. The expected type was a key "
-                "value mapping (a python dict) but we got an object of type: "
-                f"{type(patch)}"
+                "The configuration is invalid. Expected a key-"
+                f"value mapping (dict) but received: {type(patch)}"
             )
 
         self.user_configs.append(patch)

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -95,7 +95,7 @@ class SubConfig(Generic[SomeConfig], BaseConfigOption[SomeConfig]):
 
         if self._do_validation:
             # Capture errors and warnings
-            self.warnings = [f"Sub-option '{key}': {msg}" for key, msg in warnings]
+            self.warnings.extend(f"Sub-option '{key}': {msg}" for key, msg in warnings)
             if failed:
                 # Get the first failing one
                 key, err = failed[0]
@@ -188,6 +188,7 @@ class ListOfItems(Generic[T], BaseConfigOption[List[T]]):
         fake_keys = [f'{parent_key_name}[{i}]' for i in range(len(value))]
         fake_config.data = dict(zip(fake_keys, value))
 
+        self.option_type.warnings = self.warnings
         for key_name in fake_config:
             self.option_type.pre_validation(fake_config, key_name)
         for key_name in fake_config:

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -836,6 +836,33 @@ class Private(Generic[T], BaseConfigOption[T]):
             raise ValidationError('For internal use only.')
 
 
+class ExtraScriptValue(Config):
+    """An extra script to be added to the page. The `extra_javascript` config is a list of these."""
+
+    path = Type(str)
+    """The value of the `src` tag of the script."""
+    type = Type(str, default='')
+    """The value of the `type` tag of the script."""
+    defer = Type(bool, default=False)
+    """Whether to add the `defer` tag to the script."""
+    async_ = Type(bool, default=False)
+    """Whether to add the `async` tag to the script."""
+
+    def __init__(self, path: str = ''):
+        super().__init__()
+        self.path = path
+
+    def __str__(self):
+        return self.path
+
+
+class ExtraScript(SubConfig[ExtraScriptValue]):
+    def run_validation(self, value: object) -> ExtraScriptValue:
+        if isinstance(value, str):
+            value = {'path': value, 'type': 'module' if value.endswith('.mjs') else ''}
+        return super().run_validation(value)
+
+
 class MarkdownExtensions(OptionallyRequired[List[str]]):
     """
     Markdown Extensions Config Option

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -86,7 +86,7 @@ class MkDocsConfig(base.Config):
     is ignored."""
 
     extra_css = c.Type(list, default=[])
-    extra_javascript = c.Type(list, default=[])
+    extra_javascript = c.ListOfItems(c.ExtraScript(), default=[])
     """Specify which css or javascript files from the docs directory should be
     additionally included in the site."""
 

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -68,7 +68,7 @@ class SearchPlugin(BasePlugin[_PluginConfig]):
             path = os.path.join(base_path, 'templates')
             config.theme.dirs.append(path)
             if 'search/main.js' not in config.extra_javascript:
-                config.extra_javascript.append('search/main.js')
+                config.extra_javascript.append('search/main.js')  # type: ignore
         if self.config.lang is None:
             # lang setting undefined. Set default based on theme locale
             validate = _PluginConfig.lang.run_validation

--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, List
 
 from mkdocs import utils
 from mkdocs.config import base
@@ -12,6 +12,7 @@ from mkdocs.plugins import BasePlugin
 
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.util.templates import TemplateContext
 
 log = logging.getLogger(__name__)
 base_path = os.path.dirname(os.path.abspath(__file__))
@@ -85,7 +86,7 @@ class SearchPlugin(BasePlugin[_PluginConfig]):
         "Create search index instance for later use."
         self.search_index = SearchIndex(**self.config)
 
-    def on_page_context(self, context: dict[str, Any], **kwargs) -> None:
+    def on_page_context(self, context: TemplateContext, **kwargs) -> None:
         "Add page to search index."
         self.search_index.add_entry_from_context(context['page'])
 

--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -311,7 +311,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
     def _guess_type(cls, path):
         # MkDocs only ensures a few common types (as seen in livereload_tests.py::test_mime_types).
         # Other uncommon types will not be accepted.
-        if path.endswith((".js", ".JS")):
+        if path.endswith((".js", ".JS", ".mjs")):
             return "application/javascript"
         if path.endswith(".gz"):
             return "application/gzip"

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from mkdocs.structure.files import Files
     from mkdocs.structure.nav import Navigation
     from mkdocs.structure.pages import Page
+    from mkdocs.utils.templates import TemplateContext
 
 
 log = logging.getLogger('mkdocs.plugins')
@@ -267,8 +268,8 @@ class BasePlugin(Generic[SomeConfig]):
         return template
 
     def on_template_context(
-        self, context: dict[str, Any], *, template_name: str, config: MkDocsConfig
-    ) -> dict[str, Any] | None:
+        self, context: TemplateContext, *, template_name: str, config: MkDocsConfig
+    ) -> TemplateContext | None:
         """
         The `template_context` event is called immediately after the context is created
         for the subject template and can be used to alter the context for that specific
@@ -374,8 +375,8 @@ class BasePlugin(Generic[SomeConfig]):
         return html
 
     def on_page_context(
-        self, context: dict[str, Any], *, page: Page, config: MkDocsConfig, nav: Navigation
-    ) -> dict[str, Any] | None:
+        self, context: TemplateContext, *, page: Page, config: MkDocsConfig, nav: Navigation
+    ) -> TemplateContext | None:
         """
         The `page_context` event is called after the context for a page is created
         and can be used to alter the context for that specific page only.

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -269,7 +269,7 @@ class File:
 
     def is_javascript(self) -> bool:
         """Return True if file is a JavaScript file."""
-        return self.src_uri.endswith(('.js', '.javascript'))
+        return self.src_uri.endswith(('.js', '.javascript', '.mjs'))
 
     def is_css(self) -> bool:
         """Return True if file is a CSS file."""

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -27,29 +27,29 @@ log = logging.getLogger(__name__)
 
 
 class InclusionLevel(enum.Enum):
-    Excluded = -2
+    EXCLUDED = -2
     """The file is excluded from the final site, but will still be populated during `mkdocs serve`."""
-    NotInNav = -1
+    NOT_IN_NAV = -1
     """The file is part of the site, but doesn't produce nav warnings."""
-    Undefined = 0
+    UNDEFINED = 0
     """Still needs to be computed based on the config. If the config doesn't kick in, acts the same as `included`."""
-    Included = 1
+    INCLUDED = 1
     """The file is part of the site. Documentation pages that are omitted from the nav will produce warnings."""
 
     def all(self):
         return True
 
     def is_included(self):
-        return self.value > self.Excluded.value
+        return self.value > self.EXCLUDED.value
 
     def is_excluded(self):
-        return self.value <= self.Excluded.value
+        return self.value <= self.EXCLUDED.value
 
     def is_in_nav(self):
-        return self.value > self.NotInNav.value
+        return self.value > self.NOT_IN_NAV.value
 
     def is_not_in_nav(self):
-        return self.value <= self.NotInNav.value
+        return self.value <= self.NOT_IN_NAV.value
 
 
 class Files:
@@ -221,7 +221,7 @@ class File:
         use_directory_urls: bool,
         *,
         dest_uri: str | None = None,
-        inclusion: InclusionLevel = InclusionLevel.Undefined,
+        inclusion: InclusionLevel = InclusionLevel.UNDEFINED,
     ) -> None:
         self.page = None
         self.src_path = path
@@ -326,13 +326,13 @@ def _set_exclusions(files: Iterable[File], config: MkDocsConfig | Mapping[str, A
     nav_exclude: pathspec.gitignore.GitIgnoreSpec | None = config.get('not_in_nav')
 
     for file in files:
-        if file.inclusion == InclusionLevel.Undefined:
+        if file.inclusion == InclusionLevel.UNDEFINED:
             if exclude.match_file(file.src_uri):
-                file.inclusion = InclusionLevel.Excluded
+                file.inclusion = InclusionLevel.EXCLUDED
             elif nav_exclude and nav_exclude.match_file(file.src_uri):
-                file.inclusion = InclusionLevel.NotInNav
+                file.inclusion = InclusionLevel.NOT_IN_NAV
             else:
-                file.inclusion = InclusionLevel.Included
+                file.inclusion = InclusionLevel.INCLUDED
 
 
 def get_files(config: MkDocsConfig | Mapping[str, Any]) -> Files:

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -1193,8 +1193,8 @@ class SubConfigTest(TestCase):
             with self.subTest(val):
                 with self.expect_error(
                     option=re.compile(
-                        r"The configuration is invalid. The expected type was a key value mapping "
-                        r"\(a python dict\) but we got an object of type: .+"
+                        r"The configuration is invalid. Expected a key-value mapping "
+                        r"\(dict\) but received: .+"
                     )
                 ):
                     self.get_config(Schema, {'option': val})
@@ -1342,8 +1342,8 @@ class ConfigItemsTest(TestCase):
             conf = self.get_config(Schema, {'sub': [{'opt': 'z'}, {'opt': 2}]})
 
         with self.expect_error(
-            sub="The configuration is invalid. The expected type was a key value mapping "
-            "(a python dict) but we got an object of type: <class 'int'>"
+            sub="The configuration is invalid. Expected a key-value mapping "
+            "(dict) but received: <class 'int'>"
         ):
             conf = self.get_config(Schema, {'sub': [1, 2]})
 

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1242,8 +1242,8 @@ class SubConfigTest(TestCase):
             with self.subTest(val):
                 with self.expect_error(
                     option=re.compile(
-                        r"The configuration is invalid. The expected type was a key value mapping "
-                        r"\(a python dict\) but we got an object of type: .+"
+                        r"The configuration is invalid. Expected a key-value mapping "
+                        r"\(dict\) but received: .+"
                     )
                 ):
                     self.get_config(Schema, {'option': val})
@@ -1368,8 +1368,8 @@ class SubConfigTest(TestCase):
             conf = self.get_config(Schema, {'sub': [{'opt': 'z'}, {'opt': 2}]})
 
         with self.expect_error(
-            sub="The configuration is invalid. The expected type was a key value mapping "
-            "(a python dict) but we got an object of type: <class 'int'>"
+            sub="The configuration is invalid. Expected a key-value mapping "
+            "(dict) but received: <class 'int'>"
         ):
             conf = self.get_config(Schema, {'sub': [1, 2]})
 

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -678,6 +678,19 @@ class ListOfItemsTest(TestCase):
         with self.expect_error(option="'asdf' is not a valid port"):
             self.get_config(Schema, {'option': ["localhost:8000", "1.2.3.4:asdf"]})
 
+    def test_warning(self) -> None:
+        class Schema(Config):
+            option = c.ListOfItems(c.Deprecated())
+
+        self.get_config(
+            Schema,
+            {'option': ['a']},
+            warnings=dict(
+                option="The configuration option 'option[0]' has been "
+                "deprecated and will be removed in a future release."
+            ),
+        )
+
 
 class FilesystemObjectTest(TestCase):
     def test_valid_dir(self) -> None:

--- a/mkdocs/tests/utils/templates_tests.py
+++ b/mkdocs/tests/utils/templates_tests.py
@@ -1,0 +1,49 @@
+import unittest
+from textwrap import dedent
+
+import yaml
+
+from mkdocs.tests.base import load_config
+from mkdocs.utils import templates
+
+
+class UtilsTemplatesTests(unittest.TestCase):
+    def test_script_tag(self):
+        cfg_yaml = dedent(
+            '''
+            extra_javascript:
+              - some_plain_javascript.js
+              - implicitly_as_module.mjs
+              - path: explicitly_as_module.mjs
+                type: module
+              - path: deferred_plain.js
+                defer: true
+              - path: scripts/async_module.mjs
+                type: module
+                async: true
+              - path: 'aaaaaa/"my script".mjs'
+                type: module
+                async: true
+                defer: true
+              - path: plain.mjs
+            '''
+        )
+        config = load_config(**yaml.safe_load(cfg_yaml))
+        config.extra_javascript.append('plain_string.mjs')
+
+        self.assertEqual(
+            [
+                str(templates.script_tag_filter({'page': None, 'base_url': 'here'}, item))
+                for item in config.extra_javascript
+            ],
+            [
+                '<script src="here/some_plain_javascript.js"></script>',
+                '<script src="here/implicitly_as_module.mjs" type="module"></script>',
+                '<script src="here/explicitly_as_module.mjs" type="module"></script>',
+                '<script src="here/deferred_plain.js" defer></script>',
+                '<script src="here/scripts/async_module.mjs" type="module" async></script>',
+                '<script src="here/aaaaaa/&#34;my script&#34;.mjs" type="module" defer async></script>',
+                '<script src="here/plain.mjs"></script>',
+                '<script src="here/plain_string.mjs"></script>',
+            ],
+        )

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -8,7 +8,7 @@ import jinja2
 
 from mkdocs import localization, utils
 from mkdocs.config.base import ValidationError
-from mkdocs.utils import filters
+from mkdocs.utils import templates
 
 log = logging.getLogger(__name__)
 
@@ -116,6 +116,6 @@ class Theme:
         loader = jinja2.FileSystemLoader(self.dirs)
         # No autoreload because editing a template in the middle of a build is not useful.
         env = jinja2.Environment(loader=loader, auto_reload=False)
-        env.filters['url'] = filters.url_filter
+        env.filters['url'] = templates.url_filter
         localization.install_translations(env, self._vars['locale'], self.dirs)
         return env

--- a/mkdocs/theme.py
+++ b/mkdocs/theme.py
@@ -117,5 +117,6 @@ class Theme:
         # No autoreload because editing a template in the middle of a build is not useful.
         env = jinja2.Environment(loader=loader, auto_reload=False)
         env.filters['url'] = templates.url_filter
+        env.filters['script_tag'] = templates.script_tag_filter
         localization.install_translations(env, self._vars['locale'], self.dirs)
         return env

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -49,7 +49,7 @@
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', '{{ config.theme.analytics.gtag }}');
+          gtag('config', {{ config.theme.analytics.gtag|tojson }});
         </script>
         {%- elif config.google_analytics %}
         <script>
@@ -58,7 +58,7 @@
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-            ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
+            ga('create', {{ config.google_analytics[0]|tojson }}, {{ config.google_analytics[1]|tojson }});
             ga('send', 'pageview');
         </script>
         {%- endif %}
@@ -193,8 +193,8 @@
 
       {%- block scripts %}
         <script>
-            var base_url = {{ base_url | tojson }},
-                shortcuts = {{ config.theme.shortcuts | tojson }};
+            var base_url = {{ base_url|tojson }},
+                shortcuts = {{ config.theme.shortcuts|tojson }};
         </script>
         <script src="{{ 'js/base.js'|url }}" defer></script>
         {%- for path in extra_javascript %}

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -23,8 +23,8 @@
         {%- if config.theme.highlightjs %}
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/{{ config.theme.hljs_style }}.min.css">
         {%- endif %}
-        {%- for path in extra_css %}
-        <link href="{{ path }}" rel="stylesheet">
+        {%- for path in config.extra_css %}
+        <link href="{{ path|url }}" rel="stylesheet">
         {%- endfor %}
       {%- endblock %}
 
@@ -196,8 +196,8 @@
                 shortcuts = {{ config.theme.shortcuts|tojson }};
         </script>
         <script src="{{ 'js/base.js'|url }}"></script>
-        {%- for path in extra_javascript %}
-        <script src="{{ path }}"></script>
+        {%- for script in config.extra_javascript %}
+        {{ script|script_tag }}
         {%- endfor %}
       {%- endblock %}
 

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -21,7 +21,7 @@
         <link href="{{ 'css/font-awesome.min.css'|url }}" rel="stylesheet">
         <link href="{{ 'css/base.css'|url }}" rel="stylesheet">
         {%- if config.theme.highlightjs %}
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/{{ config.theme.hljs_style }}.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/{{ config.theme.hljs_style }}.min.css">
         {%- endif %}
         {%- for path in extra_css %}
         <link href="{{ path }}" rel="stylesheet">
@@ -33,11 +33,11 @@
         <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
         <script src="{{ 'js/bootstrap.min.js'|url }}" defer></script>
         {%- if config.theme.highlightjs %}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
         {%- for lang in config.theme.hljs_languages %}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/languages/{{lang}}.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/{{lang}}.min.js"></script>
         {%- endfor %}
-        <script>hljs.initHighlightingOnLoad();</script>
+        <script>hljs.highlightAll();</script>
         {%- endif %}
       {%- endblock %}
 

--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -29,9 +29,6 @@
       {%- endblock %}
 
       {%- block libs %}
-
-        <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
-        <script src="{{ 'js/bootstrap.min.js'|url }}" defer></script>
         {%- if config.theme.highlightjs %}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
         {%- for lang in config.theme.hljs_languages %}
@@ -192,13 +189,15 @@
         </footer>
 
       {%- block scripts %}
+        <script src="{{ 'js/jquery-1.10.2.min.js'|url }}"></script>
+        <script src="{{ 'js/bootstrap.min.js'|url }}"></script>
         <script>
             var base_url = {{ base_url|tojson }},
                 shortcuts = {{ config.theme.shortcuts|tojson }};
         </script>
-        <script src="{{ 'js/base.js'|url }}" defer></script>
+        <script src="{{ 'js/base.js'|url }}"></script>
         {%- for path in extra_javascript %}
-        <script src="{{ path }}" defer></script>
+        <script src="{{ path }}"></script>
         {%- endfor %}
       {%- endblock %}
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -39,7 +39,6 @@
         var mkdocs_page_url = {{ page.abs_url|tojson }};
       </script>
     {% endif %}
-    <script src="{{ 'js/jquery-3.6.0.min.js'|url }}" defer></script>
     <!--[if lt IE 9]>
       <script src="{{ 'js/html5shiv.min.js'|url }}"></script>
     <![endif]-->
@@ -168,16 +167,17 @@
   {% include "versions.html" -%}
 
   {%- block scripts %}
+    <script src="{{ 'js/jquery-3.6.0.min.js'|url }}"></script>
     <script>var base_url = {{ base_url|tojson }};</script>
-    <script src="{{ 'js/theme_extra.js'|url }}" defer></script>
-    <script src="{{ 'js/theme.js'|url }}" defer></script>
+    <script src="{{ 'js/theme_extra.js'|url }}"></script>
+    <script src="{{ 'js/theme.js'|url }}"></script>
     {%- for path in extra_javascript %}
-      <script src="{{ path }}" defer></script>
+      <script src="{{ path }}"></script>
     {%- endfor %}
-    <script defer>
-        window.onload = function () {
+    <script>
+        jQuery(function () {
             SphinxRtdTheme.Navigation.enable({{ 'true' if config.theme.sticky_navigation else 'false' }});
-        };
+        });
     </script>
   {%- endblock %}
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -62,7 +62,7 @@
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', '{{ config.theme.analytics.gtag }}'{%- if config.theme.analytics.anonymize_ip %}, {'anonymize_ip': true}{%- endif %});
+        gtag('config', {{ config.theme.analytics.gtag|tojson }}{%- if config.theme.analytics.anonymize_ip %}, {'anonymize_ip': true}{%- endif %});
       </script>
     {%- elif config.google_analytics %}
       <script>
@@ -71,7 +71,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
+        ga('create', {{ config.google_analytics[0]|tojson }}, {{ config.google_analytics[1]|tojson }});
         {%- if config.theme.analytics.anonymize_ip %}ga('set', 'anonymizeIp', true);{%- endif %}
         ga('send', 'pageview');
       </script>
@@ -168,7 +168,7 @@
   {% include "versions.html" -%}
 
   {%- block scripts %}
-    <script>var base_url = '{{ base_url }}';</script>
+    <script>var base_url = {{ base_url|tojson }};</script>
     <script src="{{ 'js/theme_extra.js'|url }}" defer></script>
     <script src="{{ 'js/theme.js'|url }}" defer></script>
     {%- for path in extra_javascript %}

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="{{ 'css/theme.css'|url }}" />
     <link rel="stylesheet" href="{{ 'css/theme_extra.css'|url }}" />
     {%- if config.theme.highlightjs %}
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/{{ config.theme.hljs_style }}.min.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/{{ config.theme.hljs_style }}.min.css" />
     {%- endif %}
     {%- for path in extra_css %}
         <link href="{{ path }}" rel="stylesheet" />
@@ -44,11 +44,11 @@
       <script src="{{ 'js/html5shiv.min.js'|url }}"></script>
     <![endif]-->
     {%- if config.theme.highlightjs %}
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
       {%- for lang in config.theme.hljs_languages %}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/languages/{{lang}}.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/{{lang}}.min.js"></script>
       {%- endfor %}
-      <script>hljs.initHighlightingOnLoad();</script>
+      <script>hljs.highlightAll();</script>
     {%- endif %}
   {%- endblock %}
 

--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -25,8 +25,8 @@
     {%- if config.theme.highlightjs %}
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/{{ config.theme.hljs_style }}.min.css" />
     {%- endif %}
-    {%- for path in extra_css %}
-        <link href="{{ path }}" rel="stylesheet" />
+    {%- for path in config.extra_css %}
+        <link href="{{ path|url }}" rel="stylesheet" />
     {%- endfor %}
   {%- endblock %}
 
@@ -171,8 +171,8 @@
     <script>var base_url = {{ base_url|tojson }};</script>
     <script src="{{ 'js/theme_extra.js'|url }}"></script>
     <script src="{{ 'js/theme.js'|url }}"></script>
-    {%- for path in extra_javascript %}
-      <script src="{{ path }}"></script>
+    {%- for script in config.extra_javascript %}
+      {{ script|script_tag }}
     {%- endfor %}
     <script>
         jQuery(function () {

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -321,9 +321,7 @@ def _get_norm_url(path: str) -> tuple[str, int]:
 def create_media_urls(
     path_list: Iterable[str], page: Page | None = None, base: str = ''
 ) -> list[str]:
-    """
-    Return a list of URLs relative to the given page or using the base.
-    """
+    """Soft-deprecated, do not use."""
     return [normalize_url(path, page, base) for path in path_list]
 
 

--- a/mkdocs/utils/filters.py
+++ b/mkdocs/utils/filters.py
@@ -1,14 +1,1 @@
-from __future__ import annotations
-
-try:
-    from jinja2 import pass_context as contextfilter  # type: ignore
-except ImportError:
-    from jinja2 import contextfilter  # type: ignore
-
-from mkdocs.utils import normalize_url
-
-
-@contextfilter
-def url_filter(context, value: str) -> str:
-    """A Template filter to normalize URLs."""
-    return normalize_url(value, page=context['page'], base=context['base_url'])
+from .templates import url_filter  # noqa - legacy re-export

--- a/mkdocs/utils/templates.py
+++ b/mkdocs/utils/templates.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Sequence
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    import datetime
+
+try:
+    from jinja2 import pass_context as contextfilter  # type: ignore
+except ImportError:
+    from jinja2 import contextfilter  # type: ignore
+
+from mkdocs.utils import normalize_url
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.structure.files import File
+    from mkdocs.structure.nav import Navigation
+    from mkdocs.structure.pages import Page
+
+
+class TemplateContext(TypedDict):
+    nav: Navigation
+    pages: Sequence[File]
+    base_url: str
+    extra_css: Sequence[str]
+    extra_javascript: Sequence[str]
+    mkdocs_version: str
+    build_date_utc: datetime.datetime
+    config: MkDocsConfig
+    page: Page | None
+
+
+@contextfilter
+def url_filter(context: TemplateContext, value: str) -> str:
+    """A Template filter to normalize URLs."""
+    return normalize_url(value, page=context['page'], base=context['base_url'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires-python = ">=3.7"
 dependencies = [
     "click >=7.0",
     "Jinja2 >=2.11.1",
+    "markupsafe >=2.0.1",
     "Markdown >=3.2.1",
     "PyYAML >=5.1",
     "watchdog >=2.0",


### PR DESCRIPTION
* Closes #2850
* Closes #1581
* Closes #3164
* Closes #3232

---

See docs [in the diff](https://github.com/mkdocs/mkdocs/pull/3237/files).

Try it out:

```
pip install git+https://github.com/mkdocs/mkdocs.git@refs/pull/3237/head
```

Particularly I'm hoping the frontend change of fiddling with `defer` in standard themes doesn't cause problems.

---

Frontend changes:
- Stop using `defer` for all scripts
- Update highlight.js to version 11.8.0

Small config features:
- Fix propagating warnings from sub-items of `ListOfItems`
- Strip trailing `_` from config members, to bypass Python reserved words
- Make it possible to create a subclass of `SubConfig[T]`

Refactors:
- Consistently use `tojson` for pasting strings to JavaScript
- More concise error message in `SubConfig`
- Make `TemplateContext` typed, move `utils.filters` to `utils.templates`

**The actual change:**
- Expand `config.extra_javascript` to support `type`, `async`, `defer`
- Include *.mjs files into `javascript_files()`
