### PR TITLE
stdin is not guaranteed to be defined

### DIFF
--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -362,7 +362,7 @@ def load_config(
         from mkdocs.config.defaults import MkDocsConfig
 
         if config_file_path is None:
-            if fd is not sys.stdin.buffer:
+            if sys.stdin and fd is not sys.stdin.buffer:
                 config_file_path = getattr(fd, 'name', None)
         cfg = MkDocsConfig(config_file_path=config_file_path)
         # load the config file


### PR DESCRIPTION
In certain constrained environments, stdin will not be defined:
```shell
bash -c $'0>&- python -c \'import sys; print(f"stdin: {sys.stdin}")\''
stdin: None
```
An example of this could be a CI or Deployments environment.