### PR TITLE
Sanitizing search entry titles

### DIFF
--- a/docs/user-guide/writing-your-docs.md
+++ b/docs/user-guide/writing-your-docs.md
@@ -538,3 +538,16 @@ Note that fenced code blocks can not be indented. Therefore, they cannot be
 nested inside list items, blockquotes, etc.
 
 [fenced code blocks]: https://python-markdown.github.io/extensions/fenced_code_blocks/
+
+### Search Keywords
+
+The [search plugin][] supports defining keywords for individual sections of a page. When search terms match the defined keywords, it ensures that the relevant section will be included in the search results. To use the feature, [enable][markdown_extensions] the [attr_list][] extension to Markdown.
+
+To define keywords for a section, assign a string of space separated words to the `data-search-keywords` attribute of any heading. Specifically, define an attribute list at the end of a heading which contains the attribute.
+
+```markdown
+# Section Title {data-search-keywords='space separated list of words'}
+```
+
+[search plugin]: configuration.md#search
+[attr_list]: https://python-markdown.github.io/extensions/attr_list/

--- a/mkdocs/contrib/search/prebuild-index.js
+++ b/mkdocs/contrib/search/prebuild-index.js
@@ -43,7 +43,7 @@ stdin.on('end', function () {
     } else if (lang.length > 1) {
       this.use(lunr.multiLanguage.apply(null, lang));
     }
-    this.field('title');
+    this.field('title', {'boost': 10});
     this.field('text');
     this.ref('location');
 

--- a/mkdocs/contrib/search/prebuild-index.js
+++ b/mkdocs/contrib/search/prebuild-index.js
@@ -43,8 +43,9 @@ stdin.on('end', function () {
     } else if (lang.length > 1) {
       this.use(lunr.multiLanguage.apply(null, lang));
     }
-    this.field('title', {'boost': 10});
+    this.field('title');
     this.field('text');
+    this.field('keywords', {'boost': 10});
     this.ref('location');
 
     data.docs.forEach(function (doc) {

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -31,12 +31,12 @@ class SearchIndex:
         self._entries: list[dict] = []
         self.config = config
 
-    def _add_entry(self, title: str | None, text: str, loc: str) -> None:
+    def _add_entry(self, title: str | None, text: str, keywords: str | None, loc: str) -> None:
         """A simple wrapper to add an entry, dropping bad characters."""
         text = text.replace('\u00a0', ' ')
         text = re.sub(r'[ \t\n\r\f\v]+', ' ', text.strip())
 
-        self._entries.append({'title': title, 'text': text, 'location': loc})
+        self._entries.append({'title': title, 'text': text, 'keywords': keywords, 'location': loc})
 
     def add_entry_from_context(self, page: Page) -> None:
         """
@@ -58,7 +58,7 @@ class SearchIndex:
 
         # Create an entry for the full page.
         text = parser.stripped_html.rstrip('\n') if self.config['indexing'] == 'full' else ''
-        self._add_entry(title=page.title, text=text, loc=url)
+        self._add_entry(title=page.title, text=text, keywords='', loc=url)
 
         if self.config['indexing'] in ['full', 'sections']:
             for section in parser.data:
@@ -72,7 +72,7 @@ class SearchIndex:
         create an entry in the index.
         """
         text = ' '.join(section.text) if self.config['indexing'] == 'full' else ''
-        self._add_entry(title=section.title, text=text, loc=f'{abs_url}#{section.id}')
+        self._add_entry(title=section.title, text=text, keywords=section.keywords, loc=f'{abs_url}#{section.id}')
 
     def generate_search_index(self) -> str:
         """Python to json conversion."""
@@ -104,7 +104,7 @@ class SearchIndex:
             if haslunrpy:
                 lunr_idx = lunr(
                     ref='location',
-                    fields=(dict(field_name='title', boost=10), 'text'),
+                    fields=('title', 'text', dict(field_name='keywords', boost=10)),
                     documents=self._entries,
                     languages=self.config['lang'],
                 )
@@ -132,16 +132,26 @@ class ContentSection:
         text: list[str] | None = None,
         id_: str | None = None,
         title: str | None = None,
+        keywords: str | None = None
     ) -> None:
         self.text = text or []
         self.id = id_
         self.title = title or ''
+        self.keywords = keywords or ''
 
     def __eq__(self, other):
-        return self.text == other.text and self.id == other.id and self.title == other.title
+        return (
+            self.text == other.text and
+            self.id == other.id and
+            self.title == other.title and
+            self.keywords == other.keywords
+        )
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(text={self.text}, id='{self.id}', title='{self.title}')"
+        return (
+            f"{self.__class__.__name__}("
+            f"text={self.text}, id='{self.id}', title='{self.title}', keywords='{self.keywords}')"
+        )
 
 
 _HEADER_TAGS = tuple(f"h{x}" for x in range(1, 7))
@@ -182,8 +192,7 @@ class ContentParser(HTMLParser):
         self.section.id = attrs.get('id', None)
         if 'data-search-keywords' in attrs:
             # Override title with user defined search keywords
-            self.section.title = attrs['data-search-keywords']
-            self.is_header_tag = False
+            self.section.keywords = attrs['data-search-keywords']
         self.data.append(self.section)
 
     def handle_endtag(self, tag: str) -> None:

--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -140,6 +140,9 @@ class ContentSection:
     def __eq__(self, other):
         return self.text == other.text and self.id == other.id and self.title == other.title
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(text={self.text}, id='{self.id}', title='{self.title}')"
+
 
 _HEADER_TAGS = tuple(f"h{x}" for x in range(1, 7))
 

--- a/mkdocs/contrib/search/templates/search/main.js
+++ b/mkdocs/contrib/search/templates/search/main.js
@@ -28,7 +28,7 @@ function escapeHtml (value) {
     .replace(/>/g, '&gt;');
 }
 
-function formatResult (location, title, summary) {
+function formatResult (location, title, summary, keywords) {
   return '<article><h3><a href="' + joinUrl(base_url, location) + '">'+ escapeHtml(title) + '</a></h3><p>' + escapeHtml(summary) +'</p></article>';
 }
 
@@ -40,7 +40,7 @@ function displayResults (results) {
   if (results.length > 0){
     for (var i=0; i < results.length; i++){
       var result = results[i];
-      var html = formatResult(result.location, result.title, result.summary);
+      var html = formatResult(result.location, result.title, result.summary, result.keywords);
       search_results.insertAdjacentHTML('beforeend', html);
     }
   } else {

--- a/mkdocs/contrib/search/templates/search/worker.js
+++ b/mkdocs/contrib/search/templates/search/worker.js
@@ -77,6 +77,7 @@ function onScriptsLoaded () {
       }
       this.field('title');
       this.field('text');
+      this.field('keywords', {'boost': 10});
       this.ref('location');
 
       for (var i=0; i < data.docs.length; i++) {

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -282,7 +282,7 @@ class SearchIndexTests(unittest.TestCase):
         parser.close()
 
         self.assertEqual(
-            parser.data, [search_index.ContentSection(text=["TEST"], id_="title", title="Title")]
+            parser.data, [search_index.ContentSection(text=["TEST"], id_="title", title="Title", keywords='')]
         )
 
     def test_content_parser_header_has_child(self):
@@ -292,7 +292,9 @@ class SearchIndexTests(unittest.TestCase):
         parser.close()
 
         self.assertEqual(
-            parser.data, [search_index.ContentSection(text=["TEST"], id_="title", title="Title title TITLE")]
+            parser.data, [search_index.ContentSection(
+                text=["TEST"], id_="title", title="Title title TITLE", keywords=''
+            )]
         )
 
     def test_content_parser_no_id(self):
@@ -302,7 +304,7 @@ class SearchIndexTests(unittest.TestCase):
         parser.close()
 
         self.assertEqual(
-            parser.data, [search_index.ContentSection(text=["TEST"], id_=None, title="Title")]
+            parser.data, [search_index.ContentSection(text=["TEST"], id_=None, title="Title", keywords='')]
         )
 
     def test_content_parser_content_before_header(self):
@@ -312,7 +314,7 @@ class SearchIndexTests(unittest.TestCase):
         parser.close()
 
         self.assertEqual(
-            parser.data, [search_index.ContentSection(text=["TEST"], id_=None, title="Title")]
+            parser.data, [search_index.ContentSection(text=["TEST"], id_=None, title="Title", keywords='')]
         )
 
     def test_content_parser_no_sections(self):
@@ -329,7 +331,9 @@ class SearchIndexTests(unittest.TestCase):
         parser.close()
 
         self.assertEqual(
-            parser.data, [search_index.ContentSection(text=["Title", "TEST"], id_="title", title="search keywords")]
+            parser.data, [search_index.ContentSection(
+                text=["TEST"], id_="title", title="Title", keywords="search keywords"
+            )]
         )
 
     def test_create_search_index(self):


### PR DESCRIPTION
MkDocs' search plugin indexes page sections by iterating over the sections of a page and adding an entry to the index for each section. It currently uses the title of a section's table of contents (TOC) entry as the title of the search index entry. As a reminder, the TOC of the page is provided by Markdown's `toc` extension which sanitizes a heading's content into plain text. In the typical case, it still works fine.

However, the Markdown `toc` extension later added support for the `data-toc-label` attribute, which a user could assign to a heading (h1-6) element (presumably via the `attr_list` extension). The content of that attribute would then be used as the label/title of the TOC item. The problem is that this allows users to introduce unsanitized (not plain) text into the title of a search index entry, which confuses search in weird ways.

It is also possible for a third-party plugin to alter the TOC of a page by inserting markup into a TOC entry. For example, the [`show_symbol_type_toc`](https://mkdocstrings.github.io/python/usage/configuration/headings/?h=show_symbol_type_toc#show_symbol_type_toc) option of mkdocsstrings-python specifically inserts spans into TOC titles. Again, this confuses search. Not only do search terms not return results as expected, but when the results are returned (due to a match in the body text), the title of the search result contains escaped HTML and is potentially confusing to the user (see Python-Markdown/markdown#1432).

Note that the same (or similar) issues exist with the Page title, but that is the subject of #3357 and will presumably be addressed with a fix to that larger issue. Therefore, I am not address that here. Although, it is possible we could run the Page title through `striptags` as extra insurance. So I could add that here if desired.

Given the above issues, a change needs to be made to ensure search is passed a sanitized version of the title of each section.  There are at least 2 ways this could be done:

1. Pass the TOC title through `striptags` and pass the plain text result to the search index.
2. Retrieve the actual heading (h1-6) element, and pass the plain text result to the search index.

While option 1 would be more consistent with current behavior, we could be indexing text that is different than what appears in the body of the page, which means section headings which should clearly be included in search results could be omitted (or visa-versa). Therefore, the search index should be passed a sanitized version of the actual heading, not the TOC title.

As it turns out, the existing code already strips tags from the headings of the document when building the search index, but then ignores those sanitized headings and uses the TOC title instead by using a section's `id` to associate the TOC title with the section. However, if we use the sanitized heading text, then we don't need to reference the TOC at all and any reference to it can be removed from the code.

Given the above reasoning, I have implemented option 2 in this PR.

Consider the following examples:

```markdown
# Some text {data-toc-label='different text'}
```

Both the previous behavior and option 1 above would be to index `different text`, and option 2 would index `Some text`. Clearly indexing `Some text` makes more sense in this instance.

```markdown
# Some text {data-toc-label='<span class="foo">Some text</span>'}
```

The previous behavior would be to index `<span class="foo">Some text</span>` and both options 1 and 2 above would index `Some text`.

```markdown
# `foo(bar=0)` {data-toc-label='foo'}
```

Both the current behavior and option 1 would index `foo`. The string `bar` would not be indexed at all. With option 2, the string `foo(bar=0)` would be indexed. But that isn't tokenized into separate words by the search index by default (in my testing the search term `foo(bar=0` was needed to get the entry returned as a search result). Of course, the [search.separator](https://www.mkdocs.org/user-guide/configuration/#separator) config option allows one to define their own set of word separator characters. That could potentially result in better search results, and maintains the unmodified title in the search results displayed to the user. That said, using the word separator alone may not be as effective as one might think. According to its developer, lunr.js is not particularly well suited to tokenizing code (see olivernn/lunr.js#424 for at least one discussion about that).

Therefore, I have added an additional new feature to my proposal:

Add an additional `keywords` field to the search index and add support for a `data-search-keywords` attribute which can be defined on a heading element. When the attribute is defined on a heading, the contents of that attribute are assigned to the `keywords` field in the entry in the search index. A heading without the attribute would have no keywords assigned to that section and would continue to behave as-is. Consider the following example:

```markdown
# `foo(bar=0)` {data-toc-label='foo' data-search-keywords='foo bar'}
```

With the proposed change, the string `foo bar` would be indexed as keywords for the above example, which would result in reasonable search results. Initially I used the keywords as the title for the search index entry, but that caused the keywords to be used as the title in returned search results, which would be confusing to a user. Therefore, adding a new keywords field seemed like the best way to address this.

I also discovered a minor bug where if a heading contained inline markup, then the entire text of the heading was not retained (which presumably went unnoticed for years because it wasn't actually being used). Specifically, each child element's text content would override/replace its previous sibling's and/or parent's text content. That bug has been fixed and a test added. Each child element's content is now appended to the the existing content of the `title`.

Finally, I added `boost=10` to the `keywords` field of the search index so that results with matching keywords would get sorted higher in the results. Although, in my limited testing, the boost doesn't seem to make much difference. I have a vague recollection that similar observations were made in the past about the ineffectiveness of boost. :shrug:
