### PR TITLE
Log excluded links only if referring page is included

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -415,7 +415,7 @@ class _RelativePathTreeprocessor(markdown.treeprocessors.Treeprocessor):
 
         assert target_uri is not None
         assert target_file is not None
-        if target_file.inclusion.is_excluded():
+        if self.file.inclusion.is_included() and target_file.inclusion.is_excluded():
             warning_level = min(logging.INFO, self.config.validation.links.not_found)
             warning = (
                 f"Doc file '{self.file.src_uri}' contains a link to "

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -609,7 +609,6 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         server = testing_server(site_dir, mount_path='/documentation/')
         with self.subTest(live_server=server):
             expected_logs = '''
-                INFO:Doc file 'test/bar.md' contains a link to 'test/baz.md' which is excluded from the built site.
                 INFO:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
                 INFO:The following pages are being built only for the preview but will be excluded from `mkdocs build` per `exclude_docs`:
                   - http://localhost:123/documentation/.zoo.html


### PR DESCRIPTION
I have several excluded folders in my site (via the `exclude_docs` setting). The excluded folders contain pages that refer to images and other files in the same folder. Would you consider not logging INFO messages for excluded targets when the referring page is also excluded?

For example, the three "Doc file ... contains a link" INFO lines below are repeated in the log every time I save a file and the site is rebuilt. These log entries are irrelevant, because the doc files are also excluded.

```
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  Doc file 'hw/hw4_draft.md' contains a link to 'hw/hw4_draft/rhody.py' which is excluded from the built site.
INFO    -  Doc file 'quiz/1a/written_v1.md' contains a link to 'quiz/1a/q1_code.svg' which is excluded from the built site.
INFO    -  Doc file 'quiz/1a/written_v2.md' contains a link to 'quiz/1a/q1_code.svg' which is excluded from the built site.
INFO    -  The following pages are being built only for the preview but will be excluded from `mkdocs build` per `exclude_docs`:
             - http://127.0.0.1:8000/cs149/hw/hw4_draft/
             - http://127.0.0.1:8000/cs149/quiz/1a/written_v1/
             - http://127.0.0.1:8000/cs149/quiz/1a/written_v2/
```