### PR TITLE
Catch ValueErrors thrown when attempting to remove a file twice

### DIFF
--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -367,9 +367,15 @@ def get_files(config: MkDocsConfig) -> Files:
                 log.warning(
                     f"Excluding '{a.src_uri}' from the site because it conflicts with '{b.src_uri}'."
                 )
-            files.remove(a)
+            try:
+                files.remove(a)
+            except ValueError:
+                pass  # Catching this to avoid errors if attempting to remove the same file twice.
         else:
-            files.remove(b)
+            try:
+                files.remove(b)
+            except ValueError:
+                pass
 
     return Files(files)
 


### PR DESCRIPTION
Fixes #3313

This PR catches `ValueError` to improve the safety of the `list.remove` calls, as they may attempt to remove the same file multiple times.

I think this is more acceptable than...

```python
if a in files: files.remove(a)
```

... because files can be a really large list to iterate across.