### PR TITLE
Remove mention of site_url being required option

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,7 +117,7 @@ Now change the configuration file to alter how the documentation is displayed by
 changing the theme. Edit the `mkdocs.yml` file and add a [`theme`][theme] setting:
 
 ```yaml
-: MkLorum
+site_name: MkLorum
 nav:
   - Home: index.md
   - About: about.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,7 +117,7 @@ Now change the configuration file to alter how the documentation is displayed by
 changing the theme. Edit the `mkdocs.yml` file and add a [`theme`][theme] setting:
 
 ```yaml
-site_name: MkLorum
+: MkLorum
 nav:
   - Home: index.md
   - About: about.md
@@ -209,6 +209,5 @@ To get help with MkDocs, please use the [GitHub discussions] or [GitHub issues].
 [GitHub discussions]: https://github.com/mkdocs/mkdocs/discussions
 [GitHub issues]: https://github.com/mkdocs/mkdocs/issues
 [site_name]: user-guide/configuration.md#site_name
-[site_url]: user-guide/configuration.md#site_url
 [theme]: user-guide/configuration.md#theme
 [User Guide]: user-guide/README.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,6 @@ Now try editing the configuration file: `mkdocs.yml`. Change the
 
 ```yaml
 site_name: MkLorum
-site_url: https://example.com/
 ```
 
 Your browser should immediately reload, and you'll see your new site name take
@@ -74,12 +73,8 @@ effect.
 ![The site_name setting](img/site-name.png)
 
 NOTE:
-The [`site_name`][site_name] and [`site_url`][site_url] configuration
-options are the only two required options in your configuration file. When
-you create a new project, the `site_url` option is assigned the placeholder
-value: `https://example.com`. If the final location is known, you can change
-the setting now to point to it. Or you may choose to leave it alone for now.
-Just be sure to edit it before you deploy your site to a production server.
+The [`site_name`][site_name] configuration
+option is the only required option in your configuration file.
 
 ## Adding pages
 
@@ -96,7 +91,6 @@ setting:
 
 ```yaml
 site_name: MkLorum
-site_url: https://example.com/
 nav:
   - Home: index.md
   - About: about.md
@@ -124,7 +118,6 @@ changing the theme. Edit the `mkdocs.yml` file and add a [`theme`][theme] settin
 
 ```yaml
 site_name: MkLorum
-site_url: https://example.com/
 nav:
   - Home: index.md
   - About: about.md


### PR DESCRIPTION
The Getting started page mentions `site_url` being a required option. This can't be true however, since making a new MkDocs project using `mkdocs new` only generates a `mkdocs.yml` file containing the `site_name` option, which works fine when using the serve and build commands, meaning site_url is optional.

This is further confirmed by the fact that the Configuration page mentions that only site_name is required and all other options being optional.

This PR removes the `site_url: https://example.com/` from the code snippets while also updating the NOTE box about this option being required, by removing it altogether.