### PR TITLE
Implement validation of anchors in links to other pages

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -20,5 +20,8 @@
   "MD024": { "siblings_only": true },
 
   // Allow inline HTML
-  "MD033": false
+  "MD033": false,
+
+  // Disable named references validation
+  "MD052": false
 }

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1262,7 +1262,7 @@ Users can review the [configuration options][search config] available and theme
 authors should review how [search and themes] interact.
 
 [search config]: ../user-guide/configuration.md#search
-[search and themes]: ../dev-guide/themes.md#search_and_themes
+[search and themes]: ../dev-guide/themes.md#search-and-themes
 
 #### `theme_dir` Configuration Option fully Deprecated
 
@@ -1406,25 +1406,18 @@ version 1.0.
 Any of the following old page variables should be updated to the new ones in
 user created and third-party templates:
 
-| Old Variable Name | New Variable Name   |
-| ----------------- | ------------------- |
-| current_page      | [page]              |
-| page_title        | [page.title]        |
-| content           | [page.content]      |
-| toc               | [page.toc]          |
-| meta              | [page.meta]         |
-| canonical_url     | [page.canonical_url]|
-| previous_page     | [page.previous_page]|
-| next_page         | [page.next_page]    |
+| Old Variable Name | New Variable Name |
+| ----------------- | ----------------- |
+| current_page      | page              |
+| page_title        | page.title        |
+| content           | page.content      |
+| toc               | page.toc          |
+| meta              | page.meta         |
+| canonical_url     | page.canonical_url|
+| previous_page     | page.previous_page|
+| next_page         | page.next_page    |
 
 [page]: ../dev-guide/themes.md#page
-[page.title]: ../dev-guide/themes.md#pagetitle
-[page.content]: ../dev-guide/themes.md#pagecontent
-[page.toc]: ../dev-guide/themes.md#pagetoc
-[page.meta]: ../dev-guide/themes.md#pagemeta
-[page.canonical_url]: ../dev-guide/themes.md#pagecanonical_url
-[page.previous_page]: ../dev-guide/themes.md#pageprevious_page
-[page.next_page]: ../dev-guide/themes.md#pagenext_page
 
 Additionally, a number of global variables have been altered and/or removed
 and user created and third-party templates should be updated as outlined below:
@@ -1793,12 +1786,11 @@ no configuration is needed to enable it.
 
 #### Change the pages configuration
 
-Provide a [new way] to define pages, and specifically [nested pages], in the
+Provide a [new way] to define pages, and specifically nested pages, in the
 mkdocs.yml file and deprecate the existing approach, support will be removed
 with MkDocs 1.0.
 
 [new way]: ../user-guide/writing-your-docs.md#configure-pages-and-navigation
-[nested pages]: ../user-guide/writing-your-docs.md#multilevel-documentation
 
 #### Warn users about the removal of builtin themes
 

--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -473,7 +473,7 @@ class MyPlugin(BasePlugin):
             # some code that could throw a KeyError
             ...
         except KeyError as error:
-            raise PluginError(str(error))
+            raise PluginError(f"Failed to find the item by key: '{error}'")
 
     def on_build_error(self, error, **kwargs):
         # some code to clean things up
@@ -482,10 +482,31 @@ class MyPlugin(BasePlugin):
 
 ### Logging in plugins
 
-MkDocs provides a `get_plugin_logger` function which returns
-a logger that can be used to log messages.
+To ensure that your plugins' log messages adhere with MkDocs' formatting and `--verbose`/`--debug` flags, please write the logs to a logger under the `mkdocs.plugins.` namespace.
 
-#### ::: mkdocs.plugins.get_plugin_logger
+> EXAMPLE:
+>
+> ```python
+> import logging
+>
+> log = logging.getLogger(f"mkdocs.plugins.{__name__}")
+>
+> log.warning("File '%s' not found. Breaks the build if --strict is passed", my_file_name)
+> log.info("Shown normally")
+> log.debug("Shown only with `--verbose`")
+>
+> if log.getEffectiveLevel() <= logging.DEBUG:
+>     log.debug("Very expensive calculation only for debugging: %s", get_my_diagnostics())
+> ```
+
+`log.error()` is another logging level that is differentiated by its look, but in all other ways it functions the same as `warning`, so it's strange to use it. If your plugin encounters an actual error, it is best to just interrupt the build by raising [`mkdocs.exceptions.PluginError`][] (which will also log an ERROR message).
+
+<!-- -->
+> NEW: New in MkDocs 1.5
+>
+> MkDocs now provides a `get_plugin_logger()` convenience function that returns a logger like the above that is also prefixed with the plugin's name.
+>
+> #### ::: mkdocs.plugins.get_plugin_logger
 
 ### Entry Point
 

