### PR TITLE
Hide instance-attribute labels in docs

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -76,7 +76,8 @@ body.homepage>div.container>div.row>div.col-md-9 {
     display: inline;
 }
 
-.doc-label-class-attribute {
+.doc-label-class-attribute,
+.doc-label-instance-attribute {
     display: none;
 }
 


### PR DESCRIPTION
I've updated mkdocstrings' Python handler, and while checking the docs for MkDocs I noticed these labels were displayed. Since you already hide `class-attribute` labels, I figured you'd like to hide these ones as well.