### PR TITLE
Expand link validation, add configs for it

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -384,24 +384,20 @@ The defaults of some of the behaviors already differ from MkDocs 1.4 and below -
 >
 > ```yaml
 > validation:
->   nav:
->     absolute_links: ignore
->   links:
->     absolute_links: ignore
->     unrecognized_links: ignore
+>   absolute_links: ignore
+>   unrecognized_links: ignore
 > ```
 <!-- -->
 >! EXAMPLE: **Recommended settings for most sites (maximal strictness):**
 >
 > ```yaml
 > validation:
->   nav:
->     omitted_files: warn
->     absolute_links: warn
->   links:
->     absolute_links: warn
->     unrecognized_links: warn
+>   omitted_files: warn
+>   absolute_links: warn
+>   unrecognized_links: warn
 > ```
+
+Note how in the above examples we omitted the 'nav' and 'links' keys. Here `absolute_links:` means setting both `nav: absolute_links:` and `links: absolute_links:`.
 
 Full list of values and examples of log messages that they can hide or make more prominent:
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -343,16 +343,84 @@ Example:
 
 ```yaml
 nav:
-    - Foo: foo.md
-    - Bar: bar.md
+  - Foo: foo.md
+  - Bar: bar.md
 
 not_in_nav: |
-    /private.md
+  /private.md
 ```
 
 As the previous option, this follows the .gitignore pattern format.
 
 NOTE: Adding a given file to [`exclude_docs`](#exclude_docs) takes precedence over and implies `not_in_nav`.
+
+### validation
+
+NEW: **New in version 1.5.**
+
+Configure the strictness of MkDocs' diagnostic messages when validating links to documents.
+
+This is a tree of configs, and for each one the value can be one of the three: `warn`, `info`, `ignore`. Which cause a logging message of the corresponding severity to be produced. The `warn` level is, of course, intended for use with `mkdocs build --strict` (where it becomes an error), which you can employ in continuous testing.
+
+> EXAMPLE: **Defaults of this config as of MkDocs 1.5:**
+>
+> ```yaml
+> validation:
+>   nav:
+>     omitted_files: info
+>     not_found: warn
+>     absolute_links: info
+>   links:
+>     not_found: warn
+>     absolute_links: info
+>     unrecognized_links: info
+> ```
+>
+> (Note: you shouldn't copy this whole example, because it only duplicates the defaults. Only individual items that differ should be set.)
+
+The defaults of some of the behaviors already differ from MkDocs 1.4 and below - they were ignored before.
+
+>? EXAMPLE: **Configure MkDocs 1.5 to behave like MkDocs 1.4 and below (reduce strictness):**
+>
+> ```yaml
+> validation:
+>   nav:
+>     absolute_links: ignore
+>   links:
+>     absolute_links: ignore
+>     unrecognized_links: ignore
+> ```
+<!-- -->
+>! EXAMPLE: **Recommended settings for most sites (maximal strictness):**
+>
+> ```yaml
+> validation:
+>   nav:
+>     omitted_files: warn
+>     absolute_links: warn
+>   links:
+>     absolute_links: warn
+>     unrecognized_links: warn
+> ```
+
+Full list of values and examples of log messages that they can hide or make more prominent:
+
+*   `validation.nav.omitted_files`  
+    * "The following pages exist in the docs directory, but are not included in the "nav" configuration: ..."
+*   `validation.nav.not_found`  
+    * "A relative path to 'foo/bar.md' is included in the 'nav' configuration, which is not found in the documentation files."
+    * "A reference to 'foo/bar.md' is included in the 'nav' configuration, but this file is excluded from the built site."
+*   `validation.nav.absolute_links`  
+    * "An absolute path to '/foo/bar.html' is included in the 'nav' configuration, which presumably points to an external resource."
+<!-- -->
+*   `validation.links.not_found`  
+    * "Doc file 'example.md' contains a relative link '../foo/bar.md', but the target is not found among documentation files."
+    * "Doc file 'example.md' contains a link to 'foo/bar.md' which is excluded from the built site."
+*   `validation.links.absolute_links`
+    * "Doc file 'example.md' contains an absolute link '/foo/bar.html', it was left as is. Did you mean 'foo/bar.md'?"
+*   `validation.links.unrecognized_links`
+    * "Doc file 'example.md' contains an unrecognized relative link '../foo/bar/', it was left as is. Did you mean 'foo/bar.md'?"
+    * "Doc file 'example.md' contains an unrecognized relative link 'mail\@example.com', it was left as is. Did you mean 'mailto:mail\@example.com'?"
 
 ## Build directories
 

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import ipaddress
+import logging
 import os
 import string
 import sys
@@ -1170,3 +1171,19 @@ class PathSpec(BaseConfigOption[pathspec.gitignore.GitIgnoreSpec]):
             return pathspec.gitignore.GitIgnoreSpec.from_lines(lines=value.splitlines())
         except ValueError as e:
             raise ValidationError(str(e))
+
+
+class _LogLevel(OptionallyRequired[int]):
+    levels: Mapping[str, int] = {
+        "warn": logging.WARNING,
+        "info": logging.INFO,
+        "ignore": logging.DEBUG,
+    }
+
+    def run_validation(self, value: object) -> int:
+        if not isinstance(value, str):
+            raise ValidationError(f'Expected a string, but a {type(value)} was given.')
+        try:
+            return self.levels[value]
+        except KeyError:
+            raise ValidationError(f'Expected one of {list(self.levels)}, got {value!r}')

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -8,10 +8,6 @@ from mkdocs.config import config_options as c
 from mkdocs.utils.yaml import get_yaml_loader, yaml_load
 
 
-def get_schema() -> base.PlainConfigSchema:
-    return MkDocsConfig._schema
-
-
 # NOTE: The order here is important. During validation some config options
 # depend on others. So, if config option A depends on B, then A should be
 # listed higher in the schema.
@@ -152,3 +148,8 @@ class MkDocsConfig(base.Config):
         """Load config options from the open file descriptor of a YAML file."""
         loader = get_yaml_loader(config=self)
         self.load_dict(yaml_load(config_file, loader))
+
+
+def get_schema() -> base.PlainConfigSchema:
+    """Soft-deprecated, do not use."""
+    return MkDocsConfig._schema

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -28,7 +28,11 @@ class MkDocsConfig(base.Config):
     """Gitignore-like patterns of files (relative to docs dir) to exclude from the site."""
 
     not_in_nav = c.Optional(c.PathSpec())
-    """Gitignore-like patterns of files (relative to docs dir) that are not intended to be in the nav."""
+    """Gitignore-like patterns of files (relative to docs dir) that are not intended to be in the nav.
+
+    This marks doc files that are expected not to be in the nav, otherwise they will cause a log message
+    (see also `validation.nav.omitted_files`).
+    """
 
     site_url = c.Optional(c.URL(is_dir=True))
     """The full URL to where the documentation will be hosted."""
@@ -134,6 +138,35 @@ class MkDocsConfig(base.Config):
 
     watch = c.ListOfPaths(default=[])
     """A list of extra paths to watch while running `mkdocs serve`."""
+
+    class Validation(base.Config):
+        class NavValidation(base.Config):
+            omitted_files = c._LogLevel(default='info')
+            """Warning level for when a doc file is never mentioned in the navigation.
+            For granular configuration, see `not_in_nav`."""
+
+            not_found = c._LogLevel(default='warn')
+            """Warning level for when the navigation links to a relative path that isn't an existing page on the site."""
+
+            absolute_links = c._LogLevel(default='info')
+            """Warning level for when the navigation links to an absolute path (starting with `/`)."""
+
+        nav = c.SubConfig(NavValidation)
+
+        class LinksValidation(base.Config):
+            not_found = c._LogLevel(default='warn')
+            """Warning level for when a Markdown doc links to a relative path that isn't an existing document on the site."""
+
+            absolute_links = c._LogLevel(default='info')
+            """Warning level for when a Markdown doc links to an absolute path (starting with `/`)."""
+
+            unrecognized_links = c._LogLevel(default='info')
+            """Warning level for when a Markdown doc links to a relative path that doesn't look like
+            it could be a valid internal link. For example, if the link ends with `/`."""
+
+        links = c.SubConfig(LinksValidation)
+
+    validation = c.SubConfig(Validation)
 
     _current_page: mkdocs.structure.pages.Page | None = None
     """The currently rendered page. Please do not access this and instead

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -166,7 +166,7 @@ class MkDocsConfig(base.Config):
 
         links = c.SubConfig(LinksValidation)
 
-    validation = c.SubConfig(Validation)
+    validation = c.PropagatingSubConfig[Validation]()
 
     _current_page: mkdocs.structure.pages.Page | None = None
     """The currently rendered page. Please do not access this and instead

--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -148,9 +148,10 @@ def get_navigation(files: Files, config: MkDocsConfig) -> Navigation:
             if file.inclusion.is_in_nav():
                 missing_from_config.append(file.src_path)
     if missing_from_config:
-        log.info(
+        log.log(
+            config.validation.nav.omitted_files,
             'The following pages exist in the docs directory, but are not '
-            'included in the "nav" configuration:\n  - ' + '\n  - '.join(missing_from_config)
+            'included in the "nav" configuration:\n  - ' + '\n  - '.join(missing_from_config),
         )
 
     links = _get_by_type(items, Link)
@@ -159,14 +160,16 @@ def get_navigation(files: Files, config: MkDocsConfig) -> Navigation:
         if scheme or netloc:
             log.debug(f"An external link to '{link.url}' is included in the 'nav' configuration.")
         elif link.url.startswith('/'):
-            log.debug(
+            log.log(
+                config.validation.nav.absolute_links,
                 f"An absolute path to '{link.url}' is included in the 'nav' "
-                "configuration, which presumably points to an external resource."
+                "configuration, which presumably points to an external resource.",
             )
         else:
-            log.warning(
+            log.log(
+                config.validation.nav.not_found,
                 f"A relative path to '{link.url}' is included in the 'nav' "
-                "configuration, which is not found in the documentation files."
+                "configuration, which is not found in the documentation files.",
             )
     return Navigation(items, pages)
 
@@ -190,9 +193,10 @@ def _data_to_navigation(data, files: Files, config: MkDocsConfig):
     file = files.get_file_from_path(path)
     if file:
         if file.inclusion.is_excluded():
-            log.info(
-                f"A relative path to '{file.src_path}' is included in the 'nav' "
-                "configuration, but this file is excluded from the built site."
+            log.log(
+                min(logging.INFO, config.validation.nav.not_found),
+                f"A reference to '{file.src_path}' is included in the 'nav' "
+                "configuration, but this file is excluded from the built site.",
             )
         return Page(title, file, config)
     return Link(title, path)

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -599,7 +599,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
 
         with self.subTest(live_server=None):
             expected_logs = '''
-                INFO:Documentation file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
+                INFO:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
             '''
             with self._assert_build_logs(expected_logs):
                 build.build(cfg)
@@ -610,8 +610,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         server = testing_server(site_dir, mount_path='/documentation/')
         with self.subTest(live_server=server):
             expected_logs = '''
-                INFO:Documentation file 'test/bar.md' contains a link to 'test/baz.md' which is excluded from the built site.
-                INFO:Documentation file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
+                INFO:Doc file 'test/bar.md' contains a link to 'test/baz.md' which is excluded from the built site.
+                INFO:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
                 INFO:The following pages are being built only for the preview but will be excluded from `mkdocs build` per `exclude_docs`:
                   - http://localhost:123/documentation/.zoo.html
                   - http://localhost:123/documentation/test/bar.html

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -58,9 +58,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             {'Home': 'index.md'},
         ]
         cfg = load_config(nav=nav_cfg, use_directory_urls=False)
-        fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         context = build.get_context(nav, files, cfg, nav.pages[0])
@@ -71,9 +69,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             {'Home': 'index.md'},
         ]
         cfg = load_config(nav=nav_cfg)
-        fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         context = build.get_context(nav, files, cfg, nav.pages[0])
@@ -86,8 +82,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         ]
         cfg = load_config(nav=nav_cfg, use_directory_urls=False)
         fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-            File('foo/bar.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
+            File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File('foo/bar.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
         ]
         files = Files(fs)
         nav = get_navigation(files, cfg)
@@ -101,8 +97,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         ]
         cfg = load_config(nav=nav_cfg)
         fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-            File('foo/bar.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
+            File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File('foo/bar.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
         ]
         files = Files(fs)
         nav = get_navigation(files, cfg)
@@ -149,9 +145,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             extra_javascript=['script.js'],
             use_directory_urls=False,
         )
-        fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         context = build.get_context(nav, files, cfg, nav.pages[0])
@@ -170,8 +164,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             use_directory_urls=False,
         )
         fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-            File('foo/bar.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
+            File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File('foo/bar.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
         ]
         files = Files(fs)
         nav = get_navigation(files, cfg)
@@ -190,8 +184,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             extra_javascript=['script.js'],
         )
         fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-            File('foo/bar.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
+            File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File('foo/bar.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
         ]
         files = Files(fs)
         nav = get_navigation(files, cfg)
@@ -210,9 +204,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             extra_css=['assets\\style.css'],
             use_directory_urls=False,
         )
-        fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         with self.assertLogs('mkdocs') as cm:
@@ -241,7 +233,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.commands.build._build_template', return_value='some content')
     def test_build_theme_template(self, mock_build_template, mock_write_file):
         cfg = load_config()
-        env = cfg['theme'].get_env()
+        env = cfg.theme.get_env()
         build._build_theme_template('main.html', env, mock.Mock(), cfg, mock.Mock())
         mock_write_file.assert_called_once()
         mock_build_template.assert_called_once()
@@ -254,7 +246,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         self, site_dir, mock_gzip_gzipfile, mock_build_template, mock_write_file
     ):
         cfg = load_config(site_dir=site_dir)
-        env = cfg['theme'].get_env()
+        env = cfg.theme.get_env()
         build._build_theme_template('sitemap.xml', env, mock.Mock(), cfg, mock.Mock())
         mock_write_file.assert_called_once()
         mock_build_template.assert_called_once()
@@ -264,7 +256,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.commands.build._build_template', return_value='')
     def test_skip_missing_theme_template(self, mock_build_template, mock_write_file):
         cfg = load_config()
-        env = cfg['theme'].get_env()
+        env = cfg.theme.get_env()
         with self.assertLogs('mkdocs') as cm:
             build._build_theme_template('missing.html', env, mock.Mock(), cfg, mock.Mock())
         self.assertEqual(
@@ -278,7 +270,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.commands.build._build_template', return_value='')
     def test_skip_theme_template_empty_output(self, mock_build_template, mock_write_file):
         cfg = load_config()
-        env = cfg['theme'].get_env()
+        env = cfg.theme.get_env()
         with self.assertLogs('mkdocs') as cm:
             build._build_theme_template('main.html', env, mock.Mock(), cfg, mock.Mock())
         self.assertEqual(
@@ -294,18 +286,14 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.commands.build.open', mock.mock_open(read_data='template content'))
     def test_build_extra_template(self, site_dir):
         cfg = load_config(site_dir=site_dir)
-        fs = [
-            File('foo.html', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('foo.html', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         build._build_extra_template('foo.html', files, cfg, mock.Mock())
 
     @mock.patch('mkdocs.commands.build.open', mock.mock_open(read_data='template content'))
     def test_skip_missing_extra_template(self):
         cfg = load_config()
-        fs = [
-            File('foo.html', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('foo.html', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         with self.assertLogs('mkdocs') as cm:
             build._build_extra_template('missing.html', files, cfg, mock.Mock())
@@ -317,9 +305,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.commands.build.open', side_effect=OSError('Error message.'))
     def test_skip_ioerror_extra_template(self, mock_open):
         cfg = load_config()
-        fs = [
-            File('foo.html', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('foo.html', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         with self.assertLogs('mkdocs') as cm:
             build._build_extra_template('foo.html', files, cfg, mock.Mock())
@@ -331,9 +317,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.commands.build.open', mock.mock_open(read_data=''))
     def test_skip_extra_template_empty_output(self):
         cfg = load_config()
-        fs = [
-            File('foo.html', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-        ]
+        fs = [File('foo.html', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         with self.assertLogs('mkdocs') as cm:
             build._build_extra_template('foo.html', files, cfg, mock.Mock())
@@ -347,7 +331,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @tempdir(files={'index.md': 'page content'})
     def test_populate_page(self, docs_dir):
         cfg = load_config(docs_dir=docs_dir)
-        file = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        file = File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         page = Page('Foo', file, cfg)
         build._populate_page(page, cfg, Files([file]))
         self.assertEqual(page.content, '<p>page content</p>')
@@ -355,7 +339,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @tempdir(files={'testing.html': '<p>page content</p>'})
     def test_populate_page_dirty_modified(self, site_dir):
         cfg = load_config(site_dir=site_dir)
-        file = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        file = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         page = Page('Foo', file, cfg)
         build._populate_page(page, cfg, Files([file]), dirty=True)
         self.assertTrue(page.markdown.startswith('# Welcome to MkDocs'))
@@ -367,7 +351,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @tempdir(files={'index.html': '<p>page content</p>'})
     def test_populate_page_dirty_not_modified(self, site_dir, docs_dir):
         cfg = load_config(docs_dir=docs_dir, site_dir=site_dir)
-        file = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        file = File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         page = Page('Foo', file, cfg)
         build._populate_page(page, cfg, Files([file]), dirty=True)
         # Content is empty as file read was skipped
@@ -378,7 +362,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.structure.pages.open', side_effect=OSError('Error message.'))
     def test_populate_page_read_error(self, docs_dir, mock_open):
         cfg = load_config(docs_dir=docs_dir)
-        file = File('missing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        file = File('missing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         page = Page('Foo', file, cfg)
         with self.assertLogs('mkdocs') as cm:
             with self.assertRaises(OSError):
@@ -400,7 +384,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         cfg = load_config(docs_dir=docs_dir)
         cfg.plugins.events['page_markdown'].append(on_page_markdown)
 
-        file = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        file = File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         page = Page('Foo', file, cfg)
         with self.assertLogs('mkdocs') as cm:
             with self.assertRaises(PluginError):
@@ -415,7 +399,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @tempdir()
     def test_build_page(self, site_dir):
         cfg = load_config(site_dir=site_dir, nav=['index.md'])
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         page = files.documentation_pages()[0].page
@@ -430,12 +414,12 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('jinja2.environment.Template.render', return_value='')
     def test_build_page_empty(self, site_dir, render_mock):
         cfg = load_config(site_dir=site_dir, nav=['index.md'])
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         with self.assertLogs('mkdocs') as cm:
             build._build_page(
-                files.documentation_pages()[0].page, cfg, files, nav, cfg['theme'].get_env()
+                files.documentation_pages()[0].page, cfg, files, nav, cfg.theme.get_env()
             )
         self.assertEqual(
             '\n'.join(cm.output),
@@ -449,7 +433,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.utils.write_file')
     def test_build_page_dirty_modified(self, site_dir, docs_dir, mock_write_file):
         cfg = load_config(docs_dir=docs_dir, site_dir=site_dir, nav=['index.md'])
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         page = files.documentation_pages()[0].page
@@ -466,7 +450,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.utils.write_file')
     def test_build_page_dirty_not_modified(self, site_dir, mock_write_file):
         cfg = load_config(site_dir=site_dir, nav=['testing.md'])
-        fs = [File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         page = files.documentation_pages()[0].page
@@ -482,7 +466,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @tempdir()
     def test_build_page_custom_template(self, site_dir):
         cfg = load_config(site_dir=site_dir, nav=['index.md'])
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         page = files.documentation_pages()[0].page
@@ -498,7 +482,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     @mock.patch('mkdocs.utils.write_file', side_effect=OSError('Error message.'))
     def test_build_page_error(self, site_dir, mock_write_file):
         cfg = load_config(site_dir=site_dir, nav=['index.md'])
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         page = files.documentation_pages()[0].page
@@ -522,7 +506,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
 
         cfg = load_config(site_dir=site_dir, nav=['index.md'])
         cfg.plugins.events['page_context'].append(on_page_context)
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         nav = get_navigation(files, cfg)
         page = files.documentation_pages()[0].page
@@ -532,7 +516,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         page.content = '<p>page content</p>'
         with self.assertLogs('mkdocs') as cm:
             with self.assertRaises(PluginError):
-                build._build_page(page, cfg, files, nav, cfg['theme'].get_env())
+                build._build_page(page, cfg, files, nav, cfg.theme.get_env())
         self.assertEqual(
             '\n'.join(cm.output),
             "ERROR:mkdocs.commands.build:Error building page 'index.md':",

--- a/mkdocs/tests/config/base_tests.py
+++ b/mkdocs/tests/config/base_tests.py
@@ -52,7 +52,7 @@ class ConfigBaseTests(unittest.TestCase):
 
         cfg = base.load_config(config_file=config_file.name)
         self.assertTrue(isinstance(cfg, defaults.MkDocsConfig))
-        self.assertEqual(cfg['site_name'], 'MkDocs Test')
+        self.assertEqual(cfg.site_name, 'MkDocs Test')
 
     @tempdir()
     def test_load_default_file(self, temp_dir):
@@ -65,7 +65,7 @@ class ConfigBaseTests(unittest.TestCase):
         with change_dir(temp_dir):
             cfg = base.load_config(config_file=None)
             self.assertTrue(isinstance(cfg, defaults.MkDocsConfig))
-            self.assertEqual(cfg['site_name'], 'MkDocs Test')
+            self.assertEqual(cfg.site_name, 'MkDocs Test')
 
     @tempdir
     def test_load_default_file_with_yaml(self, temp_dir):
@@ -78,7 +78,7 @@ class ConfigBaseTests(unittest.TestCase):
         with change_dir(temp_dir):
             cfg = base.load_config(config_file=None)
             self.assertTrue(isinstance(cfg, defaults.MkDocsConfig))
-            self.assertEqual(cfg['site_name'], 'MkDocs Test')
+            self.assertEqual(cfg.site_name, 'MkDocs Test')
 
     @tempdir()
     def test_load_default_file_prefer_yml(self, temp_dir):
@@ -94,7 +94,7 @@ class ConfigBaseTests(unittest.TestCase):
         with change_dir(temp_dir):
             cfg = base.load_config(config_file=None)
             self.assertTrue(isinstance(cfg, defaults.MkDocsConfig))
-            self.assertEqual(cfg['site_name'], 'MkDocs Test1')
+            self.assertEqual(cfg.site_name, 'MkDocs Test1')
 
     def test_load_from_missing_file(self):
         with self.assertRaisesRegex(
@@ -115,7 +115,7 @@ class ConfigBaseTests(unittest.TestCase):
 
         cfg = base.load_config(config_file=config_file)
         self.assertTrue(isinstance(cfg, defaults.MkDocsConfig))
-        self.assertEqual(cfg['site_name'], 'MkDocs Test')
+        self.assertEqual(cfg.site_name, 'MkDocs Test')
         # load_config will always close the file
         self.assertTrue(config_file.closed)
 
@@ -131,7 +131,7 @@ class ConfigBaseTests(unittest.TestCase):
 
         cfg = base.load_config(config_file=config_file)
         self.assertTrue(isinstance(cfg, defaults.MkDocsConfig))
-        self.assertEqual(cfg['site_name'], 'MkDocs Test')
+        self.assertEqual(cfg.site_name, 'MkDocs Test')
 
     @tempdir
     def test_load_missing_required(self, temp_dir):
@@ -265,8 +265,8 @@ class ConfigBaseTests(unittest.TestCase):
 
         cfg = base.load_config(config_file=config_file)
         self.assertTrue(isinstance(cfg, defaults.MkDocsConfig))
-        self.assertEqual(cfg['site_name'], 'MkDocs Test')
-        self.assertEqual(cfg['docs_dir'], docs_dir)
+        self.assertEqual(cfg.site_name, 'MkDocs Test')
+        self.assertEqual(cfg.docs_dir, docs_dir)
         self.assertEqual(cfg.config_file_path, config_fname)
         self.assertIsInstance(cfg.config_file_path, str)
 

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -354,22 +354,12 @@ class SearchIndexTests(unittest.TestCase):
         pages = [
             Page(
                 'Home',
-                File(
-                    'index.md',
-                    base_cfg['docs_dir'],
-                    base_cfg['site_dir'],
-                    base_cfg['use_directory_urls'],
-                ),
+                File('index.md', base_cfg.docs_dir, base_cfg.site_dir, base_cfg.use_directory_urls),
                 base_cfg,
             ),
             Page(
                 'About',
-                File(
-                    'about.md',
-                    base_cfg['docs_dir'],
-                    base_cfg['site_dir'],
-                    base_cfg['use_directory_urls'],
-                ),
+                File('about.md', base_cfg.docs_dir, base_cfg.site_dir, base_cfg.use_directory_urls),
                 base_cfg,
             ),
         ]

--- a/mkdocs/tests/structure/nav_tests.py
+++ b/mkdocs/tests/structure/nav_tests.py
@@ -123,7 +123,7 @@ class SiteNavigationTests(unittest.TestCase):
         self.assertEqual(
             cm.output,
             [
-                "DEBUG:mkdocs.structure.nav:An absolute path to '/local.html' is included in the 'nav' configuration, which presumably points to an external resource.",
+                "INFO:mkdocs.structure.nav:An absolute path to '/local.html' is included in the 'nav' configuration, which presumably points to an external resource.",
                 "DEBUG:mkdocs.structure.nav:An external link to 'http://example.com/external.html' is included in the 'nav' configuration.",
             ],
         )

--- a/mkdocs/tests/structure/nav_tests.py
+++ b/mkdocs/tests/structure/nav_tests.py
@@ -25,9 +25,7 @@ class SiteNavigationTests(unittest.TestCase):
         )
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
         fs = [
-            File(
-                list(item.values())[0], cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']
-            )
+            File(list(item.values())[0], cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
             for item in nav_cfg
         ]
         files = Files(fs)
@@ -50,9 +48,7 @@ class SiteNavigationTests(unittest.TestCase):
         )
         cfg = load_config(nav=nav_cfg, use_directory_urls=False, site_url='http://example.com/')
         fs = [
-            File(
-                list(item.values())[0], cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']
-            )
+            File(list(item.values())[0], cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
             for item in nav_cfg
         ]
         files = Files(fs)
@@ -73,8 +69,8 @@ class SiteNavigationTests(unittest.TestCase):
         )
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
         fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-            File('page_not_in_nav.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
+            File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File('page_not_in_nav.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
         ]
         files = Files(fs)
         site_navigation = get_navigation(files, cfg)
@@ -97,8 +93,8 @@ class SiteNavigationTests(unittest.TestCase):
         )
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
         fs = [
-            File(nav_cfg[0], cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-            File(nav_cfg[1]['About'], cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
+            File(nav_cfg[0], cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File(nav_cfg[1]['About'], cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
         ]
         files = Files(fs)
         site_navigation = get_navigation(files, cfg)
@@ -120,17 +116,15 @@ class SiteNavigationTests(unittest.TestCase):
             """
         )
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         with self.assertLogs('mkdocs', level='DEBUG') as cm:
             site_navigation = get_navigation(files, cfg)
         self.assertEqual(
             cm.output,
             [
-                "DEBUG:mkdocs.structure.nav:An absolute path to '/local.html' is included in the "
-                "'nav' configuration, which presumably points to an external resource.",
-                "DEBUG:mkdocs.structure.nav:An external link to 'http://example.com/external.html' "
-                "is included in the 'nav' configuration.",
+                "DEBUG:mkdocs.structure.nav:An absolute path to '/local.html' is included in the 'nav' configuration, which presumably points to an external resource.",
+                "DEBUG:mkdocs.structure.nav:An external link to 'http://example.com/external.html' is included in the 'nav' configuration.",
             ],
         )
         self.assertEqual(str(site_navigation).strip(), expected)
@@ -151,17 +145,15 @@ class SiteNavigationTests(unittest.TestCase):
             """
         )
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
-        fs = [File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         with self.assertLogs('mkdocs') as cm:
             site_navigation = get_navigation(files, cfg)
         self.assertEqual(
             cm.output,
             [
-                "WARNING:mkdocs.structure.nav:A relative path to 'missing.html' is included "
-                "in the 'nav' configuration, which is not found in the documentation files.",
-                "WARNING:mkdocs.structure.nav:A relative path to 'example.com' is included "
-                "in the 'nav' configuration, which is not found in the documentation files.",
+                "WARNING:mkdocs.structure.nav:A relative path to 'missing.html' is included in the 'nav' configuration, which is not found in the documentation files.",
+                "WARNING:mkdocs.structure.nav:A relative path to 'example.com' is included in the 'nav' configuration, which is not found in the documentation files.",
             ],
         )
         self.assertEqual(str(site_navigation).strip(), expected)
@@ -215,9 +207,7 @@ class SiteNavigationTests(unittest.TestCase):
             'api-guide/advanced/part-1.md',
             'about/release-notes.md',
         ]
-        files = Files(
-            [File(s, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']) for s in fs]
-        )
+        files = Files([File(s, cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls) for s in fs])
         site_navigation = get_navigation(files, cfg)
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.items), 4)
@@ -282,9 +272,7 @@ class SiteNavigationTests(unittest.TestCase):
         )
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
         fs = [
-            File(
-                list(item.values())[0], cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']
-            )
+            File(list(item.values())[0], cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
             for item in nav_cfg
         ]
         files = Files(fs)
@@ -308,10 +296,7 @@ class SiteNavigationTests(unittest.TestCase):
         )
 
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
-        fs = [
-            File(item, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
-            for item in nav_cfg
-        ]
+        fs = [File(item, cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls) for item in nav_cfg]
         files = Files(fs)
         site_navigation = get_navigation(files, cfg)
         self.assertEqual(str(site_navigation).strip(), expected)
@@ -335,10 +320,7 @@ class SiteNavigationTests(unittest.TestCase):
         )
 
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
-        fs = [
-            File(item, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
-            for item in nav_cfg
-        ]
+        fs = [File(item, cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls) for item in nav_cfg]
         files = Files(fs)
         site_navigation = get_navigation(files, cfg)
         self.assertEqual(str(site_navigation).strip(), expected)
@@ -354,8 +336,8 @@ class SiteNavigationTests(unittest.TestCase):
         )
         cfg = load_config(site_url='http://example.com/')
         fs = [
-            File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
-            File('about.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']),
+            File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File('about.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
         ]
         files = Files(fs)
         site_navigation = get_navigation(files, cfg)
@@ -389,9 +371,7 @@ class SiteNavigationTests(unittest.TestCase):
             'api-guide/testing.md',
             'api-guide/advanced/part-1.md',
         ]
-        files = Files(
-            [File(s, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']) for s in fs]
-        )
+        files = Files([File(s, cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls) for s in fs])
         site_navigation = get_navigation(files, cfg)
         self.assertEqual(str(site_navigation).strip(), expected)
         self.assertEqual(len(site_navigation.items), 3)
@@ -430,9 +410,7 @@ class SiteNavigationTests(unittest.TestCase):
             'about/release-notes.md',
             'about/license.md',
         ]
-        files = Files(
-            [File(s, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']) for s in fs]
-        )
+        files = Files([File(s, cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls) for s in fs])
         site_navigation = get_navigation(files, cfg)
         # Confirm nothing is active
         self.assertTrue(all(page.active is False for page in site_navigation.pages))
@@ -471,7 +449,7 @@ class SiteNavigationTests(unittest.TestCase):
             },
         ]
         cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
-        fs = [File('page.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])]
+        fs = [File('page.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)]
         files = Files(fs)
         site_navigation = get_navigation(files, cfg)
         self.assertEqual(len(_get_by_type(site_navigation, Section)), 2)

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import functools
 import os
 import sys
+import textwrap
 import unittest
 from unittest import mock
 
@@ -11,15 +14,13 @@ from mkdocs.tests.base import dedent, load_config, tempdir
 
 load_config = functools.lru_cache(maxsize=None)(load_config)
 
+DOCS_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../integration/subpages/docs')
+
 
 class PageTests(unittest.TestCase):
-    DOCS_DIR = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), '../integration/subpages/docs'
-    )
-
     def test_homepage(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         self.assertIsNone(fl.page)
         pg = Page('Foo', fl, cfg)
         self.assertEqual(fl.page, pg)
@@ -43,8 +44,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.toc, [])
 
     def test_nested_index_page(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('sub1/index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('sub1/index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         pg.parent = 'foo'
         self.assertEqual(pg.url, 'sub1/')
@@ -67,8 +68,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.toc, [])
 
     def test_nested_index_page_no_parent(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('sub1/index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('sub1/index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         pg.parent = None  # non-homepage at nav root level; see #1919.
         self.assertEqual(pg.url, 'sub1/')
@@ -91,8 +92,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.toc, [])
 
     def test_nested_index_page_no_parent_no_directory_urls(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR, use_directory_urls=False)
-        fl = File('sub1/index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR, use_directory_urls=False)
+        fl = File('sub1/index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         pg.parent = None  # non-homepage at nav root level; see #1919.
         self.assertEqual(pg.url, 'sub1/index.html')
@@ -115,8 +116,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.toc, [])
 
     def test_nested_nonindex_page(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('sub1/non-index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('sub1/non-index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         pg.parent = 'foo'
         self.assertEqual(pg.url, 'sub1/non-index/')
@@ -140,7 +141,7 @@ class PageTests(unittest.TestCase):
 
     def test_page_defaults(self):
         cfg = load_config()
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         self.assertRegex(pg.update_date, r'\d{4}-\d{2}-\d{2}')
         self.assertEqual(pg.url, 'testing/')
@@ -164,7 +165,7 @@ class PageTests(unittest.TestCase):
 
     def test_page_no_directory_url(self):
         cfg = load_config(use_directory_urls=False)
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         self.assertEqual(pg.url, 'testing.html')
         self.assertEqual(pg.abs_url, None)
@@ -187,7 +188,7 @@ class PageTests(unittest.TestCase):
 
     def test_page_canonical_url(self):
         cfg = load_config(site_url='http://example.com')
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         self.assertEqual(pg.url, 'testing/')
         self.assertEqual(pg.abs_url, '/testing/')
@@ -210,7 +211,7 @@ class PageTests(unittest.TestCase):
 
     def test_page_canonical_url_nested(self):
         cfg = load_config(site_url='http://example.com/foo/')
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         self.assertEqual(pg.url, 'testing/')
         self.assertEqual(pg.abs_url, '/foo/testing/')
@@ -233,7 +234,7 @@ class PageTests(unittest.TestCase):
 
     def test_page_canonical_url_nested_no_slash(self):
         cfg = load_config(site_url='http://example.com/foo')
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         self.assertEqual(pg.url, 'testing/')
         self.assertEqual(pg.abs_url, '/foo/testing/')
@@ -256,7 +257,7 @@ class PageTests(unittest.TestCase):
 
     def test_predefined_page_title(self):
         cfg = load_config()
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Page Title', fl, cfg)
         pg.read_source(cfg)
         self.assertEqual(pg.url, 'testing/')
@@ -280,7 +281,7 @@ class PageTests(unittest.TestCase):
 
     def test_page_title_from_markdown(self):
         cfg = load_config()
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page(None, fl, cfg)
         pg.read_source(cfg)
         self.assertEqual(pg.url, 'testing/')
@@ -380,8 +381,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.title, 'Welcome to MkDocs Attr { #welcome }')
 
     def test_page_title_from_meta(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('metadata.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('metadata.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page(None, fl, cfg)
         pg.read_source(cfg)
         self.assertEqual(pg.url, 'metadata/')
@@ -406,8 +407,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.title, 'A Page Title')
 
     def test_page_title_from_filename(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('page-title.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('page-title.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page(None, fl, cfg)
         pg.read_source(cfg)
         self.assertEqual(pg.url, 'page-title/')
@@ -431,8 +432,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.title, 'Page title')
 
     def test_page_title_from_capitalized_filename(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('pageTitle.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('pageTitle.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page(None, fl, cfg)
         pg.read_source(cfg)
         self.assertEqual(pg.url, 'pageTitle/')
@@ -454,8 +455,8 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.title, 'pageTitle')
 
     def test_page_title_from_homepage_filename(self):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fl = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        cfg = load_config(docs_dir=DOCS_DIR)
+        fl = File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page(None, fl, cfg)
         pg.read_source(cfg)
         self.assertEqual(pg.url, '')
@@ -479,14 +480,14 @@ class PageTests(unittest.TestCase):
 
     def test_page_eq(self):
         cfg = load_config()
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         self.assertTrue(pg == Page('Foo', fl, cfg))
 
     def test_page_ne(self):
         cfg = load_config()
-        f1 = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
-        f2 = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        f1 = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
+        f2 = File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', f1, cfg)
         # Different Title
         self.assertTrue(pg != Page('Bar', f1, cfg))
@@ -497,7 +498,7 @@ class PageTests(unittest.TestCase):
     def test_BOM(self, docs_dir):
         md_src = '# An UTF-8 encoded file with a BOM'
         cfg = load_config(docs_dir=docs_dir)
-        fl = File('index.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page(None, fl, cfg)
         # Create an UTF-8 Encoded file with BOM (as Microsoft editors do). See #1186
         with open(fl.abs_src_path, 'w', encoding='utf-8-sig') as f:
@@ -632,7 +633,7 @@ class PageTests(unittest.TestCase):
                 edit_url_key = f'edit_url{i}' if i > 1 else 'edit_url'
                 with self.subTest(case['config'], path=path):
                     cfg = load_config(**case['config'])
-                    fl = File(path, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+                    fl = File(path, cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
                     pg = Page('Foo', fl, cfg)
                     self.assertEqual(pg.url, paths[path])
                     self.assertEqual(pg.edit_url, case[edit_url_key])
@@ -655,9 +656,7 @@ class PageTests(unittest.TestCase):
             with self.subTest(case['config']):
                 with self.assertLogs('mkdocs') as cm:
                     cfg = load_config(**case['config'])
-                    fl = File(
-                        'testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']
-                    )
+                    fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
                     pg = Page('Foo', fl, cfg)
                 self.assertEqual(pg.url, 'testing/')
                 self.assertEqual(pg.edit_url, case['edit_url'])
@@ -665,7 +664,7 @@ class PageTests(unittest.TestCase):
 
     def test_page_render(self):
         cfg = load_config()
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         pg.read_source(cfg)
         self.assertEqual(pg.content, None)
@@ -687,7 +686,7 @@ class PageTests(unittest.TestCase):
 
     def test_missing_page(self):
         cfg = load_config()
-        fl = File('missing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('missing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         with self.assertLogs('mkdocs') as cm:
             with self.assertRaises(OSError):
@@ -704,7 +703,7 @@ class SourceDateEpochTests(unittest.TestCase):
 
     def test_source_date_epoch(self):
         cfg = load_config()
-        fl = File('testing.md', cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls'])
+        fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
         pg = Page('Foo', fl, cfg)
         self.assertEqual(pg.update_date, '1970-01-01')
 
@@ -716,180 +715,188 @@ class SourceDateEpochTests(unittest.TestCase):
 
 
 class RelativePathExtensionTests(unittest.TestCase):
-    DOCS_DIR = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), '../integration/subpages/docs'
-    )
-
-    def get_rendered_result(self, files):
-        cfg = load_config(docs_dir=self.DOCS_DIR)
-        fs = [File(f, cfg['docs_dir'], cfg['site_dir'], cfg['use_directory_urls']) for f in files]
+    def get_rendered_result(
+        self, *, content: str, files: list[str], logs: str = '', **kwargs
+    ) -> str:
+        cfg = load_config(docs_dir=DOCS_DIR, **kwargs)
+        fs = [File(f, cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls) for f in files]
         pg = Page('Foo', fs[0], cfg)
-        pg.read_source(cfg)
-        pg.render(cfg, Files(fs))
-        return pg.content
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](non-index.md)'))
+        with mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data=content)):
+            pg.read_source(cfg)
+        if logs:
+            with self.assertLogs('mkdocs.structure.pages') as cm:
+                pg.render(cfg, Files(fs))
+            msgs = [f'{r.levelname}:{r.message}' for r in cm.records]
+            self.assertEqual('\n'.join(msgs), textwrap.dedent(logs).strip('\n'))
+        elif sys.version_info >= (3, 10):
+            with self.assertNoLogs('mkdocs.structure.pages'):
+                pg.render(cfg, Files(fs))
+        else:
+            pg.render(cfg, Files(fs))
+
+        assert pg.content is not None
+        content = pg.content
+        if content.startswith('<p>') and content.endswith('</p>'):
+            content = content[3:-4]
+        return content
+
     def test_relative_html_link(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'non-index.md']),
-            '<p><a href="non-index/">link</a></p>',  # No trailing /
+            self.get_rendered_result(
+                content='[link](non-index.md)', files=['index.md', 'non-index.md']
+            ),
+            '<a href="non-index/">link</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](index.md)'))
     def test_relative_html_link_index(self):
         self.assertEqual(
-            self.get_rendered_result(['non-index.md', 'index.md']),
-            '<p><a href="../">link</a></p>',
+            self.get_rendered_result(
+                content='[link](index.md)', files=['non-index.md', 'index.md']
+            ),
+            '<a href="../">link</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](sub2/index.md)'))
     def test_relative_html_link_sub_index(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'sub2/index.md']),
-            '<p><a href="sub2/">link</a></p>',  # No trailing /
+            self.get_rendered_result(
+                content='[link](sub2/index.md)', files=['index.md', 'sub2/index.md']
+            ),
+            '<a href="sub2/">link</a>',
         )
 
-    @mock.patch(
-        'mkdocs.structure.pages.open', mock.mock_open(read_data='[link](sub2/non-index.md)')
-    )
     def test_relative_html_link_sub_page(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'sub2/non-index.md']),
-            '<p><a href="sub2/non-index/">link</a></p>',  # No trailing /
+            self.get_rendered_result(
+                content='[link](sub2/non-index.md)', files=['index.md', 'sub2/non-index.md']
+            ),
+            '<a href="sub2/non-index/">link</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](file%20name.md)'))
     def test_relative_html_link_with_encoded_space(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'file name.md']),
-            '<p><a href="file%20name/">link</a></p>',
+            self.get_rendered_result(
+                content='[link](file%20name.md)', files=['index.md', 'file name.md']
+            ),
+            '<a href="file%20name/">link</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](file name.md)'))
     def test_relative_html_link_with_unencoded_space(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'file name.md']),
-            '<p><a href="file%20name/">link</a></p>',
+            self.get_rendered_result(
+                content='[link](file name.md)', files=['index.md', 'file name.md']
+            ),
+            '<a href="file%20name/">link</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](../index.md)'))
     def test_relative_html_link_parent_index(self):
         self.assertEqual(
-            self.get_rendered_result(['sub2/non-index.md', 'index.md']),
-            '<p><a href="../../">link</a></p>',
+            self.get_rendered_result(
+                content='[link](../index.md)', files=['sub2/non-index.md', 'index.md']
+            ),
+            '<a href="../../">link</a>',
         )
 
-    @mock.patch(
-        'mkdocs.structure.pages.open', mock.mock_open(read_data='[link](non-index.md#hash)')
-    )
     def test_relative_html_link_hash(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'non-index.md']),
-            '<p><a href="non-index/#hash">link</a></p>',
+            self.get_rendered_result(
+                content='[link](non-index.md#hash)', files=['index.md', 'non-index.md']
+            ),
+            '<a href="non-index/#hash">link</a>',
         )
 
-    @mock.patch(
-        'mkdocs.structure.pages.open', mock.mock_open(read_data='[link](sub2/index.md#hash)')
-    )
     def test_relative_html_link_sub_index_hash(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'sub2/index.md']),
-            '<p><a href="sub2/#hash">link</a></p>',
+            self.get_rendered_result(
+                content='[link](sub2/index.md#hash)', files=['index.md', 'sub2/index.md']
+            ),
+            '<a href="sub2/#hash">link</a>',
         )
 
-    @mock.patch(
-        'mkdocs.structure.pages.open', mock.mock_open(read_data='[link](sub2/non-index.md#hash)')
-    )
     def test_relative_html_link_sub_page_hash(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'sub2/non-index.md']),
-            '<p><a href="sub2/non-index/#hash">link</a></p>',
+            self.get_rendered_result(
+                content='[link](sub2/non-index.md#hash)', files=['index.md', 'sub2/non-index.md']
+            ),
+            '<a href="sub2/non-index/#hash">link</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](#hash)'))
     def test_relative_html_link_hash_only(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md']),
-            '<p><a href="#hash">link</a></p>',
+            self.get_rendered_result(content='[link](#hash)', files=['index.md']),
+            '<a href="#hash">link</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='![image](image.png)'))
     def test_relative_image_link_from_homepage(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md', 'image.png']),
-            '<p><img alt="image" src="image.png" /></p>',  # no opening ./
+            self.get_rendered_result(
+                content='![image](image.png)', files=['index.md', 'image.png']
+            ),
+            '<img alt="image" src="image.png" />',  # no opening ./
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='![image](../image.png)'))
     def test_relative_image_link_from_subpage(self):
         self.assertEqual(
-            self.get_rendered_result(['sub2/non-index.md', 'image.png']),
-            '<p><img alt="image" src="../../image.png" /></p>',
+            self.get_rendered_result(
+                content='![image](../image.png)', files=['sub2/non-index.md', 'image.png']
+            ),
+            '<img alt="image" src="../../image.png" />',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='![image](image.png)'))
     def test_relative_image_link_from_sibling(self):
         self.assertEqual(
-            self.get_rendered_result(['non-index.md', 'image.png']),
-            '<p><img alt="image" src="../image.png" /></p>',
+            self.get_rendered_result(
+                content='![image](image.png)', files=['non-index.md', 'image.png']
+            ),
+            '<img alt="image" src="../image.png" />',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='*__not__ a link*.'))
     def test_no_links(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md']),
-            '<p><em><strong>not</strong> a link</em>.</p>',
+            self.get_rendered_result(content='*__not__ a link*.', files=['index.md']),
+            '<em><strong>not</strong> a link</em>.',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='[link](non-existent.md)'))
     def test_bad_relative_html_link(self):
-        with self.assertLogs('mkdocs') as cm:
-            self.assertEqual(
-                self.get_rendered_result(['index.md']),
-                '<p><a href="non-existent.md">link</a></p>',
-            )
         self.assertEqual(
-            '\n'.join(cm.output),
-            "WARNING:mkdocs.structure.pages:Documentation file 'index.md' contains a link "
-            "to 'non-existent.md' which is not found in the documentation files.",
+            self.get_rendered_result(
+                content='[link](non-existent.md)',
+                files=['index.md'],
+                logs="WARNING:Documentation file 'index.md' contains a link to 'non-existent.md' which is not found in the documentation files.",
+            ),
+            '<a href="non-existent.md">link</a>',
         )
 
-    @mock.patch(
-        'mkdocs.structure.pages.open',
-        mock.mock_open(read_data='[external](http://example.com/index.md)'),
-    )
     def test_external_link(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md']),
-            '<p><a href="http://example.com/index.md">external</a></p>',
+            self.get_rendered_result(
+                content='[external](http://example.com/index.md)', files=['index.md']
+            ),
+            '<a href="http://example.com/index.md">external</a>',
         )
 
-    @mock.patch(
-        'mkdocs.structure.pages.open', mock.mock_open(read_data='[absolute link](/path/to/file.md)')
-    )
     def test_absolute_link(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md']),
-            '<p><a href="/path/to/file.md">absolute link</a></p>',
+            self.get_rendered_result(
+                content='[absolute link](/path/to/file.md)', files=['index.md']
+            ),
+            '<a href="/path/to/file.md">absolute link</a>',
         )
 
-    @mock.patch(
-        'mkdocs.structure.pages.open',
-        mock.mock_open(read_data='[absolute local path](\\image.png)'),
-    )
     def test_absolute_win_local_path(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md']),
-            '<p><a href="\\image.png">absolute local path</a></p>',
+            self.get_rendered_result(
+                content='[absolute local path](\\image.png)', files=['index.md']
+            ),
+            '<a href="\\image.png">absolute local path</a>',
         )
 
-    @mock.patch('mkdocs.structure.pages.open', mock.mock_open(read_data='<mail@example.com>'))
     def test_email_link(self):
         self.assertEqual(
-            self.get_rendered_result(['index.md']),
+            self.get_rendered_result(content='<mail@example.com>', files=['index.md']),
             # Markdown's default behavior is to obscure email addresses by entity-encoding them.
-            # The following is equivalent to: '<p><a href="mailto:mail@example.com">mail@example.com</a></p>'
-            '<p><a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#109;&#97;&#105;&#108;&#64;&#101;'
+            # The following is equivalent to: '<a href="mailto:mail@example.com">mail@example.com</a>'
+            '<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#109;&#97;&#105;&#108;&#64;&#101;'
             '&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;">&#109;&#97;&#105;&#108;&#64;'
-            '&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;</a></p>',
+            '&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;</a>',
         )

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -964,21 +964,48 @@ class RelativePathExtensionTests(unittest.TestCase):
             '<a href="http://example.com/index.md">external</a>',
         )
 
-    def test_absolute_link(self):
+    def test_absolute_link_with_suggestion(self):
         self.assertEqual(
             self.get_rendered_result(
                 content='[absolute link](/path/to/file.md)',
-                files=['index.md'],
-                logs="INFO:Doc file 'index.md' contains an absolute link '/path/to/file.md', it was left as is.",
+                files=['index.md', 'path/to/file.md'],
+                logs="INFO:Doc file 'index.md' contains an absolute link '/path/to/file.md', it was left as is. Did you mean 'path/to/file.md'?",
             ),
             '<a href="/path/to/file.md">absolute link</a>',
         )
+        self.assertEqual(
+            self.get_rendered_result(
+                use_directory_urls=False,
+                content='[absolute link](/path/to/file/)',
+                files=['path/index.md', 'path/to/file.md'],
+                logs="INFO:Doc file 'path/index.md' contains an absolute link '/path/to/file/', it was left as is.",
+            ),
+            '<a href="/path/to/file/">absolute link</a>',
+        )
+        self.assertEqual(
+            self.get_rendered_result(
+                content='[absolute link](/path/to/file)',
+                files=['path/index.md', 'path/to/file.md'],
+                logs="INFO:Doc file 'path/index.md' contains an absolute link '/path/to/file', it was left as is. Did you mean 'to/file.md'?",
+            ),
+            '<a href="/path/to/file">absolute link</a>',
+        )
+
+    def test_absolute_link(self):
         self.assertEqual(
             self.get_rendered_result(
                 validation=dict(links=dict(absolute_links='warn')),
                 content='[absolute link](/path/to/file.md)',
                 files=['index.md'],
                 logs="WARNING:Doc file 'index.md' contains an absolute link '/path/to/file.md', it was left as is.",
+            ),
+            '<a href="/path/to/file.md">absolute link</a>',
+        )
+        self.assertEqual(
+            self.get_rendered_result(
+                validation=dict(links=dict(absolute_links='ignore')),
+                content='[absolute link](/path/to/file.md)',
+                files=['index.md'],
             ),
             '<a href="/path/to/file.md">absolute link</a>',
         )
@@ -1010,7 +1037,7 @@ class RelativePathExtensionTests(unittest.TestCase):
             self.get_rendered_result(
                 content='[contact](mail@example.com)',
                 files=['index.md'],
-                logs="WARNING:Doc file 'index.md' contains a relative link 'mail@example.com', but the target is not found among documentation files.",
+                logs="WARNING:Doc file 'index.md' contains a relative link 'mail@example.com', but the target is not found among documentation files. Did you mean 'mailto:mail@example.com'?",
             ),
             '<a href="mail@example.com">contact</a>',
         )

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -92,6 +92,16 @@ def get_build_date() -> str:
     return get_build_datetime().strftime('%Y-%m-%d')
 
 
+if sys.version_info >= (3, 9):
+    _removesuffix = str.removesuffix
+else:
+
+    def _removesuffix(s: str, suffix: str) -> str:
+        if suffix and s.endswith(suffix):
+            return s[: -len(suffix)]
+        return s
+
+
 def reduce_list(data_set: Iterable[T]) -> list[T]:
     """Reduce duplicate items in a list and preserve order"""
     return list(dict.fromkeys(data_set))


### PR DESCRIPTION
* Expand the situations where logs about broken links are produced, make the logging levels fully configurable
* Guess what existing page might have been meant based on the provided link, and mention it in the log message.

Closes #1755 and a lot more