### PR TITLE
Add YAML placeholder tags that resolve to current paths

### DIFF
--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -110,7 +110,7 @@ class MyPlugin(mkdocs.plugins.BasePlugin):
 > from mkdocs.config import base, config_options as c
 >
 > class _ValidationOptions(base.Config):
->     enable = c.Type(bool, default=True)
+>     enabled = c.Type(bool, default=True)
 >     verbose = c.Type(bool, default=False)
 >     skip_checks = c.ListOfItems(c.Choice(('foo', 'bar', 'baz')), default=[])
 >
@@ -130,7 +130,7 @@ class MyPlugin(mkdocs.plugins.BasePlugin):
 > my_plugin:
 >   definition_file: configs/test.ini  # relative to mkdocs.yml
 >   validation:
->     enable: !ENV [CI, false]
+>     enabled: !ENV [CI, false]
 >     verbose: true
 >     skip_checks:
 >       - foo

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -16,7 +16,7 @@ def _get_language_of_translation_file(path: Path) -> str:
 
 def on_page_markdown(markdown: str, page: Page, config: MkDocsConfig, **kwargs):
     if page.file.src_uri == 'user-guide/choosing-your-theme.md':
-        here = Path(config.config_file_path or '').parent
+        here = Path(config.config_file_path).parent
 
         def replacement(m: re.Match) -> str:
             lines = []

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -618,7 +618,7 @@ For example, to enable permalinks in the (included) `toc` extension, use:
 ```yaml
 markdown_extensions:
     - toc:
-        permalink: True
+        permalink: true
 ```
 
 Note that a colon (`:`) must follow the extension name (`toc`) and then on a new
@@ -629,7 +629,7 @@ defined on a separate line:
 ```yaml
 markdown_extensions:
     - toc:
-        permalink: True
+        permalink: true
         separator: "_"
 ```
 
@@ -641,9 +641,13 @@ for that extension:
 markdown_extensions:
     - smarty
     - toc:
-        permalink: True
+        permalink: true
     - sane_lists
 ```
+
+> NOTE: **Dynamic config values.**
+>
+> To dynamically configure the extensions, you can get the config values from [environment variables](#environment-variables) or [obtain paths](#paths-relative-to-the-current-file-or-site) of the currently rendered Markdown file or the overall MkDocs site.
 
 In the above examples, each extension is a list item (starts with a `-`). As an
 alternative, key/value pairs can be used instead. However, in that case an empty
@@ -654,14 +658,14 @@ Therefore, the last example above could also be defined as follows:
 markdown_extensions:
     smarty: {}
     toc:
-        permalink: True
+        permalink: true
     sane_lists: {}
 ```
 
 This alternative syntax is required if you intend to override some options via
 [inheritance].
 
-> NOTE: **See Also:**
+> NOTE: **More extensions.**
 >
 > The Python-Markdown documentation provides a [list of extensions][exts]
 > which are available out-of-the-box. For a list of configuration options
@@ -896,7 +900,9 @@ plugins:
 
 **default**: `full`
 
-## Environment Variables
+## Special YAML tags
+
+### Environment variables
 
 In most cases, the value of a configuration option is set directly in the
 configuration file. However, as an option, the value of a configuration option
