### PR TITLE
Add blockquote styling for mkdocs theme

### DIFF
--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -213,7 +213,10 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-
+blockquote {
+    padding-left: 10px;
+    border-left: 4px solid #e6e6e6;
+}
 
 .admonition, details {
     padding: 15px;


### PR DESCRIPTION
Style before: literally just a normal paragraph

Style after: 
![image](https://github.com/mkdocs/mkdocs/assets/371383/41dd49de-cb91-4bbf-909d-5aa521ff4fcf)
