### PR TITLE
Switch from flake8 to ruff linter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-extend-ignore = E501, E203, TC004

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Check with black + isort
         if: always()
         run: hatch run style:format && git diff --exit-code
-      - name: Check with flake8
+      - name: Check with ruff
         if: always()
         run: hatch run style:lint
       - name: Check with mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,12 +160,11 @@ detached = true
 dependencies = [
     "black",
     "isort",
-    "flake8",
-    "flake8-type-checking",
+    "ruff",
 ]
 [tool.hatch.envs.style.scripts]
 lint = [
-    "flake8 mkdocs",
+    "ruff mkdocs",
 ]
 check = [
     "isort --check-only --diff mkdocs docs",
@@ -215,3 +214,7 @@ ignore_missing_imports = true
 warn_unreachable = true
 no_implicit_optional = true
 show_error_codes = true
+
+[tool.ruff]
+line-length = 100
+ignore = ["E501"]


### PR DESCRIPTION
Ruff project: https://github.com/astral-sh/ruff

It's pyproject.toml compatible and performant