@@ -932,6 +938,41 @@ cannot be defined within a single environment variable.
 
 For more details, see the [pyyaml_env_tag](https://github.com/waylan/pyyaml-env-tag)
 project.
+
+### Paths relative to the current file or site
+
+NEW: **New in version 1.5.**
+
+Some Markdown extensions can benefit from knowing the path of the Markdown file that's currently being processed, or just the root path of the current site. For that, the special tag `!relative` can be used in most contexts within the config file, though the only known usecases are within [`markdown_extensions`](#markdown_extensions).
+
+Examples of the possible values are:
+
+```yaml
+- !relative  # Relative to the directory of the current Markdown file
+- !relative $docs_dir  # Path of the docs_dir
+- !relative $config_dir  # Path of the directory that contains the main mkdocs.yml
+- !relative $config_dir/some/child/dir  # Some subdirectory of the root config directory
+```
+
+(Here, `$docs_dir` and `$config_dir` are currently the *only* special prefixes that are recognized.)
+
+Example:
+
+```yaml
+markdown_extensions:
+  - pymdownx.snippets:
+      base_path: !relative  # Relative to the current Markdown file
+```
+
+This allows the [pymdownx.snippets] extension to include files relative to the current Markdown file, which without this tag it would have no way of knowing.
+
+> NOTE: Even for the default case, any extension's base path is technically the *current working directory* although the assumption is that it's the *directory of mkdocs.yml*. So even if you don't want the paths to be relative, to improve the default behavior, always prefer to use this idiom:
+>
+> ```yaml
+> markdown_extensions:
+>   - pymdownx.snippets:
+>       base_path: !relative $config_dir  # Relative to the root directory with mkdocs.yml
+> ```
 
 ## Configuration Inheritance
 
@@ -1077,3 +1118,4 @@ echo '{INHERIT: mkdocs.yml, site_name: "Renamed site"}' | mkdocs build -f -
 [markdown_extensions]: #markdown_extensions
 [nav]: #nav
 [inheritance]: #configuration-inheritance
+[pymdownx.snippets]: https://facelessuser.github.io/pymdown-extensions/extensions/snippets/

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -154,6 +154,7 @@ def _build_extra_template(template_name: str, files: Files, config: MkDocsConfig
 def _populate_page(page: Page, config: MkDocsConfig, files: Files, dirty: bool = False) -> None:
     """Read page content from docs_dir and render Markdown."""
 
+    config._current_page = page
     try:
         # When --dirty is used, only read the page if the file has been modified since the
         # previous build of the output.
@@ -185,6 +186,8 @@ def _populate_page(page: Page, config: MkDocsConfig, files: Files, dirty: bool =
             message += f" {e}"
         log.error(message)
         raise
+    finally:
+        config._current_page = None
 
 
 def _build_page(
@@ -198,6 +201,7 @@ def _build_page(
 ) -> None:
     """Pass a Page to theme template and write output to site_dir."""
 
+    config._current_page = page
     try:
         # When --dirty is used, only build the page if the file has been modified since the
         # previous build of the output.
@@ -238,8 +242,6 @@ def _build_page(
         else:
             log.info(f"Page skipped: '{page.file.src_uri}'. Generated empty output.")
 
-        # Deactivate page
-        page.active = False
     except Exception as e:
         message = f"Error building page '{page.file.src_uri}':"
         # Prevent duplicated the error message because it will be printed immediately afterwards.
@@ -247,6 +249,10 @@ def _build_page(
             message += f" {e}"
         log.error(message)
         raise
+    finally:
+        # Deactivate page
+        page.active = False
+        config._current_page = None
 
 
 def build(

--- a/mkdocs/commands/gh_deploy.py
+++ b/mkdocs/commands/gh_deploy.py
@@ -116,7 +116,7 @@ def gh_deploy(
 
     if message is None:
         message = default_message
-    sha = _get_current_sha(os.path.dirname(config.config_file_path or ''))
+    sha = _get_current_sha(os.path.dirname(config.config_file_path))
     message = message.format(version=mkdocs.__version__, sha=sha)
 
     log.info(

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -100,7 +100,8 @@ def serve(
         if livereload:
             # Watch the documentation files, the config file and the theme files.
             server.watch(config.docs_dir)
-            server.watch(config.config_file_path)
+            if config.config_file_path:
+                server.watch(config.config_file_path)
 
             if watch_theme:
                 for d in config.theme.dirs:

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -21,8 +21,6 @@ from typing import (
     overload,
 )
 
-from yaml import YAMLError
-
 from mkdocs import exceptions, utils
 from mkdocs.utils import weak_property
 
@@ -257,13 +255,12 @@ class Config(UserDict):
 
     def load_file(self, config_file: IO) -> None:
         """Load config options from the open file descriptor of a YAML file."""
-        try:
-            return self.load_dict(utils.yaml_load(config_file))
-        except YAMLError as e:
-            # MkDocs knows and understands ConfigurationErrors
-            raise exceptions.ConfigurationError(
-                f"MkDocs encountered an error parsing the configuration file: {e}"
-            )
+        warnings.warn(
+            "Config.load_file is not used since MkDocs 1.5 and will be removed soon. "
+            "Use MkDocsConfig.load_file instead",
+            DeprecationWarning,
+        )
+        return self.load_dict(utils.yaml_load(config_file))
 
     @weak_property
     def user_configs(self) -> Sequence[Mapping[str, Any]]:

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -708,7 +708,7 @@ class Dir(FilesystemObject):
 
 class DocsDir(Dir):
     def post_validation(self, config: Config, key_name: str):
-        if config.config_file_path is None:
+        if not config.config_file_path:
             return
 
         # Validate that the dir is not the parent dir of the config file.
@@ -826,7 +826,7 @@ class Theme(BaseConfigOption[theme.Theme]):
 
         # Ensure custom_dir is an absolute path
         if 'custom_dir' in theme_config and not os.path.isabs(theme_config['custom_dir']):
-            config_dir = os.path.dirname(self.config_file_path or '')
+            config_dir = os.path.dirname(self.config_file_path)
             theme_config['custom_dir'] = os.path.join(config_dir, theme_config['custom_dir'])
 
         if 'custom_dir' in theme_config and not os.path.isdir(theme_config['custom_dir']):

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -16,7 +16,7 @@ def get_schema() -> base.PlainConfigSchema:
 class MkDocsConfig(base.Config):
     """The configuration of MkDocs itself (the root object of mkdocs.yml)."""
 
-    config_file_path: str | None = c.Optional(c.Type(str))  # type: ignore[assignment]
+    config_file_path: str = c.Type(str)  # type: ignore[assignment]
     """The path to the mkdocs.yml config file. Can't be populated from the config."""
 
     site_name = c.Type(str)

--- a/mkdocs/utils/yaml.py
+++ b/mkdocs/utils/yaml.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import os.path
+from typing import IO, TYPE_CHECKING, Any
+
+import mergedeep
+import yaml
+import yaml.constructor
+import yaml_env_tag
+
+from mkdocs import exceptions
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
+
+log = logging.getLogger(__name__)
+
+
+def _construct_dir_placeholder(
+    config: MkDocsConfig, loader: yaml.BaseLoader, node: yaml.ScalarNode
+) -> _DirPlaceholder:
+    loader.construct_scalar(node)
+
+    value = (node and node.value) or ''
+    prefix, _, subvalue = value.partition('/')
+    if prefix.startswith('$'):
+        if prefix == '$config_dir':
+            return _ConfigDirPlaceholder(config, subvalue)
+        elif prefix == '$docs_dir':
+            return _DocsDirPlaceholder(config, subvalue)
+        else:
+            raise exceptions.ConfigurationError(
+                f"Unknown prefix {prefix!r} in {node.tag} {node.value!r}"
+            )
+    else:
+        if value:
+            raise exceptions.ConfigurationError(
+                f"{node.tag!r} tag does not expect any value; received {node.value!r}"
+            )
+        return _RelativeDirPlaceholder(config)
+
+
+class _DirPlaceholder(os.PathLike):
+    def __init__(self, config: MkDocsConfig, suffix: str = ''):
+        self.config = config
+        self.suffix = suffix
+
+    def value(self) -> str:
+        raise NotImplementedError
+
+    def __fspath__(self) -> str:
+        return os.path.join(self.value(), self.suffix)
+
+    def __str__(self) -> str:
+        return self.__fspath__()
+
+
+class _ConfigDirPlaceholder(_DirPlaceholder):
+    def value(self) -> str:
+        return os.path.dirname(self.config.config_file_path)
+
+
+class _DocsDirPlaceholder(_DirPlaceholder):
+    def value(self) -> str:
+        return self.config.docs_dir
+
+
+class _RelativeDirPlaceholder(_DirPlaceholder):
+    def value(self) -> str:
+        if self.config._current_page is None:
+            raise exceptions.ConfigurationError(
+                "The current file is not set for the '!relative' tag. "
+                "It cannot be used in this context; the intended usage is within `markdown_extensions`."
+            )
+        return os.path.dirname(self.config._current_page.file.abs_src_path)
+
+
+def get_yaml_loader(loader=yaml.Loader, config: MkDocsConfig | None = None):
+    """Wrap PyYaml's loader so we can extend it to suit our needs."""
+
+    class Loader(loader):
+        """
+        Define a custom loader derived from the global loader to leave the
+        global loader unaltered.
+        """
+
+    # Attach Environment Variable constructor.
+    # See https://github.com/waylan/pyyaml-env-tag
+    Loader.add_constructor('!ENV', yaml_env_tag.construct_env_tag)
+
+    if config is not None:
+        Loader.add_constructor('!relative', functools.partial(_construct_dir_placeholder, config))
+
+    return Loader
+
+
+def yaml_load(source: IO | str, loader: type[yaml.BaseLoader] | None = None) -> dict[str, Any]:
+    """Return dict of source YAML file using loader, recursively deep merging inherited parent."""
+    loader = loader or get_yaml_loader()
+    try:
+        result = yaml.load(source, Loader=loader)
+    except yaml.YAMLError as e:
+        raise exceptions.ConfigurationError(
+            f"MkDocs encountered an error parsing the configuration file: {e}"
+        )
+    if result is None:
+        return {}
+    if 'INHERIT' in result and not isinstance(source, str):
+        relpath = result.pop('INHERIT')
+        abspath = os.path.normpath(os.path.join(os.path.dirname(source.name), relpath))
+        if not os.path.exists(abspath):
+            raise exceptions.ConfigurationError(
+                f"Inherited config file '{relpath}' does not exist at '{abspath}'."
+            )
+        log.debug(f"Loading inherited configuration file: {abspath}")
+        with open(abspath, 'rb') as fd:
+            parent = yaml_load(fd, loader)
+        result = mergedeep.merge(parent, result)
+    return result


### PR DESCRIPTION
* Closes #2154

```yaml
- !relative  # Obtains the directory of the currently rendered Markdown file
- !relative $config_dir  # Obtains the directory of mkdocs.yml
- !relative $docs_dir  # Obtains the docs_dir
- !relative $docs_dir/some/child/dir
```
