### PR TITLE
POC: demonstrate mkdocs generated_by detection wrt #3344

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 
 from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure.files import File
 from mkdocs.structure.nav import Page
 
 
@@ -31,3 +32,16 @@ def on_page_markdown(markdown: str, page: Page, config: MkDocsConfig, **kwargs):
             markdown,
             flags=re.MULTILINE,
         )
+
+
+def on_files(files, config):
+    new_file = open("/tmp/this_file_was_generated.md", "wb").write(b"# Test file")
+    files.append(
+        File(
+            "this_file_was_generated.md",
+            "/tmp",
+            config.site_dir,
+            config.use_directory_urls
+        )
+    )
+    return files

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -213,6 +213,9 @@ class File:
 
     page: Page | None
 
+    generated_by: str | None = None
+    """The name of the plugin which have generated the file or None if the file is part of docs_dir."""
+
     def __init__(
         self,
         path: str,
@@ -243,9 +246,10 @@ class File:
         )
 
     def __repr__(self):
+        generated_by = f", generated_by='{self.generated_by}'" if self.generated_by else ""
         return (
             f"File(src_uri='{self.src_uri}', dest_uri='{self.dest_uri}',"
-            f" name='{self.name}', url='{self.url}')"
+            f" name='{self.name}', url='{self.url}'{generated_by})"
         )
 
     def _get_stem(self) -> str:


### PR DESCRIPTION
With regards to my [comment](https://github.com/mkdocs/mkdocs/pull/3344#issuecomment-1689841586) in #3344 

Sample result:

```bash
$ hatch -e docs shell
$ mkdocs build
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/alexys/github/forks/mkdocs/site
WARNING -  files_added_by_plugin={'this_file_was_generated.md'}
WARNING -  File(src_uri='this_file_was_generated.md', dest_uri='this_file_was_generated/index.html', name='this_file_was_generated', url='this_file_was_generated/',
           generated_by='docs/hooks.py')
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - this_file_was_generated.md
INFO    -  Documentation built in 0.98 seconds
```