### PR TITLE
Make sitemap.xml.gz slightly more reproducible

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -112,9 +112,8 @@ def _build_theme_template(
             log.debug(f"Gzipping template: {template_name}")
             gz_filename = f'{output_path}.gz'
             with open(gz_filename, 'wb') as f:
-                timestamp = utils.get_build_timestamp()
                 with gzip.GzipFile(
-                    fileobj=f, filename=gz_filename, mode='wb', mtime=timestamp
+                    fileobj=f, filename=gz_filename, mode='wb', mtime=utils._REPRODUCIBLE_TIMESTAMP
                 ) as gz_buf:
                     gz_buf.write(output.encode('utf-8'))
     else:

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -112,8 +112,11 @@ def _build_theme_template(
             log.debug(f"Gzipping template: {template_name}")
             gz_filename = f'{output_path}.gz'
             with open(gz_filename, 'wb') as f:
+                timestamp = utils.get_build_timestamp(
+                    pages=[f.page for f in files.documentation_pages() if f.page is not None]
+                )
                 with gzip.GzipFile(
-                    fileobj=f, filename=gz_filename, mode='wb', mtime=utils._REPRODUCIBLE_TIMESTAMP
+                    fileobj=f, filename=gz_filename, mode='wb', mtime=timestamp
                 ) as gz_buf:
                     gz_buf.write(output.encode('utf-8'))
     else:

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -42,7 +42,7 @@ class Page(StructureItem):
         self.next_page = None
         self.active = False
 
-        self.update_date = get_build_date()
+        self.update_date: str = get_build_date()
 
         self._set_canonical_url(config.get('site_url', None))
         self._set_edit_url(

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -233,7 +233,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     def test_build_theme_template(self, mock_build_template, mock_write_file):
         cfg = load_config()
         env = cfg.theme.get_env()
-        build._build_theme_template('main.html', env, mock.Mock(), cfg, mock.Mock())
+        build._build_theme_template('main.html', env, Files([]), cfg, mock.Mock())
         mock_write_file.assert_called_once()
         mock_build_template.assert_called_once()
 
@@ -246,7 +246,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     ):
         cfg = load_config(site_dir=site_dir)
         env = cfg.theme.get_env()
-        build._build_theme_template('sitemap.xml', env, mock.Mock(), cfg, mock.Mock())
+        build._build_theme_template('sitemap.xml', env, Files([]), cfg, mock.Mock())
         mock_write_file.assert_called_once()
         mock_build_template.assert_called_once()
         mock_gzip_gzipfile.assert_called_once()
@@ -257,7 +257,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         cfg = load_config()
         env = cfg.theme.get_env()
         with self.assertLogs('mkdocs') as cm:
-            build._build_theme_template('missing.html', env, mock.Mock(), cfg, mock.Mock())
+            build._build_theme_template('missing.html', env, Files([]), cfg, mock.Mock())
         self.assertEqual(
             '\n'.join(cm.output),
             "WARNING:mkdocs.commands.build:Template skipped: 'missing.html' not found in theme directories.",
@@ -271,7 +271,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         cfg = load_config()
         env = cfg.theme.get_env()
         with self.assertLogs('mkdocs') as cm:
-            build._build_theme_template('main.html', env, mock.Mock(), cfg, mock.Mock())
+            build._build_theme_template('main.html', env, Files([]), cfg, mock.Mock())
         self.assertEqual(
             '\n'.join(cm.output),
             "INFO:mkdocs.commands.build:Template skipped: 'main.html' generated empty output.",

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -48,11 +48,7 @@ _REPRODUCIBLE_TIMESTAMP = 1580601600
 
 def get_build_timestamp() -> int:
     """Soft-deprecated, do not use."""
-    source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH')
-    if source_date_epoch is None:
-        return int(datetime.now(timezone.utc).timestamp())
-
-    return int(source_date_epoch)
+    return int(get_build_datetime().timestamp())
 
 
 def get_build_datetime() -> datetime:

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -43,14 +43,11 @@ markdown_extensions = (
     '.md',
 )
 
+_REPRODUCIBLE_TIMESTAMP = 1580601600
+
 
 def get_build_timestamp() -> int:
-    """
-    Returns the number of seconds since the epoch.
-
-    Support SOURCE_DATE_EPOCH environment variable for reproducible builds.
-    See https://reproducible-builds.org/specs/source-date-epoch/
-    """
+    """Soft-deprecated, do not use."""
     source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH')
     if source_date_epoch is None:
         return int(datetime.now(timezone.utc).timestamp())

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -43,12 +43,20 @@ markdown_extensions = (
     '.md',
 )
 
-_REPRODUCIBLE_TIMESTAMP = 1580601600
 
+def get_build_timestamp(*, pages: Collection[Page] | None = None) -> int:
+    """
+    Returns the number of seconds since the epoch for the latest updated page.
 
-def get_build_timestamp() -> int:
-    """Soft-deprecated, do not use."""
-    return int(get_build_datetime().timestamp())
+    In reality this is just today's date because that's how pages' update time is populated.
+    """
+    if pages:
+        # Lexicographic comparison is OK for ISO date.
+        date_string = max(p.update_date for p in pages)
+        dt = datetime.fromisoformat(date_string)
+    else:
+        dt = get_build_datetime()
+    return int(dt.timestamp())
 
 
 def get_build_datetime() -> datetime:


### PR DESCRIPTION
The gzip format stores a timestamp inside it, but there's no real point to it being correct.

If a site is rebuilt exactly the same twice, the timestamp *metadata* of files will be different sure, but this gzip file was the only one that also had *actual content* that is different each time.

Now instead the date of the gzip file will change only once per day, based on the pages' update date. The sitemap.xml itself also changes once per day already.

* Closes #2689