--- a/docs/dev-guide/themes.md
+++ b/docs/dev-guide/themes.md
@@ -245,7 +245,6 @@ used options include:
 * [config.repo_url](../user-guide/configuration.md#repo_url)
 * [config.repo_name](../user-guide/configuration.md#repo_name)
 * [config.copyright](../user-guide/configuration.md#copyright)
-* [config.google_analytics](../user-guide/configuration.md#google_analytics)
 
 #### nav
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1188,7 +1188,7 @@ echo '{INHERIT: mkdocs.yml, site_name: "Renamed site"}' | mkdocs build -f -
 [Python-Markdown wiki]: https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions
 [catalog]: https://github.com/mkdocs/catalog
 [configuring pages and navigation]: writing-your-docs.md#configure-pages-and-navigation
-[theme_dir]: customizing-your-theme.md#using-the-theme_dir
+[theme_dir]: customizing-your-theme.md#using-the-theme-custom_dir
 [choosing your theme]: choosing-your-theme.md
 [Localizing your theme]: localizing-your-theme.md
 [extra_css]: #extra_css

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -364,7 +364,7 @@ Configure the strictness of MkDocs' diagnostic messages when validating links to
 
 This is a tree of configs, and for each one the value can be one of the three: `warn`, `info`, `ignore`. Which cause a logging message of the corresponding severity to be produced. The `warn` level is, of course, intended for use with `mkdocs build --strict` (where it becomes an error), which you can employ in continuous testing.
 
-> EXAMPLE: **Defaults of this config as of MkDocs 1.5:**
+> EXAMPLE: **Defaults of this config as of MkDocs 1.6:**
 >
 > ```yaml
 > validation:
@@ -374,6 +374,7 @@ This is a tree of configs, and for each one the value can be one of the three: `
 >     absolute_links: info
 >   links:
 >     not_found: warn
+>     anchors: ignore
 >     absolute_links: info
 >     unrecognized_links: info
 > ```
@@ -382,7 +383,7 @@ This is a tree of configs, and for each one the value can be one of the three: `
 
 The defaults of some of the behaviors already differ from MkDocs 1.4 and below - they were ignored before.
 
->? EXAMPLE: **Configure MkDocs 1.5 to behave like MkDocs 1.4 and below (reduce strictness):**
+>? EXAMPLE: **Configure MkDocs 1.6 to behave like MkDocs 1.4 and below (reduce strictness):**
 >
 > ```yaml
 > validation:
@@ -397,23 +398,27 @@ The defaults of some of the behaviors already differ from MkDocs 1.4 and below -
 >   omitted_files: warn
 >   absolute_links: warn
 >   unrecognized_links: warn
+>   anchors: warn  # New in MkDocs 1.6
 > ```
 
 Note how in the above examples we omitted the 'nav' and 'links' keys. Here `absolute_links:` means setting both `nav: absolute_links:` and `links: absolute_links:`.
 
 Full list of values and examples of log messages that they can hide or make more prominent:
 
-*   `validation.nav.omitted_files`  
+*   `validation.nav.omitted_files`
     * "The following pages exist in the docs directory, but are not included in the "nav" configuration: ..."
-*   `validation.nav.not_found`  
+*   `validation.nav.not_found`
     * "A relative path to 'foo/bar.md' is included in the 'nav' configuration, which is not found in the documentation files."
     * "A reference to 'foo/bar.md' is included in the 'nav' configuration, but this file is excluded from the built site."
-*   `validation.nav.absolute_links`  
+*   `validation.nav.absolute_links`
     * "An absolute path to '/foo/bar.html' is included in the 'nav' configuration, which presumably points to an external resource."
 <!-- -->
-*   `validation.links.not_found`  
-    * "Doc file 'example.md' contains a relative link '../foo/bar.md', but the target is not found among documentation files."
+*   `validation.links.not_found`
+    * "Doc file 'example.md' contains a link '../foo/bar.md', but the target is not found among documentation files."
     * "Doc file 'example.md' contains a link to 'foo/bar.md' which is excluded from the built site."
+*   `validation.links.anchors`
+    * "Doc file 'example.md' contains a link '../foo/bar.md#some-heading', but the doc 'foo/bar.md' does not contain an anchor '#some-heading'."
+    * "Doc file 'example.md' contains a link '#some-heading', but there is no such anchor on this page."
 *   `validation.links.absolute_links`
     * "Doc file 'example.md' contains an absolute link '/foo/bar.html', it was left as is. Did you mean 'foo/bar.md'?"
 *   `validation.links.unrecognized_links`

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -89,13 +89,11 @@ class State:
 
     def __init__(self, log_name='mkdocs', level=logging.INFO):
         self.logger = logging.getLogger(log_name)
-        # Don't restrict level on logger; use handler
-        self.logger.setLevel(1)
+        self.logger.setLevel(level)
         self.logger.propagate = False
 
         self.stream = logging.StreamHandler()
         self.stream.setFormatter(ColorFormatter())
-        self.stream.setLevel(level)
         self.stream.name = 'MkDocsStreamHandler'
         self.logger.addHandler(self.stream)
 
@@ -161,7 +159,7 @@ def verbose_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
         if value:
-            state.stream.setLevel(logging.DEBUG)
+            state.logger.setLevel(logging.DEBUG)
 
     return click.option(
         '-v',
@@ -177,7 +175,7 @@ def quiet_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
         if value:
-            state.stream.setLevel(logging.ERROR)
+            state.logger.setLevel(logging.ERROR)
 
     return click.option(
         '-q',

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -341,6 +341,11 @@ def build(
                 file.page, config, doc_files, nav, env, dirty, excluded=file.inclusion.is_excluded()
             )
 
+        log_level = config.validation.links.anchors
+        for file in doc_files:
+            assert file.page is not None
+            file.page.validate_anchor_links(files=files, log_level=log_level)
+
         # Run `post_build` plugin events.
         config.plugins.on_post_build(config=config)
 

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -166,6 +166,9 @@ class MkDocsConfig(base.Config):
             """Warning level for when a Markdown doc links to a relative path that doesn't look like
             it could be a valid internal link. For example, if the link ends with `/`."""
 
+            anchors = c._LogLevel(default='ignore')
+            """Warning level for when a Markdown doc links to an anchor that's not present on the target page."""
+
         links = c.SubConfig(LinksValidation)
 
     validation = c.PropagatingSubConfig[Validation]()

--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -237,14 +237,6 @@ class File:
         self.abs_dest_path = os.path.normpath(os.path.join(dest_dir, self.dest_uri))
         self.inclusion = inclusion
 
-    def __eq__(self, other) -> bool:
-        return (
-            isinstance(other, self.__class__)
-            and self.src_uri == other.src_uri
-            and self.abs_src_path == other.abs_src_path
-            and self.url == other.url
-        )
-
     def __repr__(self):
         return (
             f"File(src_uri='{self.src_uri}', dest_uri='{self.dest_uri}',"

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -609,7 +609,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         server = testing_server(site_dir, mount_path='/documentation/')
         with self.subTest(live_server=server):
             expected_logs = '''
-                INFO:Doc file 'test/bar.md' contains a relative link 'nonexistent.md', but the target 'test/nonexistent.md' is not found among documentation files.
+                INFO:Doc file 'test/bar.md' contains a link 'nonexistent.md', but the target 'test/nonexistent.md' is not found among documentation files.
                 INFO:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
                 INFO:The following pages are being built only for the preview but will be excluded from `mkdocs build` per `exclude_docs`:
                   - http://localhost:123/documentation/.zoo.html
@@ -671,6 +671,88 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
                 index_path = Path(site_dir, 'foo', 'index.html')
                 self.assertPathIsFile(index_path)
                 self.assertRegex(index_path.read_text(), r'page1 content')
+
+    @tempdir(
+        files={
+            'test/foo.md': '## page1 heading\n\n[bar](bar.md#page1-heading)',
+            'test/bar.md': '## page2 heading\n\n[aaa](#a)',
+        }
+    )
+    @tempdir()
+    def test_anchor_warning(self, site_dir, docs_dir):
+        cfg = load_config(docs_dir=docs_dir, site_dir=site_dir, validation={'anchors': 'warn'})
+
+        expected_logs = '''
+            WARNING:Doc file 'test/bar.md' contains a link '#a', but there is no such anchor on this page.
+            WARNING:Doc file 'test/foo.md' contains a link 'bar.md#page1-heading', but the doc 'test/bar.md' does not contain an anchor '#page1-heading'.
+        '''
+        with self._assert_build_logs(expected_logs):
+            build.build(cfg)
+
+    @tempdir(
+        files={
+            'test/foo.md': '[bar](bar.md#heading1)',
+            'test/bar.md': '## heading1',
+        }
+    )
+    @tempdir()
+    def test_anchor_no_warning(self, site_dir, docs_dir):
+        cfg = load_config(docs_dir=docs_dir, site_dir=site_dir, validation={'anchors': 'warn'})
+        build.build(cfg)
+
+    @unittest.skip("The implementation is not good enough to understand this yet.")  # TODO
+    @tempdir(
+        files={
+            'test/foo.md': '[bar](bar.md#heading2)',
+            'test/bar.md': '## heading1\n\n<a id="heading2">hi</a>',
+        }
+    )
+    @tempdir()
+    def test_anchor_no_warning_with_html(self, site_dir, docs_dir):
+        cfg = load_config(
+            docs_dir=docs_dir,
+            site_dir=site_dir,
+            validation={'anchors': 'warn'},
+            markdown_extensions=['md_in_html'],
+        )
+        build.build(cfg)
+
+    @tempdir(
+        files={
+            'test/foo.md': '[bar1](bar.md?test#heading1), [bar2](bar.md?test#headingno), [bar3](bar.md?test), [self4](?test), [self5](?test#hi)',
+            'test/bar.md': '## heading1',
+        }
+    )
+    @tempdir()
+    def test_anchor_warning_and_query(self, site_dir, docs_dir):
+        cfg = load_config(docs_dir=docs_dir, site_dir=site_dir, validation={'anchors': 'info'})
+
+        expected_logs = '''
+            INFO:Doc file 'test/foo.md' contains a link 'bar.md?test#headingno', but the doc 'test/bar.md' does not contain an anchor '#headingno'.
+            INFO:Doc file 'test/foo.md' contains a link '?test#hi', but there is no such anchor on this page.
+        '''
+        with self._assert_build_logs(expected_logs):
+            build.build(cfg)
+
+    @tempdir(
+        files={
+            'test/foo.md': 'test[^1]\n\n[^1]: footnote1\n[^2]: footnote2',
+        }
+    )
+    @tempdir()
+    def test_anchor_warning_for_footnote(self, site_dir, docs_dir):
+        cfg = load_config(
+            docs_dir=docs_dir,
+            site_dir=site_dir,
+            validation={'anchors': 'info'},
+            markdown_extensions=['footnotes'],
+        )
+
+        expected_logs = '''
+            INFO:Doc file 'test/foo.md' contains a link '#fnref:2', but there is no such anchor on this page. This seems to be a footnote that is never referenced.
+        '''
+        with self._assert_build_logs(expected_logs):
+            build.build(cfg)
 
     @tempdir(
         files={

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -222,8 +222,8 @@ class CLITests(unittest.TestCase):
             use_directory_urls=None,
             site_dir=None,
         )
-        handler = logging._handlers.get('MkDocsStreamHandler')
-        self.assertEqual(handler.level, logging.INFO)
+        for log_name in 'mkdocs', 'mkdocs.structure.pages', 'mkdocs.plugins.foo':
+            self.assertEqual(logging.getLogger(log_name).getEffectiveLevel(), logging.INFO)
 
     @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
@@ -352,8 +352,8 @@ class CLITests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_build.call_count, 1)
-        handler = logging._handlers.get('MkDocsStreamHandler')
-        self.assertEqual(handler.level, logging.DEBUG)
+        for log_name in 'mkdocs', 'mkdocs.structure.pages', 'mkdocs.plugins.foo':
+            self.assertEqual(logging.getLogger(log_name).getEffectiveLevel(), logging.DEBUG)
 
     @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
@@ -362,8 +362,8 @@ class CLITests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_build.call_count, 1)
-        handler = logging._handlers.get('MkDocsStreamHandler')
-        self.assertEqual(handler.level, logging.ERROR)
+        for log_name in 'mkdocs', 'mkdocs.structure.pages', 'mkdocs.plugins.foo':
+            self.assertEqual(logging.getLogger(log_name).getEffectiveLevel(), logging.ERROR)
 
     @mock.patch('mkdocs.commands.new.new', autospec=True)
     def test_new(self, mock_new):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1586,6 +1586,7 @@ class NestedSubConfigTest(TestCase):
                 'not_found': logging.WARNING,
                 'absolute_links': logging.INFO,
                 'unrecognized_links': logging.INFO,
+                'anchors': logging.DEBUG,
             },
         }
 

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -8,27 +8,6 @@ from mkdocs.tests.base import PathAssertionMixin, load_config, tempdir
 
 
 class TestFiles(PathAssertionMixin, unittest.TestCase):
-    def test_file_eq(self):
-        file = File('a.md', '/path/to/docs', '/path/to/site', use_directory_urls=False)
-        self.assertTrue(
-            file == File('a.md', '/path/to/docs', '/path/to/site', use_directory_urls=False)
-        )
-
-    def test_file_ne(self):
-        file = File('a.md', '/path/to/docs', '/path/to/site', use_directory_urls=False)
-        # Different filename
-        self.assertTrue(
-            file != File('b.md', '/path/to/docs', '/path/to/site', use_directory_urls=False)
-        )
-        # Different src_path
-        self.assertTrue(
-            file != File('a.md', '/path/to/other', '/path/to/site', use_directory_urls=False)
-        )
-        # Different URL
-        self.assertTrue(
-            file != File('a.md', '/path/to/docs', '/path/to/site', use_directory_urls=True)
-        )
-
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_src_path_windows(self):
         f = File('foo\\a.md', '/path/to/docs', '/path/to/site', use_directory_urls=False)

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -960,7 +960,7 @@ class RelativePathExtensionTests(unittest.TestCase):
             self.get_rendered_result(
                 content='[link](non-existent.md)',
                 files=['index.md'],
-                logs="WARNING:Doc file 'index.md' contains a relative link 'non-existent.md', but the target is not found among documentation files.",
+                logs="WARNING:Doc file 'index.md' contains a link 'non-existent.md', but the target is not found among documentation files.",
             ),
             '<a href="non-existent.md">link</a>',
         )
@@ -969,7 +969,7 @@ class RelativePathExtensionTests(unittest.TestCase):
                 validation=dict(links=dict(not_found='info')),
                 content='[link](../non-existent.md)',
                 files=['sub/index.md'],
-                logs="INFO:Doc file 'sub/index.md' contains a relative link '../non-existent.md', but the target 'non-existent.md' is not found among documentation files.",
+                logs="INFO:Doc file 'sub/index.md' contains a link '../non-existent.md', but the target 'non-existent.md' is not found among documentation files.",
             ),
             '<a href="../non-existent.md">link</a>',
         )
@@ -1062,7 +1062,7 @@ class RelativePathExtensionTests(unittest.TestCase):
             self.get_rendered_result(
                 content='![image](../image.png)',
                 files=['foo/bar.md', 'foo/image.png'],
-                logs="WARNING:Doc file 'foo/bar.md' contains a relative link '../image.png', but the target 'image.png' is not found among documentation files. Did you mean 'image.png'?",
+                logs="WARNING:Doc file 'foo/bar.md' contains a link '../image.png', but the target 'image.png' is not found among documentation files. Did you mean 'image.png'?",
             ),
             '<img alt="image" src="../image.png" />',
         )
@@ -1102,7 +1102,7 @@ class RelativePathExtensionTests(unittest.TestCase):
             self.get_rendered_result(
                 content='[contact](mail@example.com)',
                 files=['index.md'],
-                logs="WARNING:Doc file 'index.md' contains a relative link 'mail@example.com', but the target is not found among documentation files. Did you mean 'mailto:mail@example.com'?",
+                logs="WARNING:Doc file 'index.md' contains a link 'mail@example.com', but the target is not found among documentation files. Did you mean 'mailto:mail@example.com'?",
             ),
             '<a href="mail@example.com">contact</a>',
         )


### PR DESCRIPTION
Example message:
    
    WARNING -  Doc file 'dev-guide/themes.md' contains a link '../user-guide/configuration.md#google_analytics', but the doc 'user-guide/configuration.md' does not contain an anchor '#google>
    
It is not enabled by default. To increase to warning level, use config `validation: {anchors: warn}`
    
The implementation only detects Markdown anchors, not raw HTML anchors. As such it may have false positives.

~~The implementation now detects both Markdown anchors and raw HTML anchors~~

```markdown
<a id="undetectable-anchor"></a>

## Detectable anchor
```

But that's just about user-authored HTML.
As for HTML that Markdown extensions insert: it will also work correctly if they insert the HTML as etree elements and will never work if they insert it via `htmlStash`. Basically the same rules as for what `toc_tokens` is able to detect.

---

Extra commits:
- Make `File` hashable, without `__eq__`
- Docs: fix or drop broken anchor links
- Set logging levels on the logger rather than just the stream
- Update docs about logging in plugins

---

* Closes #658