### PR TITLE
Quoted pip arguments containing square brackets

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -85,7 +85,7 @@ most likely need to have tests and documentation if it is a new feature.
 
 ### Submitting changes to the builtin themes
 
-When installed with `i18n` support (`pip install mkdocs[i18n]`), MkDocs allows
+When installed with `i18n` support (`pip install 'mkdocs[i18n]'`), MkDocs allows
 themes to support being translated into various languages (referred to as
 locales) if they respect [Jinja's i18n extension] by wrapping text placeholders
 with `{% trans %}` and `{% endtrans %}` tags.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -733,7 +733,7 @@ happen by default. Users must first install the necessary dependencies with
 the following command:
 
 ```bash
-pip install mkdocs[i18n]
+pip install 'mkdocs[i18n]'
 ```
 
 Translation contributions are welcome and detailed in the [Translation

--- a/docs/dev-guide/themes.md
+++ b/docs/dev-guide/themes.md
@@ -1038,7 +1038,7 @@ WARNING:
 As **[pybabel] is not installed by default** and most users will not have
 pybabel installed, theme developers and/or translators should make sure to
 have installed the necessary dependencies
-(using `pip install mkdocs[i18n]`) in order for the commands to be
+(using `pip install 'mkdocs[i18n]'`) in order for the commands to be
 available for use.
 
 The translation commands should be called from the root of your theme's working tree.

--- a/docs/dev-guide/translations.md
+++ b/docs/dev-guide/translations.md
@@ -38,7 +38,7 @@ are working from a properly configured development environment.
 Make sure translation requirements are installed in your environment:
 
 ```bash
-pip install mkdocs[i18n]
+pip install 'mkdocs[i18n]'
 ```
 
 [babel]: https://babel.pocoo.org/en/latest/cmdline.html

--- a/docs/user-guide/localizing-your-theme.md
+++ b/docs/user-guide/localizing-your-theme.md
@@ -17,7 +17,7 @@ For theme localization to work, you must use a theme which supports it and
 enable `i18n` (internationalization) support by installing `mkdocs[i18n]`:
 
 ```bash
-pip install mkdocs[i18n]
+pip install 'mkdocs[i18n]'
 ```
 
 ## Supported locales


### PR DESCRIPTION
This is strictly necessary when using non-bash shells (e.g. tcsh).