### PR TITLE
Improve debug output for subclasses of navigation elements

### DIFF
--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -51,7 +51,8 @@ class Section(StructureItem):
         self.active = False
 
     def __repr__(self):
-        return f"Section(title={self.title!r})"
+        name = self.__class__.__name__
+        return f"{name}(title={self.title!r})"
 
     title: str
     """The title of the section."""
@@ -97,8 +98,9 @@ class Link(StructureItem):
         self.url = url
 
     def __repr__(self):
+        name = self.__class__.__name__
         title = f"{self.title!r}" if self.title is not None else '[blank]'
-        return f"Link(title={title}, url={self.url!r})"
+        return f"{name}(title={title}, url={self.url!r})"
 
     title: str
     """The title of the link. This would generally be used as the label of the link."""

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -65,9 +65,10 @@ class Page(StructureItem):
         )
 
     def __repr__(self):
+        name = self.__class__.__name__
         title = f"{self.title!r}" if self.title is not None else '[blank]'
         url = self.abs_url or self.file.url
-        return f"Page(title={title}, url={url!r})"
+        return f"{name}(title={title}, url={url!r})"
 
     markdown: str | None
     """The original Markdown content from the file."""


### PR DESCRIPTION
I'm currently rewriting the [blog plugin](https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#built-in-blog-plugin) in Material for MkDocs (which is now free as part of the community edition), trying to improve interop with the plugin ecosystem, specifically plugins like awesome-pages or static-i18n. For this, I'm subclassing some of the existing classes. However, when we print `nav` for debugging, the names of the subclasses are not taken into account. This PR improves debug output when subclassing `Page`, `Link` or `Section` classes, which is especially useful for understanding navigation structure.

In this example, `Archive` and `Category` are subclasses of `Page`:


```
Section(title='Blog')
    Page(title=[blank], url='/blog/')
    Page(title=[blank], url='/blog/about/')
    Section(title='Archive')
        Archive(title='2023', url='/blog/archive/2023/')
        Archive(title='2022', url='/blog/archive/2022/')
    Section(title='Categories')
        Category(title='foo', url='/blog/category/foo/')
        Category(title='bar', url='/blog/category/bar/')
```