### PR TITLE
Revert to pre-1.5 title rendering behavior

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -454,5 +454,5 @@ class _ExtractTitleTreeprocessor(markdown.treeprocessors.Treeprocessor):
         md.treeprocessors.register(
             self,
             "mkdocs_extract_title",
-            priority=-1,  # After the end.
+            priority=40,  # First, or at least much earlier than `inline`.
         )

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -366,7 +366,7 @@ class PageTests(unittest.TestCase):
         pg = Page(None, fl, cfg)
         pg.read_source(cfg)
         pg.render(cfg, fl)
-        self.assertEqual(pg.title, '*Hello &mdash; beautiful world')
+        self.assertEqual(pg.title, '\\*Hello --- *beautiful* `world`')
 
     _ATTRLIST_CONTENT = dedent(
         '''


### PR DESCRIPTION
MkDocs 1.5 changed so that title detection is based fully on Markdown parsing, which makes it more reliable. But that also brought in another change - that Markdown actually gets partly rendered.

This way we can keep *only* the H1 tag detection and yank the title as soon as possible - before processing any inline elements.

* Fixes #3357