### PR TITLE
Stop config validation after the first error

### DIFF
--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -190,6 +190,7 @@ class Config(UserDict):
                 config_option.reset_warnings()
             except ValidationError as e:
                 failed.append((key, e))
+                break
 
         for key in set(self.keys()) - self._schema_keys:
             warnings.append((key, f"Unrecognised configuration name: {key}"))
@@ -382,7 +383,7 @@ def load_config(
         log.debug(f"Config value '{key}' = {value!r}")
 
     if len(errors) > 0:
-        raise exceptions.Abort(f"Aborted with {len(errors)} configuration errors!")
+        raise exceptions.Abort("Aborted with a configuration error!")
     elif cfg.strict and len(warnings) > 0:
         raise exceptions.Abort(
             f"Aborted with {len(warnings)} configuration warnings in 'strict' mode!"


### PR DESCRIPTION
If one config option completely fails validation, that means its value remains "raw" from YAML, which can cause unpredictable errors when validating other options that might look at the value. Instead just decide one error is enough.

* See one such case: https://github.com/mkdocs/mkdocs/pull/3351