### PR TITLE
Refactor test cases to improve unit test quality

### DIFF
--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1184,7 +1184,7 @@ class ThemeTest(TestCase):
             conf.option.static_templates,
             {'404.html', 'sitemap.xml', 'sitemap.html'},
         )
-        self.assertEqual(conf.option['show_sidebar'], False)
+        self.assertFalse(conf.option['show_sidebar'])
 
     def test_theme_name_is_none(self) -> None:
         config = {

--- a/mkdocs/tests/config/config_tests.py
+++ b/mkdocs/tests/config/config_tests.py
@@ -70,8 +70,7 @@ class ConfigTests(unittest.TestCase):
         os.mkdir(os.path.join(temp_path, 'docs'))
 
         result = config.load_config(config_file=config_file.name)
-        self.assertEqual(result['site_name'], expected_result['site_name'])
-        self.assertEqual(result['nav'], expected_result['nav'])
+        self.assertTrue(expected_result.items() <= result.items())
 
     @tempdir()
     @tempdir()

--- a/mkdocs/tests/livereload_tests.py
+++ b/mkdocs/tests/livereload_tests.py
@@ -434,7 +434,7 @@ class BuildTests(unittest.TestCase):
 
             _, output = do_request(server, f"GET /livereload/{initial_epoch}/0")
 
-            self.assertNotEqual(server._visible_epoch, initial_epoch)
+            self.assertGreater(server._visible_epoch, initial_epoch)
             self.assertEqual(output, str(server._visible_epoch))
 
     @tempdir()
@@ -445,7 +445,7 @@ class BuildTests(unittest.TestCase):
 
             start_time = time.monotonic()
             _, output = do_request(server, f"GET /livereload/{initial_epoch}/0")
-            self.assertGreaterEqual(time.monotonic(), start_time + 0.2)
+            self.assertGreaterEqual(time.monotonic(), start_time + server.poll_response_timeout)
             self.assertEqual(output, str(initial_epoch))
 
     @tempdir()

--- a/mkdocs/tests/plugin_tests.py
+++ b/mkdocs/tests/plugin_tests.py
@@ -227,7 +227,7 @@ class TestPluginCollection(unittest.TestCase):
         plugin = DummyPlugin()
         plugin.load_config({'foo': 'new'})
         collection['foo'] = plugin
-        self.assertEqual(collection.on_pre_build(config={}), None)
+        self.assertIsNone(collection.on_pre_build(config={}))
 
     def test_run_undefined_event_on_collection(self):
         collection = plugins.PluginCollection()

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -68,7 +68,7 @@ class ThemeTests(unittest.TestCase):
     def test_vars(self):
         theme = Theme(name='mkdocs', foo='bar', baz=True)
         self.assertEqual(theme['foo'], 'bar')
-        self.assertEqual(theme['baz'], True)
+        self.assertTrue(theme['baz'])
         self.assertTrue('new' not in theme)
         with self.assertRaises(KeyError):
             theme['new']


### PR DESCRIPTION
## Summary

Hello, first PR here.

This PR improves the readability of the assert statements in unit tests by using more expressive assert methods from Python's unittest module. These changes improve code quality (avoid test smells) by:

- Making the assert statements more readable. For example, it's quicker to understand assertFalse(x) than assertEquals(x, False).

- Simplifying code management. For example, instead of simply saying 0.2, use the parameter name(poll_response_timeout) so that developers could only update the value in one place.


Happy to update more related issues in the test code if needed.

