### PR TITLE
Allow docs to be in the root directory

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -40,11 +40,8 @@ def serve(
     site_dir = tempfile.mkdtemp(prefix='mkdocs_')
 
     def get_config():
-        config = load_config(
-            config_file=config_file,
-            site_dir=site_dir,
-            **kwargs,
-        )
+        config = load_config(config_file=config_file, **kwargs)
+        config.site_dir = site_dir  # Overwrite it afterwards, so normal validation still kicks in.
         config.watch.extend(watch)
         return config
 

--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -168,7 +168,10 @@ class Config(UserDict):
                 config_file_path = config_file_path.decode(encoding=sys.getfilesystemencoding())
             except UnicodeDecodeError:
                 raise ValidationError("config_file_path is not a Unicode string.")
-        self.config_file_path = config_file_path or ''
+        if config_file_path:
+            self.config_file_path = os.path.abspath(config_file_path)
+        else:
+            self.config_file_path = ''
 
     def set_defaults(self) -> None:
         """

--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -804,17 +804,19 @@ class SiteDir(Dir):
         # and eventually make a deep nested mess.
         if _relative_path(docs_dir, to=site_dir):
             raise ValidationError(
-                f"The 'docs_dir' should not be within the 'site_dir' as this "
-                f"can mean the source files are overwritten by the output or "
-                f"it will be deleted if --clean is passed to mkdocs build. "
-                f"(site_dir: '{site_dir}', docs_dir: '{docs_dir}')"
+                "The docs_dir should not be inside the site_dir as this "
+                "can mean the source files are overwritten by the output or "
+                "deleted entirely."
             )
-        if _relative_path(site_dir, to=docs_dir):
+        if site_rel_path := _relative_path(site_dir, to=docs_dir):
+            exclude_docs: pathspec.gitignore.GitIgnoreSpec | None = config.get('exclude_docs')
+            if exclude_docs and exclude_docs.match_file(site_rel_path):
+                return  # Good, the appropriate config is present.
             raise ValidationError(
-                f"The 'site_dir' should not be within the 'docs_dir' as this "
-                f"leads to the build directory being copied into itself and "
-                f"duplicate nested files in the 'site_dir'. "
-                f"(site_dir: '{site_dir}', docs_dir: '{docs_dir}')"
+                f"The site_dir should not be inside the docs_dir as this "
+                f"leads to the build directory being copied into itself.\n"
+                f"To allow this arrangement, please exclude the directory (and other files as applicable) by adding the following configuration:\n\n"
+                f"exclude_docs: |\n  /{site_rel_path.as_posix()}"
             )
 
 

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -768,17 +768,20 @@ class FilesystemObjectTest(TestCase):
                 )
                 self.assertEqual(conf['dir'], os.path.join(base_path, 'foo'))
 
-    def test_site_dir_is_config_dir_fails(self):
+    def test_docs_dir_is_config_dir_fails(self):
         class Schema:
-            dir = c.DocsDir()
+            docs_dir = c.DocsDir()
 
         with self.expect_error(
-            dir="The 'dir' should not be the parent directory of the config file. "
-            "Use a child directory instead so that the 'dir' is a sibling of the config file."
+            docs_dir="""The 'mkdocs.yml' config file should not be inside the docs_dir.
+To allow this arrangement, please exclude the file (and other files as applicable) by adding the following configuration:
+
+exclude_docs: |
+  /mkdocs.yml"""
         ):
             self.get_config(
                 Schema,
-                {'dir': '.'},
+                {'docs_dir': '.'},
                 config_file_path=os.path.join(os.path.abspath('.'), 'mkdocs.yml'),
             )
 

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -863,7 +863,7 @@ class SiteDirTest(TestCase):
         site_dir = c.SiteDir()
         docs_dir = c.Dir()
 
-    def test_doc_dir_in_site_dir(self):
+    def test_doc_dir_in_site_dir_fails(self):
         j = os.path.join
         # The parent dir is not the same on every system, so use the actual dir name
         parent_dir = mkdocs.__file__.split(os.sep)[-3]
@@ -881,24 +881,27 @@ class SiteDirTest(TestCase):
         for test_config in test_configs:
             with self.subTest(test_config):
                 with self.expect_error(
-                    site_dir=re.compile(r"The 'docs_dir' should not be within the 'site_dir'.*")
+                    site_dir="The docs_dir should not be inside the site_dir as this can mean the source files are overwritten by the output or deleted entirely."
                 ):
                     self.get_config(self.Schema, test_config)
 
-    def test_site_dir_in_docs_dir(self):
+    def test_site_dir_in_docs_dir_fails(self):
         j = os.path.join
 
         test_configs = (
             {'docs_dir': 'docs', 'site_dir': j('docs', 'site')},
             {'docs_dir': '.', 'site_dir': 'site'},
             {'docs_dir': '', 'site_dir': 'site'},
-            {'docs_dir': '/', 'site_dir': 'site'},
         )
 
         for test_config in test_configs:
             with self.subTest(test_config):
                 with self.expect_error(
-                    site_dir=re.compile(r"The 'site_dir' should not be within the 'docs_dir'.*")
+                    site_dir="""The site_dir should not be inside the docs_dir as this leads to the build directory being copied into itself.
+To allow this arrangement, please exclude the directory (and other files as applicable) by adding the following configuration:
+
+exclude_docs: |
+  /site"""
                 ):
                     self.get_config(self.Schema, test_config)
 

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -1275,7 +1275,7 @@ class SubConfigTest(TestCase):
 
         config_path = "foo/mkdocs.yaml"
         self.get_config(Schema, {"sub": {"opt": "bar"}}, config_file_path=config_path)
-        self.assertEqual(passed_config_path, config_path)
+        self.assertEqual(passed_config_path, os.path.abspath(config_path))
 
 
 class ConfigItemsTest(TestCase):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1571,7 +1571,7 @@ class SubConfigTest(TestCase):
 
         config_path = "foo/mkdocs.yaml"
         self.get_config(Schema, {"sub": [{"opt": "bar"}]}, config_file_path=config_path)
-        self.assertEqual(passed_config_path, config_path)
+        self.assertEqual(passed_config_path, os.path.abspath(config_path))
 
 
 class NestedSubConfigTest(TestCase):


### PR DESCRIPTION
* Closes #3450 by @athackst 

If the config file is inside docs_dir, you get this message:

```
ERROR   -  Config value 'docs_dir': The 'mkdocs.yml' config file should not be inside the docs_dir.
           To allow this arrangement, please exclude the file (and other files as applicable) by adding the following configuration:

           exclude_docs: |
             /mkdocs.yml
```

If the site_dir is inside docs_dir, you get this message:

```
ERROR   -  Config value 'site_dir': The site_dir should not be inside the docs_dir as this leads to the build directory being copied into itself.
           To allow this arrangement, please exclude the directory (and other files as applicable) by adding the following configuration:

           exclude_docs: |
             /site
```