### PR TITLE
Enhance `serve`: randomize the port, allow to open a browser

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -646,13 +646,12 @@ This is also available as a command line flag: `--strict`.
 
 ### dev_addr
 
-Determines the address used when running `mkdocs serve`. Must be of the format
-`IP:PORT`.
+Determines the address used when running `mkdocs serve`. Can be just the IP address, or `IP:PORT`.
 
 Allows a custom default to be set without the need to pass it through the
-`--dev-addr` option every time the `mkdocs serve` command is called.
+`--dev-addr` or `--port` option every time the `mkdocs serve` command is called.
 
-**default**: `'127.0.0.1:8000'`
+**default**: `'127.0.0.1'`, with an arbitrary port number between 8001 and 8099, based on a hash of the `site_name` and `site_url`.
 
 See also: [site_url](#site_url).
 

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -109,7 +109,10 @@ clean_help = "Remove old files from the site_dir before building (the default)."
 config_help = (
     "Provide a specific MkDocs config. This can be a file name, or '-' to read from stdin."
 )
-dev_addr_help = "IP address and port to serve documentation locally (default: localhost:8000)"
+dev_addr_help = "IP address to serve documentation locally (default: localhost)."
+serve_port_help = (
+    "Port to serve documentation locally (default: 80XX). Overrides the port from dev_addr."
+)
 serve_open_help = "Open the website in a Web browser after the initial build finishes."
 strict_help = "Enable strict mode. This will cause MkDocs to abort the build on any warnings."
 theme_help = "The theme to use when building your documentation."
@@ -249,7 +252,8 @@ def cli():
 
 
 @cli.command(name="serve")
-@click.option('-a', '--dev-addr', help=dev_addr_help, metavar='<IP:PORT>')
+@click.option('-a', '--dev-addr', help=dev_addr_help, metavar='IP:PORT')
+@click.option('-p', '--port', type=int, help=serve_port_help)
 @click.option('-o', '--open', 'open_in_browser', help=serve_open_help, is_flag=True)
 @click.option('--no-livereload', 'livereload', flag_value=False, help=no_reload_help)
 @click.option('--livereload', 'livereload', flag_value=True, default=True, hidden=True)

--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -59,7 +59,8 @@ def serve(
     host = config.dev_addr.host
     if port is None:
         port = config.dev_addr.port
-    if port is None:
+    port_unspecified = port is None
+    if port_unspecified:
         port = get_random_port(config)
 
     mount_path = urlsplit(config.site_url or '/').path
@@ -108,7 +109,10 @@ def serve(
                 server.watch(item)
 
         try:
-            server.serve(open_in_browser=open_in_browser)
+            server.serve(
+                try_extra_ports=3 if port_unspecified else 0,
+                open_in_browser=open_in_browser,
+            )
         except KeyboardInterrupt:
             log.info("Shutting down...")
         finally:

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -68,7 +68,7 @@ class MkDocsConfig(base.Config):
     """set of values for Google analytics containing the account IO and domain
     this should look like, ['UA-27795084-5', 'mkdocs.org']"""
 
-    dev_addr = c.IpAddress(default='127.0.0.1:8000')
+    dev_addr = c.IpAddress(default='127.0.0.1')
     """The address on which to serve the live reloading docs server."""
 
     use_directory_urls = c.Type(bool, default=True)

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -21,6 +21,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,
@@ -54,6 +55,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr='0.0.0.0:80',
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,
@@ -72,6 +74,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,
@@ -92,6 +95,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,
@@ -112,6 +116,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,
@@ -132,6 +137,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,
@@ -150,6 +156,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,
@@ -168,6 +175,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=False,
             build_type=None,
@@ -186,6 +194,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type='dirty',
@@ -204,6 +213,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_serve.assert_called_once_with(
             dev_addr=None,
+            port=None,
             open_in_browser=False,
             livereload=True,
             build_type=None,

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -366,20 +366,24 @@ class IpAddressTest(TestCase):
             self.get_config(self.Schema, {'option': '277.0.0.1:8000'})
 
     def test_invalid_address_format(self):
-        with self.expect_error(option="Must be a string of format 'IP:PORT'"):
+        with self.expect_error(
+            option="'127.0.0.18000' does not appear to be an IPv4 or IPv6 address"
+        ):
             self.get_config(self.Schema, {'option': '127.0.0.18000'})
 
     def test_invalid_address_type(self):
-        with self.expect_error(option="Must be a string of format 'IP:PORT'"):
+        with self.expect_error(option="Must be a string"):
             self.get_config(self.Schema, {'option': 123})
 
     def test_invalid_address_port(self):
         with self.expect_error(option="'foo' is not a valid port"):
             self.get_config(self.Schema, {'option': '127.0.0.1:foo'})
 
-    def test_invalid_address_missing_port(self):
-        with self.expect_error(option="Must be a string of format 'IP:PORT'"):
-            self.get_config(self.Schema, {'option': '127.0.0.1'})
+    def test_address_without_port(self) -> None:
+        conf = self.get_config(self.Schema, {'option': '127.0.0.1'})
+        self.assertEqual(str(conf['option']), '127.0.0.1')
+        self.assertEqual(conf['option'].host, '127.0.0.1')
+        self.assertEqual(conf['option'].port, None)
 
     def test_unsupported_address(self):
         class Schema:

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -299,7 +299,7 @@ class IpAddressTest(TestCase):
 
         assert_type(conf.option, c._IpAddressValue)
         assert_type(conf.option.host, str)
-        assert_type(conf.option.port, int)
+        assert_type(conf.option.port, Union[int, None])
 
         self.assertEqual(str(conf.option), addr)
         self.assertEqual(conf.option.host, '127.0.0.1')
@@ -354,20 +354,24 @@ class IpAddressTest(TestCase):
             self.get_config(self.Schema, {'option': '277.0.0.1:8000'})
 
     def test_invalid_address_format(self) -> None:
-        with self.expect_error(option="Must be a string of format 'IP:PORT'"):
+        with self.expect_error(
+            option="'127.0.0.18000' does not appear to be an IPv4 or IPv6 address"
+        ):
             self.get_config(self.Schema, {'option': '127.0.0.18000'})
 
     def test_invalid_address_type(self) -> None:
-        with self.expect_error(option="Must be a string of format 'IP:PORT'"):
+        with self.expect_error(option="Must be a string"):
             self.get_config(self.Schema, {'option': 123})
 
     def test_invalid_address_port(self) -> None:
         with self.expect_error(option="'foo' is not a valid port"):
             self.get_config(self.Schema, {'option': '127.0.0.1:foo'})
 
-    def test_invalid_address_missing_port(self) -> None:
-        with self.expect_error(option="Must be a string of format 'IP:PORT'"):
-            self.get_config(self.Schema, {'option': '127.0.0.1'})
+    def test_address_without_port(self) -> None:
+        conf = self.get_config(self.Schema, {'option': '127.0.0.1'})
+        self.assertEqual(str(conf.option), '127.0.0.1')
+        self.assertEqual(conf.option.host, '127.0.0.1')
+        self.assertEqual(conf.option.port, None)
 
     def test_unsupported_address(self) -> None:
         class Schema(Config):


### PR DESCRIPTION
- **Choose a random port for `serve`, add flag to override it**
  The range is 8000-8099.
  The port is actually not random but is reproducible based on the hash of `site_name` and `site_url`.
  Bonus: `dev_addr` config can now be just the address, to allow for this default selection behavior to remain.

- **Try 3 following ports for `serve` if the initial one is taken**
  This is done only for the default "random" choice of port, not when it's explicitly specified

  Closes #3496

I think to resolve this feature request in a good way, **both** of these actions needed to be done together. Just trying next ports would make a mess if you regularly use 2 sites and they arbitrarily switch port numbers between each other.

So first we make the collisions extremely unlikely in the first place, **but** each site still has its predictable port number (for example, MkDocs' own site will always be 127.0.0.1:8062). **Then** still let it try next ports in case it's the same site or a collision happened.