### PR TITLE
Improve editing experience when using `--livereload`

### DIFF
--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -49,7 +49,7 @@ var livereload = function(epoch, requestId) {
         req = timeout = undefined
     }
 
-    window.addEventListener("load", function () {
+    window.addEventListener("load", function() {
         if (document.visibilityState === "visible")
             poll()
     })

--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -44,21 +44,28 @@ var livereload = function(epoch, requestId) {
     }
 
     var stop = function() {
-        if (req)     req.abort()
-        if (timeout) clearTimeout(timeout)
-        req = timeout = undefined
-    }
+        if (req) {
+            req.abort();
+        }
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+        req = timeout = undefined;
+    };
 
     window.addEventListener("load", function() {
-        if (document.visibilityState === "visible")
-            poll()
-    })
-    window.addEventListener("beforeunload", stop)
+        if (document.visibilityState === "visible") {
+            poll();
+        }
+    });
     window.addEventListener("visibilitychange", function() {
-        var visible = document.visibilityState === "visible"
-        if (visible) poll()
-        else         stop()
-    })
+        if (document.visibilityState === "visible") {
+            poll();
+        } else {
+            stop();
+        }
+    });
+    window.addEventListener("beforeunload", stop);
 
     console.log('Enabled live reload');
 }


### PR DESCRIPTION
Closes #3389 and supersedes/closes #3390.

I've refactored the livereload functionality. It's more predictable now and solves another problem: it's currently not possible to open more than 6 tabs, because browsers are limited to 10 connections per destination, and the livereload connections queue up and block further connections. The problem is that every tab will keep an active livereload connection, regardless of whether it is visible or not.

This makes working on several pages in parallel impossible – see the never ending loading indicators here:

<img width="1508" alt="Bildschirm­foto 2023-09-13 um 13 44 58" src="https://github.com/mkdocs/mkdocs/assets/932156/089f0f4d-af0a-45e2-883c-3861d32670eb">

This PR addresses this issue and makes livereload more efficient.

1. Logic is refactored into two functions, `poll` and `stop`, that are called when certain events happen
2. The livereload server connection is cancelled when the tab becomes inactive
3. Once a tab becomes active, the livereload connection is immediately established again

The limitation on the number of open pages is gone:

<img width="1552" alt="Bildschirm­foto 2023-09-13 um 13 51 17" src="https://github.com/mkdocs/mkdocs/assets/932156/0740cd2f-ee00-48cb-832b-30dda703a783">

If you switch back and forth between two tabs, you can inspect the network and see the new behavior:

<img width="1552" alt="Bildschirm­foto 2023-09-13 um 13 53 44" src="https://github.com/mkdocs/mkdocs/assets/932156/3b65f5db-6c84-4395-9c24-41160314fcfd">

IMHO, there's no upside in keeping livereload connections for inactive tabs alive. This implementation improves the editing experience, as it is sometimes necessary to open more than 5 or 6 pages simultaneously ☺️