### PR TITLE
refactor: only pass server url to build function

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -22,8 +22,6 @@ from mkdocs.utils import templates
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
 
-if TYPE_CHECKING:
-    from mkdocs.livereload import LiveReloadServer
 
 log = logging.getLogger(__name__)
 
@@ -256,7 +254,9 @@ def _build_page(
 
 
 def build(
-    config: MkDocsConfig, live_server: LiveReloadServer | None = None, dirty: bool = False
+    config: MkDocsConfig,
+    live_server_url: str | None = None,
+    dirty: bool = False,
 ) -> None:
     """Perform a full site build."""
 
@@ -268,7 +268,7 @@ def build(
     if config.strict:
         logging.getLogger('mkdocs').addHandler(warning_counter)
 
-    inclusion = InclusionLevel.all if live_server else InclusionLevel.is_included
+    inclusion = InclusionLevel.all if live_server_url else InclusionLevel.is_included
 
     try:
         start = time.monotonic()
@@ -289,7 +289,7 @@ def build(
                 " links within your site. This option is designed for site development purposes only."
             )
 
-        if not live_server:  # pragma: no cover
+        if not live_server_url:  # pragma: no cover
             log.info(f"Building documentation to directory: {config.site_dir}")
             if dirty and site_directory_contains_stale_files(config.site_dir):
                 log.info("The directory contains stale files. Use --clean to remove them.")
@@ -315,8 +315,8 @@ def build(
         for file in files.documentation_pages(inclusion=inclusion):
             log.debug(f"Reading: {file.src_uri}")
             if file.page is None and file.inclusion.is_excluded():
-                if live_server:
-                    excluded.append(urljoin(live_server.url, file.url))
+                if live_server_url:
+                    excluded.append(urljoin(live_server_url, file.url))
                 Page(None, file, config)
             assert file.page is not None
             _populate_page(file.page, config, files, dirty)

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -59,14 +59,17 @@ def serve(
     config = get_config()
     config.plugins.on_startup(command=('build' if is_clean else 'serve'), dirty=is_dirty)
 
+    host, port = config.dev_addr
+    suffix = mount_path(config).lstrip("/").rstrip("/")
+    live_server_url = f"http://{host}:{port}/{suffix}/"
+
     def builder(config: MkDocsConfig | None = None):
         log.info("Building documentation...")
         if config is None:
             config = get_config()
 
-        build(config, live_server=None if is_clean else server, dirty=is_dirty)
+        build(config, live_server_url=None if is_clean else live_server_url, dirty=is_dirty)
 
-    host, port = config.dev_addr
     server = LiveReloadServer(
         builder=builder, host=host, port=port, root=site_dir, mount_path=mount_path(config)
     )

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -618,7 +618,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
                   - http://localhost:123/documentation/test/baz.html
             '''
             with self._assert_build_logs(expected_logs):
-                build.build(cfg, live_server=server)
+                build.build(cfg, live_server_url=server.url)
 
             foo_path = Path(site_dir, 'test', 'foo.html')
             self.assertTrue(foo_path.is_file())
@@ -646,7 +646,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
                     WARNING:Excluding 'foo/README.md' from the site because it conflicts with 'foo/index.md'.
                 '''
                 with self._assert_build_logs(expected_logs):
-                    build.build(cfg, live_server=server)
+                    build.build(cfg, live_server_url=server.url if server else None)
 
                 index_path = Path(site_dir, 'foo', 'index.html')
                 self.assertPathIsFile(index_path)
@@ -667,7 +667,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         for server in None, testing_server(site_dir):
             with self.subTest(live_server=server):
                 with self._assert_build_logs(''):
-                    build.build(cfg, live_server=server)
+                    build.build(cfg, live_server_url=server.url if server else None)
 
                 index_path = Path(site_dir, 'foo', 'index.html')
                 self.assertPathIsFile(index_path)
@@ -718,7 +718,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
                               - http://localhost:123/SUMMARY.html
                         '''
                     with self._assert_build_logs(expected_logs):
-                        build.build(cfg, live_server=server)
+                        build.build(cfg, live_server_url=server.url if server else None)
 
                     foo_path = Path(site_dir, 'foo.html')
                     self.assertPathIsFile(foo_path)


### PR DESCRIPTION
Small refactor, dont pass the whole Live server instance to the build function.
Right now, the builder method knows about the live server and the live server knows about the build method.
(see https://github.com/mkdocs/mkdocs/compare/master...phil65:mkdocs:untangle_build_and_serve?expand=1#diff-6ce1f9285defedc650e776dc5832321bc5297c681ac941dac31982ee237c7589L67 and https://github.com/mkdocs/mkdocs/compare/master...phil65:mkdocs:untangle_build_and_serve?expand=1#diff-6ce1f9285defedc650e776dc5832321bc5297c681ac941dac31982ee237c7589L70
This untangles this so that the build method only needs the server url.