### PR TITLE
Fix breadcrumb display in readthedocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -1,12 +1,12 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">
-    <li><a href="{{ nav.homepage.url|url }}" class="icon icon-home" aria-label="{% trans %}Docs{% endtrans %}"></a> &raquo;</li>
+    <li><a href="{{ nav.homepage.url|url }}" class="icon icon-home" aria-label="{% trans %}Docs{% endtrans %}"></a></li>
     {%- if page %}
       {%- for doc in page.ancestors[::-1] %}
         {%- if doc.link %}
           <li class="breadcrumb-item"><a href="{{ doc.link|e }}">{{ doc.title }}</a></li>
         {%- else %}
-          <li>{{ doc.title }} &raquo;</li>
+          <li class="breadcrumb-item">{{ doc.title }}</li>
         {%- endif %}
       {%- endfor %}
       <li class="breadcrumb-item active">{{ page.title }}</li>

--- a/mkdocs/themes/readthedocs/breadcrumbs.html
+++ b/mkdocs/themes/readthedocs/breadcrumbs.html
@@ -3,8 +3,8 @@
     <li><a href="{{ nav.homepage.url|url }}" class="icon icon-home" aria-label="{% trans %}Docs{% endtrans %}"></a></li>
     {%- if page %}
       {%- for doc in page.ancestors[::-1] %}
-        {%- if doc.link %}
-          <li class="breadcrumb-item"><a href="{{ doc.link|e }}">{{ doc.title }}</a></li>
+        {%- if doc.url %}
+          <li class="breadcrumb-item"><a href="{{ doc.url|url }}">{{ doc.title }}</a></li>
         {%- else %}
           <li class="breadcrumb-item">{{ doc.title }}</li>
         {%- endif %}


### PR DESCRIPTION
- Fix broken styling of breadcrumbs in readthedocs theme

  Commit https://github.com/mkdocs/mkdocs/commit/3c3670d92c972d874d7fe927df5abf728e003a66 left it half way between the old and new style

  Fixes #3382

- Fix linkified breadcrumb items in readthedocs theme

  A doc can never have a `link` attribute so this branch never kicked in.
  Actually even now, this branch will still not kick in, only mkdocs-section-index makes this state possible.