### PR TITLE
Set up automatic fixes for PRs using pre-commit-ci-lite

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,23 @@
+name: Auto-fix
+on:
+  push:
+  pull_request:
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade hatch
+      - name: Fix code style
+        run: hatch run style:fix --fix-only
+      - name: Check if any edits are necessary
+        run: git diff --color --exit-code
+      - name: Apply automatic fixes using pre-commit-ci-lite
+        if: failure() && github.event_name == 'pull_request'
+        uses: pre-commit-ci/lite-action@v1.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,7 @@ jobs:
           node-version: 20
       - name: Check with ruff
         if: always()
-        run: hatch run style:fix
-      - name: Check with black + isort
-        if: always()
-        run: hatch run style:format && git diff --color --exit-code
+        run: hatch run style:lint
       - name: Check with mypy
         if: always()
         run: hatch run types:check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,10 +180,10 @@ check = [
     "lint",
 ]
 lint = [
-    "ruff check mkdocs docs"
+    "ruff check mkdocs docs {args}"
 ]
 fix = [
-    "ruff check --fix mkdocs docs",
+    "lint --fix",
     "format",
 ]
 format = [


### PR DESCRIPTION
If a pull request has applicable Ruff fixes or needs re-formatting with Black/isort, these will be automatically pushed to the pull request via https://pre-commit.ci/lite.html

Versions of these formatter tools are already pinned since commit c9cf11b94172b9cf851e29c535def8667891b65c, so unexpected unrelated changes from just updating these tools will not happen.

Note that the actual pre-commit tool is not used, and there are no plans for that.

---

See how it looks: https://github.com/oprypin/mkdocs/pull/3