### PR TITLE
Add `DictOfItems` type for configuration options

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -241,13 +241,16 @@ class DictOfItems(Generic[T], BaseConfigOption[Dict[str, T]]):
         # Emulate a config-like environment for pre_validation and post_validation.
         fake_config.data = value
 
-        for key_name in fake_config:
-            self.option_type.pre_validation(fake_config, key_name)
-        for key_name in fake_config:
+        for key in fake_config:
+            self.option_type.pre_validation(fake_config, key)
+        for key in fake_config:
+            if not isinstance(key, str):
+                raise ValidationError(f"Expected type: {str} for keys, but received: {type(key)} (key={key})")
+        for key in fake_config:
             # Specifically not running `validate` to avoid the OptionallyRequired effect.
-            fake_config[key_name] = self.option_type.run_validation(fake_config[key_name])
-        for key_name in fake_config:
-            self.option_type.post_validation(fake_config, key_name)
+            fake_config[key] = self.option_type.run_validation(fake_config[key])
+        for key in fake_config:
+            self.option_type.post_validation(fake_config, key)
 
         return value
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -245,7 +245,9 @@ class DictOfItems(Generic[T], BaseConfigOption[Dict[str, T]]):
             self.option_type.pre_validation(fake_config, key)
         for key in fake_config:
             if not isinstance(key, str):
-                raise ValidationError(f"Expected type: {str} for keys, but received: {type(key)} (key={key})")
+                raise ValidationError(
+                    f"Expected type: {str} for keys, but received: {type(key)} (key={key})"
+                )
         for key in fake_config:
             # Specifically not running `validate` to avoid the OptionallyRequired effect.
             fake_config[key] = self.option_type.run_validation(fake_config[key])

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -13,6 +13,7 @@ from typing import (
     Any,
     Callable,
     Collection,
+    Dict,
     Generic,
     Iterator,
     List,
@@ -197,6 +198,58 @@ class ListOfItems(Generic[T], BaseConfigOption[List[T]]):
             self.option_type.post_validation(fake_config, key_name)
 
         return [fake_config[k] for k in fake_keys]
+
+
+class DictOfItems(Generic[T], BaseConfigOption[Dict[str, T]]):
+    """
+    Validates a dict of items. Keys are always strings.
+
+    E.g. for `config_options.DictOfItems(config_options.Type(int))` a valid item is `{"a": 1, "b": 2}`.
+    """
+
+    required: Union[bool, None] = None  # Only for subclasses to set.
+
+    def __init__(self, option_type: BaseConfigOption[T], default=None) -> None:
+        super().__init__()
+        self.default = default
+        self.option_type = option_type
+        self.option_type.warnings = self.warnings
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}: {self.option_type}"
+
+    def pre_validation(self, config: Config, key_name: str):
+        self._config = config
+        self._key_name = key_name
+
+    def run_validation(self, value: object) -> Dict[str, T]:
+        if value is None:
+            if self.required or self.default is None:
+                raise ValidationError("Required configuration not provided.")
+            value = self.default
+        if not isinstance(value, dict):
+            raise ValidationError(f"Expected a dict of items, but a {type(value)} was given.")
+        if not value:  # Optimization for empty list
+            return value
+
+        fake_config = LegacyConfig(())
+        try:
+            fake_config.config_file_path = self._config.config_file_path
+        except AttributeError:
+            pass
+
+        # Emulate a config-like environment for pre_validation and post_validation.
+        fake_config.data = value
+
+        for key_name in fake_config:
+            self.option_type.pre_validation(fake_config, key_name)
+        for key_name in fake_config:
+            # Specifically not running `validate` to avoid the OptionallyRequired effect.
+            fake_config[key_name] = self.option_type.run_validation(fake_config[key_name])
+        for key_name in fake_config:
+            self.option_type.post_validation(fake_config, key_name)
+
+        return value
 
 
 class ConfigItems(ListOfItems[LegacyConfig]):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -778,10 +778,8 @@ class DictOfItemsTest(TestCase):
         class Schema(Config):
             option = c.DictOfItems(c.Type(int))
 
-        with self.expect_error(option="Expected type: <class 'str'> for keys, but received: <class 'int'> (key=1)"):
-            self.get_config(
-                Schema, {'option': {1: 2}}
-            )
+        with self.expect_error(option="Expected type: <class 'str'> for keys, but received: <class 'int'> (key=2)"):
+            self.get_config(Schema, {'option': {"a": 1, 2: 3}})
 
 
 class FilesystemObjectTest(TestCase):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -778,7 +778,9 @@ class DictOfItemsTest(TestCase):
         class Schema(Config):
             option = c.DictOfItems(c.Type(int))
 
-        with self.expect_error(option="Expected type: <class 'str'> for keys, but received: <class 'int'> (key=2)"):
+        with self.expect_error(
+            option="Expected type: <class 'str'> for keys, but received: <class 'int'> (key=2)"
+        ):
             self.get_config(Schema, {'option': {"a": 1, 2: 3}})
 
 

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -774,6 +774,15 @@ class DictOfItemsTest(TestCase):
                 Schema, {'option': {"ip_foo": "localhost:8000", "ip_bar": "1.2.3.4:asdf"}}
             )
 
+    def test_all_keys_are_strings(self) -> None:
+        class Schema(Config):
+            option = c.DictOfItems(c.Type(int))
+
+        with self.expect_error(option="Expected type: <class 'str'> for keys, but received: <class 'int'> (key=1)"):
+            self.get_config(
+                Schema, {'option': {1: 2}}
+            )
+
 
 class FilesystemObjectTest(TestCase):
     def test_valid_dir(self) -> None:


### PR DESCRIPTION
As discussed in https://github.com/mkdocs/mkdocs/discussions/3240.
Absolutely feel free to push to the branch directly.
I copied the tests for `ListOfItems` and adapted them.