### PR TITLE
Change extra_javascript items to usually be strings again

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -945,11 +945,18 @@ class ExtraScriptValue(Config):
         return self.path
 
 
-class ExtraScript(SubConfig[ExtraScriptValue]):
-    def run_validation(self, value: object) -> ExtraScriptValue:
+class ExtraScript(BaseConfigOption[Union[ExtraScriptValue, str]]):
+    def __init__(self):
+        super().__init__()
+        self.option_type = SubConfig[ExtraScriptValue]()
+
+    def run_validation(self, value: object) -> ExtraScriptValue | str:
+        self.option_type.warnings = self.warnings
         if isinstance(value, str):
-            value = {'path': value, 'type': 'module' if value.endswith('.mjs') else ''}
-        return super().run_validation(value)
+            if value.endswith('.mjs'):
+                return self.option_type.run_validation({'path': value, 'type': 'module'})
+            return value
+        return self.option_type.run_validation(value)
 
 
 class MarkdownExtensions(OptionallyRequired[List[str]]):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -9,7 +9,7 @@ import re
 import sys
 import textwrap
 import unittest
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
 from unittest.mock import patch
 
 if TYPE_CHECKING:
@@ -700,14 +700,14 @@ class ExtraScriptsTest(TestCase):
             option = c.ListOfItems(c.ExtraScript(), default=[])
 
         conf = self.get_config(Schema, {'option': ['foo.js', {'path': 'bar.js', 'async': True}]})
-        assert_type(conf.option, List[c.ExtraScriptValue])
+        assert_type(conf.option, List[Union[c.ExtraScriptValue, str]])
         self.assertEqual(len(conf.option), 2)
-        self.assertIsInstance(conf.option[0], c.ExtraScriptValue)
+        self.assertIsInstance(conf.option[1], c.ExtraScriptValue)
         self.assertEqual(
-            [(x.path, x.type, x.defer, x.async_) for x in conf.option],
+            conf.option,
             [
-                ('foo.js', '', False, False),
-                ('bar.js', '', False, True),
+                'foo.js',
+                {'path': 'bar.js', 'type': '', 'defer': False, 'async': True},
             ],
         )
 
@@ -718,14 +718,14 @@ class ExtraScriptsTest(TestCase):
         conf = self.get_config(
             Schema, {'option': ['foo.mjs', {'path': 'bar.js', 'type': 'module'}]}
         )
-        assert_type(conf.option, List[c.ExtraScriptValue])
+        assert_type(conf.option, List[Union[c.ExtraScriptValue, str]])
         self.assertEqual(len(conf.option), 2)
         self.assertIsInstance(conf.option[0], c.ExtraScriptValue)
         self.assertEqual(
-            [(x.path, x.type, x.defer, x.async_) for x in conf.option],
+            conf.option,
             [
-                ('foo.mjs', 'module', False, False),
-                ('bar.js', 'module', False, False),
+                {'path': 'foo.mjs', 'type': 'module', 'defer': False, 'async': False},
+                {'path': 'bar.js', 'type': 'module', 'defer': False, 'async': False},
             ],
         )
 
@@ -748,8 +748,8 @@ class ExtraScriptsTest(TestCase):
             warnings=dict(option="Sub-option 'foo': Unrecognised configuration name: foo"),
         )
         self.assertEqual(
-            [(x.path, x.type, x.defer, x.async_) for x in conf.option],
-            [('foo.js', '', False, False)],
+            conf.option,
+            [{'path': 'foo.js', 'type': '', 'defer': False, 'async': False, 'foo': 'bar'}],
         )
 
 


### PR DESCRIPTION
In 1.5.0 `extra_javascript` was changed to become a `list[ExtraScriptValue]`, but strings could sneak in anyway, although MkDocs would never put them there anymore.

Let's change it to officially be `list[ExtraScriptValue | str]` but typically these items will be strings once again, unless specified as a dictionary in the config in the first place. This will guard plugins that aren't updated yet from a breakages unless users actually use `mjs` files.

* Fixes #3321, #3310
