### PR TITLE
Ensure page titles from rendered Markdown do not contain any markup

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -8,6 +8,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Callable, Iterator, MutableMapping, Sequence
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urljoin, urlsplit, urlunsplit
+from markupsafe import Markup
 
 import markdown
 import markdown.htmlparser  # type: ignore
@@ -559,7 +560,7 @@ class _ExtractTitleTreeprocessor(markdown.treeprocessors.Treeprocessor):
                 # Unescape per Markdown implementation details.
                 for pp in self.postprocessors:
                     title = pp.run(title)
-                self.title = title
+                self.title = Markup(title).striptags()
             break
         return root
 

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -8,13 +8,13 @@ import warnings
 from typing import TYPE_CHECKING, Any, Callable, Iterator, MutableMapping, Sequence
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urljoin, urlsplit, urlunsplit
-from markupsafe import Markup
 
 import markdown
 import markdown.htmlparser  # type: ignore
 import markdown.postprocessors
 import markdown.treeprocessors
 from markdown.util import AMP_SUBSTITUTE
+from markupsafe import Markup
 
 from mkdocs import utils
 from mkdocs.structure import StructureItem

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -366,7 +366,24 @@ class PageTests(unittest.TestCase):
         pg = Page(None, fl, cfg)
         pg.read_source(cfg)
         pg.render(cfg, fl)
-        self.assertEqual(pg.title, '*Hello &mdash; beautiful world')
+        self.assertEqual(pg.title, '*Hello — beautiful world')
+
+    _RAW_CONTENT = dedent(
+        '''
+        # Hello <span>world</span>
+
+        Hi.
+        '''
+    )
+
+    @tempdir(files={'testing_raw_content.md': _RAW_CONTENT})
+    def test_page_title_from_markdown_strip_raw_tags(self, docs_dir):
+        cfg = load_config()
+        fl = File('testing_raw_content.md', docs_dir, docs_dir, use_directory_urls=True)
+        pg = Page(None, fl, cfg)
+        pg.read_source(cfg)
+        pg.render(cfg, fl)
+        self.assertEqual(pg.title, 'Hello world')
 
     _ATTRLIST_CONTENT = dedent(
         '''


### PR DESCRIPTION
While the `_ExtractTitleTreeprocessor` already extracts text from the etree, postprocessors may add more markup. Therefore, markupsafe's `striptags`  is used to ensure all markup is removed. Conveniently, `markupsafe` is already a dependency and available. Fixes #3357.