### PR TITLE
Pass config file path through SubConfig to Config

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -58,6 +58,8 @@ class SubConfig(Generic[SomeConfig], BaseConfigOption[SomeConfig]):
     `config_options` are ignored (`validate=False`). Users should typically
     enable validation with `validate=True`.
     """
+    
+    __config_file_path = None
 
     @overload
     def __init__(
@@ -88,8 +90,12 @@ class SubConfig(Generic[SomeConfig], BaseConfigOption[SomeConfig]):
             self._make_config = functools.partial(LegacyConfig, config_options)
         self._do_validation = bool(validate)
 
+
+    def pre_validation(self, config: Config, key_name: str):
+        self._config_file_path = config.config_file_path
+
     def run_validation(self, value: object) -> SomeConfig:
-        config = self._make_config()
+        config = self._make_config(config_file_path=self._config_file_path)
         try:
             config.load_dict(value)
             failed, warnings = config.validate()

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -59,7 +59,7 @@ class SubConfig(Generic[SomeConfig], BaseConfigOption[SomeConfig]):
     enable validation with `validate=True`.
     """
 
-    __config_file_path = None
+    _config_file_path: str | None = None
     config_class: type[SomeConfig]
 
     @overload

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -58,7 +58,7 @@ class SubConfig(Generic[SomeConfig], BaseConfigOption[SomeConfig]):
     `config_options` are ignored (`validate=False`). Users should typically
     enable validation with `validate=True`.
     """
-    
+
     __config_file_path = None
 
     @overload
@@ -89,7 +89,6 @@ class SubConfig(Generic[SomeConfig], BaseConfigOption[SomeConfig]):
         else:
             self._make_config = functools.partial(LegacyConfig, config_options)
         self._do_validation = bool(validate)
-
 
     def pre_validation(self, config: Config, key_name: str):
         self._config_file_path = config.config_file_path

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -1262,6 +1262,20 @@ class SubConfigTest(TestCase):
         conf = self.get_config(Schema, {'option': {'cc': 'foo'}})
         self.assertEqual(conf['option'], {'cc': 'foo'})
 
+    def test_config_file_path_pass_through(self) -> None:
+        """Necessary to ensure FilesystemObject validates the correct path"""
+
+        class SubType(c.BaseConfigOption):
+            def pre_validation(self, config: c.Config, key_name: str) -> None:
+                assert_equal(config.config_file_path, CONFIG_PATH)
+
+        class Schema:
+            sub = c.SubConfig(('opt', SubType()))
+
+        assert_equal = self.assertEqual
+        CONFIG_PATH = "foo/mkdocs.yaml"
+        conf = self.get_config(Schema, {"sub": {"opt": "bar"}}, config_file_path=CONFIG_PATH)
+
 
 class ConfigItemsTest(TestCase):
     def test_subconfig_with_multiple_items(self):

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -1274,7 +1274,7 @@ class SubConfigTest(TestCase):
 
         assert_equal = self.assertEqual
         CONFIG_PATH = "foo/mkdocs.yaml"
-        conf = self.get_config(Schema, {"sub": {"opt": "bar"}}, config_file_path=CONFIG_PATH)
+        _ = self.get_config(Schema, {"sub": {"opt": "bar"}}, config_file_path=CONFIG_PATH)
 
 
 class ConfigItemsTest(TestCase):

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -1262,19 +1262,22 @@ class SubConfigTest(TestCase):
         conf = self.get_config(Schema, {'option': {'cc': 'foo'}})
         self.assertEqual(conf['option'], {'cc': 'foo'})
 
-    def test_config_file_path_pass_through(self) -> None:
+    def test_config_file_path_pass_through(self):
         """Necessary to ensure FilesystemObject validates the correct path"""
 
+        passed_config_path = None
+
         class SubType(c.BaseConfigOption):
-            def pre_validation(self, config: c.Config, key_name: str) -> None:
-                assert_equal(config.config_file_path, CONFIG_PATH)
+            def pre_validation(self, config, key_name):
+                nonlocal passed_config_path
+                passed_config_path = config.config_file_path
 
         class Schema:
             sub = c.SubConfig(('opt', SubType()))
 
-        assert_equal = self.assertEqual
-        CONFIG_PATH = "foo/mkdocs.yaml"
-        _ = self.get_config(Schema, {"sub": {"opt": "bar"}}, config_file_path=CONFIG_PATH)
+        config_path = "foo/mkdocs.yaml"
+        self.get_config(Schema, {"sub": {"opt": "bar"}}, config_file_path=config_path)
+        self.assertEqual(passed_config_path, config_path)
 
 
 class ConfigItemsTest(TestCase):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1494,7 +1494,7 @@ class SubConfigTest(TestCase):
 
         assert_equal = self.assertEqual
         CONFIG_PATH = "foo/mkdocs.yaml"
-        conf = self.get_config(Schema, {"sub": [{"opt": "bar"}]}, config_file_path=CONFIG_PATH)
+        _ = self.get_config(Schema, {"sub": [{"opt": "bar"}]}, config_file_path=CONFIG_PATH)
 
 
 class MarkdownExtensionsTest(TestCase):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1479,6 +1479,23 @@ class SubConfigTest(TestCase):
         with self.expect_error(sub="Required configuration not provided."):
             conf = self.get_config(Schema, {'sub': None})
 
+    def test_config_file_path_pass_through(self) -> None:
+        """Necessary to ensure FilesystemObject validates the correct path"""
+
+        class SubType(c.BaseConfigOption):
+            def pre_validation(self, config: Config, key_name: str) -> None:
+                assert_equal(config.config_file_path, CONFIG_PATH)
+
+        class Sub(Config):
+            opt = SubType()
+
+        class Schema(Config):
+            sub = c.ListOfItems(c.SubConfig(Sub), default=[])
+
+        assert_equal = self.assertEqual
+        CONFIG_PATH = "foo/mkdocs.yaml"
+        conf = self.get_config(Schema, {"sub": [{"opt": "bar"}]}, config_file_path=CONFIG_PATH)
+
 
 class MarkdownExtensionsTest(TestCase):
     @patch('markdown.Markdown')

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1555,9 +1555,12 @@ class SubConfigTest(TestCase):
     def test_config_file_path_pass_through(self) -> None:
         """Necessary to ensure FilesystemObject validates the correct path"""
 
+        passed_config_path = None
+
         class SubType(c.BaseConfigOption):
             def pre_validation(self, config: Config, key_name: str) -> None:
-                assert_equal(config.config_file_path, CONFIG_PATH)
+                nonlocal passed_config_path
+                passed_config_path = config.config_file_path
 
         class Sub(Config):
             opt = SubType()
@@ -1565,9 +1568,9 @@ class SubConfigTest(TestCase):
         class Schema(Config):
             sub = c.ListOfItems(c.SubConfig(Sub), default=[])
 
-        assert_equal = self.assertEqual
-        CONFIG_PATH = "foo/mkdocs.yaml"
-        _ = self.get_config(Schema, {"sub": [{"opt": "bar"}]}, config_file_path=CONFIG_PATH)
+        config_path = "foo/mkdocs.yaml"
+        self.get_config(Schema, {"sub": [{"opt": "bar"}]}, config_file_path=config_path)
+        self.assertEqual(passed_config_path, config_path)
 
 
 class MarkdownExtensionsTest(TestCase):


### PR DESCRIPTION
This ensures FilesystemObject fields in Config are correctly evaluated relative to mkdocs.yaml.

See #3264