### PR TITLE
Add fallback git link for non-provider repos

### DIFF
--- a/mkdocs/themes/readthedocs/versions.html
+++ b/mkdocs/themes/readthedocs/versions.html
@@ -12,6 +12,10 @@
         <span>
           <a href="{{ config.repo_url }}" class="icon icon-gitlab" style="color: #fcfcfc"> GitLab</a>
         </span>
+    {% elif config.repo_name %}
+        <span>
+          <a href="{{ config.repo_url }}" class="fa fa-git" style="color: #fcfcfc"> {{ config.repo_name }}</a>
+        </span>
     {% endif %}
     {% if page.previous_page %}
       <span><a href="{{ page.previous_page.url|url }}" style="color: #fcfcfc">&laquo; {% trans %}Previous{% endtrans %}</a></span>

--- a/mkdocs/themes/readthedocs/versions.html
+++ b/mkdocs/themes/readthedocs/versions.html
@@ -14,7 +14,7 @@
         </span>
     {% elif config.repo_name %}
         <span>
-          <a href="{{ config.repo_url }}" class="fa fa-git" style="color: #fcfcfc"> {{ config.repo_name }}</a>
+          <a href="{{ config.repo_url }}" class="fa fa-code-fork" style="color: #fcfcfc"> {{ config.repo_name }}</a>
         </span>
     {% endif %}
     {% if page.previous_page %}


### PR DESCRIPTION
If a repo was defined for the readthedocs theme, but the repo wasn't a predefined provider (GitHub, Bitbucket, or GitLab), no repo link would be rendered.

This adds a fallback generic git repo link.

Fixes #3259 