### PR TITLE
Prevent a stacktrace for `theme: foo` when theme is not installed

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -1092,7 +1092,9 @@ class Plugins(OptionallyRequired[plugins.PluginCollection]):
         else:
             # Attempt to load with prepended namespace for the current theme.
             if self.theme_key and self._config:
-                current_theme = self._config[self.theme_key]['name']
+                current_theme = self._config[self.theme_key]
+                if not isinstance(current_theme, str):
+                    current_theme = current_theme['name']
                 if current_theme:
                     expanded_name = f'{current_theme}/{name}'
                     if expanded_name in self.installed_plugins:

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1137,14 +1137,15 @@ class ThemeTest(TestCase):
 
     def test_uninstalled_theme_as_string(self) -> None:
         class Schema(Config):
-            option = c.Theme()
+            theme = c.Theme()
+            plugins = c.Plugins(theme_key='theme')
 
         with self.expect_error(
-            option=re.compile(
+            theme=re.compile(
                 r"Unrecognised theme name: 'mkdocs2'. The available installed themes are: .+"
             )
         ):
-            self.get_config(Schema, {'option': "mkdocs2"})
+            self.get_config(Schema, {'theme': "mkdocs2", 'plugins': "search"})
 
     def test_theme_default(self) -> None:
         class Schema(Config):


### PR DESCRIPTION
This happens because the `theme` option fails validation (being not installed) but then validation of `plugins` option fatally fails because that option is invalid. Maybe in the future it would be better to change validation so it stops after the first error, because there can be countless such combinations of interactions.
