### PR TITLE
Add Polish translation for built-in themes

### DIFF
--- a/mkdocs/themes/mkdocs/locales/pl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/pl/LC_MESSAGES/messages.po
@@ -1,0 +1,102 @@
+# Polish translations for MkDocs.
+# Copyright (C) 2022 MkDocs
+# This file is distributed under the same license as the MkDocs project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MkDocs 1.3.1\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"POT-Creation-Date: 2022-08-15 17:05+0200\n"
+"PO-Revision-Date: 2024-03-21 17:46+0100\n"
+"Last-Translator: Szymon Rakowski <szymon.rakowski@ac.com.pl>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: mkdocs/themes/mkdocs/404.html:8
+msgid "Page not found"
+msgstr "Strony nie znaleziono"
+
+#: mkdocs/themes/mkdocs/base.html:116
+#: mkdocs/themes/mkdocs/keyboard-modal.html:31
+#: mkdocs/themes/mkdocs/search-modal.html:5
+msgid "Search"
+msgstr "Szukaj"
+
+#: mkdocs/themes/mkdocs/base.html:126
+msgid "Previous"
+msgstr "Wstecz"
+
+#: mkdocs/themes/mkdocs/base.html:131
+msgid "Next"
+msgstr "Dalej"
+
+#: mkdocs/themes/mkdocs/base.html:142 mkdocs/themes/mkdocs/base.html:144
+#: mkdocs/themes/mkdocs/base.html:146 mkdocs/themes/mkdocs/base.html:148
+#, python-format
+msgid "Edit on %(repo_name)s"
+msgstr "Edytuj w %(repo_name)s"
+
+#: mkdocs/themes/mkdocs/base.html:150
+msgid "Edit"
+msgstr "Edytuj"
+
+#: mkdocs/themes/mkdocs/base.html:190
+#, python-format
+msgid "Documentation built with %(mkdocs_link)s."
+msgstr "Dokumentacja zbudowana przy użyciu %(mkdocs_link)s."
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:5
+msgid "Keyboard Shortcuts"
+msgstr "Skróty klawiszowe"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:6
+#: mkdocs/themes/mkdocs/search-modal.html:6
+msgid "Close"
+msgstr "Zamknij"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:12
+msgid "Keys"
+msgstr "Klawisze"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:13
+msgid "Action"
+msgstr "Akcja"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:19
+msgid "Open this help"
+msgstr "Otwórz tę pomoc"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:23
+msgid "Next page"
+msgstr "Następna strona"
+
+#: mkdocs/themes/mkdocs/keyboard-modal.html:27
+msgid "Previous page"
+msgstr "Poprzednia strona"
+
+#: mkdocs/themes/mkdocs/search-modal.html:9
+msgid "From here you can search these documents. Enter your search terms below."
+msgstr "W tym miejscu możesz przeszukiwać dokumenty. Wpisz swoje kryteria wyszukiwania poniżej."
+
+#: mkdocs/themes/mkdocs/search-modal.html:12
+msgid "Search..."
+msgstr "Szukaj..."
+
+#: mkdocs/themes/mkdocs/search-modal.html:12
+msgid "Type search term here"
+msgstr "Wpisz tutaj kryteria wyszukiwania"
+
+#: mkdocs/themes/mkdocs/search-modal.html:15
+msgid "No results found"
+msgstr "Nie znaleziono żadnych wyników"
+
+#: mkdocs/themes/mkdocs/toc.html:3
+msgid "Table of Contents"
+msgstr "Spis treści"
+

--- a/mkdocs/themes/mkdocs/locales/pl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/pl/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: mkdocs/themes/mkdocs/404.html:8
 msgid "Page not found"
-msgstr "Strony nie znaleziono"
+msgstr "Nie znaleziono strony"
 
 #: mkdocs/themes/mkdocs/base.html:116
 #: mkdocs/themes/mkdocs/keyboard-modal.html:31
@@ -49,7 +49,7 @@ msgstr "Edytuj"
 #: mkdocs/themes/mkdocs/base.html:190
 #, python-format
 msgid "Documentation built with %(mkdocs_link)s."
-msgstr "Dokumentacja zbudowana przy użyciu %(mkdocs_link)s."
+msgstr "Dokumentacja zbudowana przy użyciu pakietu %(mkdocs_link)s."
 
 #: mkdocs/themes/mkdocs/keyboard-modal.html:5
 msgid "Keyboard Shortcuts"
@@ -82,7 +82,7 @@ msgstr "Poprzednia strona"
 
 #: mkdocs/themes/mkdocs/search-modal.html:9
 msgid "From here you can search these documents. Enter your search terms below."
-msgstr "W tym miejscu możesz przeszukiwać dokumenty. Wpisz swoje kryteria wyszukiwania poniżej."
+msgstr "W tym miejscu możesz przeszukiwać dokumenty. Wpisz swoją frazę do wyszukania poniżej."
 
 #: mkdocs/themes/mkdocs/search-modal.html:12
 msgid "Search..."
@@ -90,11 +90,11 @@ msgstr "Szukaj..."
 
 #: mkdocs/themes/mkdocs/search-modal.html:12
 msgid "Type search term here"
-msgstr "Wpisz tutaj kryteria wyszukiwania"
+msgstr "Wpisz tutaj frazę do wyszukiwania"
 
 #: mkdocs/themes/mkdocs/search-modal.html:15
 msgid "No results found"
-msgstr "Nie znaleziono żadnych wyników"
+msgstr "Nie znaleziono wyników"
 
 #: mkdocs/themes/mkdocs/toc.html:3
 msgid "Table of Contents"

--- a/mkdocs/themes/readthedocs/footer.html
+++ b/mkdocs/themes/readthedocs/footer.html
@@ -22,5 +22,5 @@
     {%- endif %}
   </div>
 
-  {% trans mkdocs_link='<a href="https://www.mkdocs.org/">MkDocs</a>', sphinx_link='<a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a>', rtd_link='<a href="https://readthedocs.org">Read the Docs</a>' %}Built with %(mkdocs_link)s using a %(sphinx_link)s provided by %(rtd_link)s.{% endtrans %}
+  {% trans mkdocs_link='<a href="https://www.mkdocs.org/">MkDocs</a>', sphinx_link='<a href="https://github.com/readthedocs/sphinx_rtd_theme">{}</a>'.format(gettext('theme')), rtd_link='<a href="https://readthedocs.org">Read the Docs</a>' %}Built with %(mkdocs_link)s using a %(sphinx_link)s provided by %(rtd_link)s.{% endtrans %}
 </footer>

--- a/mkdocs/themes/readthedocs/locales/pl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/pl/LC_MESSAGES/messages.po
@@ -1,0 +1,109 @@
+# Polish translations for MkDocs.
+# Copyright (C) 2022 MkDocs
+# This file is distributed under the same license as the MkDocs project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MkDocs 1.3.1\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"POT-Creation-Date: 2022-08-15 17:05+0200\n"
+"PO-Revision-Date: 2024-03-21 17:46+0100\n"
+"Last-Translator: Szymon Rakowski <szymon.rakowski@ac.com.pl>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: mkdocs/themes/readthedocs/404.html:7
+msgid "Page not found"
+msgstr "Strony nie znaleziono"
+
+#: mkdocs/themes/readthedocs/base.html:97
+msgid "Logo"
+msgstr "Logo"
+
+#: mkdocs/themes/readthedocs/base.html:111
+msgid "Navigation menu"
+msgstr "Menu nawigacji"
+
+#: mkdocs/themes/readthedocs/base.html:140
+msgid "Mobile navigation menu"
+msgstr "Mobilne menu nawigacji"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:3
+msgid "Docs"
+msgstr "Dokumentacja"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:18
+#: mkdocs/themes/readthedocs/breadcrumbs.html:20
+#: mkdocs/themes/readthedocs/breadcrumbs.html:22
+#: mkdocs/themes/readthedocs/breadcrumbs.html:24
+#, python-format
+msgid "Edit on %(repo_name)s"
+msgstr "Edytuj w %(repo_name)s"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:26
+msgid "Edit"
+msgstr "Edytuj"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:34
+msgid "Breadcrumb Navigation"
+msgstr "Nawigacja typu Breadcrumb"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:36
+#: mkdocs/themes/readthedocs/footer.html:7
+#: mkdocs/themes/readthedocs/versions.html:17
+msgid "Previous"
+msgstr "Wstecz"
+
+#: mkdocs/themes/readthedocs/breadcrumbs.html:39
+#: mkdocs/themes/readthedocs/footer.html:10
+#: mkdocs/themes/readthedocs/versions.html:20
+msgid "Next"
+msgstr "Dalej"
+
+#: mkdocs/themes/readthedocs/footer.html:5
+msgid "Footer Navigation"
+msgstr "Nawigacja w stopce"
+
+#: mkdocs/themes/readthedocs/footer.html:25
+#, python-format
+msgid ""
+"Built with %(mkdocs_link)s using a %(sphinx_link)s provided by "
+"%(rtd_link)s."
+msgstr "Zbudowano przy użyciu %(mkdocs_link)s z pomocą %(sphinx_link)s dostarczonego przez %(rtd_link)s."
+
+#: mkdocs/themes/readthedocs/search.html:5
+msgid "Search Results"
+msgstr "Wyniki wyszukiwania"
+
+#: mkdocs/themes/readthedocs/search.html:9
+msgid "Search the Docs"
+msgstr "Przeszukaj dokumentację"
+
+#: mkdocs/themes/readthedocs/search.html:9
+#: mkdocs/themes/readthedocs/searchbox.html:3
+msgid "Type search term here"
+msgstr "Wpisz tutaj kryteria wyszukiwania"
+
+#: mkdocs/themes/readthedocs/search.html:12
+msgid "No results found"
+msgstr "Nie znaleziono żadnych wyników"
+
+#: mkdocs/themes/readthedocs/search.html:13
+msgid "Searching..."
+msgstr "Wyszukiwanie..."
+
+#: mkdocs/themes/readthedocs/searchbox.html:3
+msgid "Search docs"
+msgstr "Przeszukaj dokumentację"
+
+#: mkdocs/themes/readthedocs/versions.html:1
+msgid "Versions"
+msgstr "Wersje"
+

--- a/mkdocs/themes/readthedocs/locales/pl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/pl/LC_MESSAGES/messages.po
@@ -1,13 +1,13 @@
 # Polish translations for MkDocs.
-# Copyright (C) 2022 MkDocs
+# Copyright (C) 2024 MkDocs
 # This file is distributed under the same license as the MkDocs project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
 "Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
-"POT-Creation-Date: 2022-08-15 17:05+0200\n"
+"POT-Creation-Date: 2024-03-30 23:45+0100\n"
 "PO-Revision-Date: 2024-03-21 17:46+0100\n"
 "Last-Translator: Szymon Rakowski <szymon.rakowski@ac.com.pl>\n"
 "Language: pl\n"
@@ -21,17 +21,17 @@ msgstr ""
 
 #: mkdocs/themes/readthedocs/404.html:7
 msgid "Page not found"
-msgstr "Strony nie znaleziono"
+msgstr "Nie znaleziono strony"
 
-#: mkdocs/themes/readthedocs/base.html:97
+#: mkdocs/themes/readthedocs/base.html:96
 msgid "Logo"
 msgstr "Logo"
 
-#: mkdocs/themes/readthedocs/base.html:111
+#: mkdocs/themes/readthedocs/base.html:110
 msgid "Navigation menu"
 msgstr "Menu nawigacji"
 
-#: mkdocs/themes/readthedocs/base.html:140
+#: mkdocs/themes/readthedocs/base.html:147
 msgid "Mobile navigation menu"
 msgstr "Mobilne menu nawigacji"
 
@@ -57,13 +57,13 @@ msgstr "Nawigacja typu Breadcrumb"
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:36
 #: mkdocs/themes/readthedocs/footer.html:7
-#: mkdocs/themes/readthedocs/versions.html:17
+#: mkdocs/themes/readthedocs/versions.html:21
 msgid "Previous"
 msgstr "Wstecz"
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:39
 #: mkdocs/themes/readthedocs/footer.html:10
-#: mkdocs/themes/readthedocs/versions.html:20
+#: mkdocs/themes/readthedocs/versions.html:24
 msgid "Next"
 msgstr "Dalej"
 
@@ -76,7 +76,13 @@ msgstr "Nawigacja w stopce"
 msgid ""
 "Built with %(mkdocs_link)s using a %(sphinx_link)s provided by "
 "%(rtd_link)s."
-msgstr "Zbudowano przy użyciu %(mkdocs_link)s z pomocą %(sphinx_link)s dostarczonego przez %(rtd_link)s."
+msgstr ""
+"Zbudowano przy użyciu pakietu %(mkdocs_link)s oraz %(sphinx_link)s "
+"dostarczonego przez %(rtd_link)s."
+
+#: mkdocs/themes/readthedocs/footer.html:25
+msgid "theme"
+msgstr "motywu"
 
 #: mkdocs/themes/readthedocs/search.html:5
 msgid "Search Results"
@@ -89,11 +95,11 @@ msgstr "Przeszukaj dokumentację"
 #: mkdocs/themes/readthedocs/search.html:9
 #: mkdocs/themes/readthedocs/searchbox.html:3
 msgid "Type search term here"
-msgstr "Wpisz tutaj kryteria wyszukiwania"
+msgstr "Wpisz tutaj frazę do wyszukania"
 
 #: mkdocs/themes/readthedocs/search.html:12
 msgid "No results found"
-msgstr "Nie znaleziono żadnych wyników"
+msgstr "Nie znaleziono wyników"
 
 #: mkdocs/themes/readthedocs/search.html:13
 msgid "Searching..."

--- a/mkdocs/themes/readthedocs/messages.pot
+++ b/mkdocs/themes/readthedocs/messages.pot
@@ -1,35 +1,35 @@
 # Translations template for MkDocs.
-# Copyright (C) 2022 MkDocs
+# Copyright (C) 2024 MkDocs
 # This file is distributed under the same license as the MkDocs project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
-"POT-Creation-Date: 2022-08-15 17:05+0200\n"
+"Project-Id-Version: MkDocs 1.5.3\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"POT-Creation-Date: 2024-03-30 23:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.10.3\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: mkdocs/themes/readthedocs/404.html:7
 msgid "Page not found"
 msgstr ""
 
-#: mkdocs/themes/readthedocs/base.html:97
+#: mkdocs/themes/readthedocs/base.html:96
 msgid "Logo"
 msgstr ""
 
-#: mkdocs/themes/readthedocs/base.html:111
+#: mkdocs/themes/readthedocs/base.html:110
 msgid "Navigation menu"
 msgstr ""
 
-#: mkdocs/themes/readthedocs/base.html:140
+#: mkdocs/themes/readthedocs/base.html:147
 msgid "Mobile navigation menu"
 msgstr ""
 
@@ -55,13 +55,13 @@ msgstr ""
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:36
 #: mkdocs/themes/readthedocs/footer.html:7
-#: mkdocs/themes/readthedocs/versions.html:17
+#: mkdocs/themes/readthedocs/versions.html:21
 msgid "Previous"
 msgstr ""
 
 #: mkdocs/themes/readthedocs/breadcrumbs.html:39
 #: mkdocs/themes/readthedocs/footer.html:10
-#: mkdocs/themes/readthedocs/versions.html:20
+#: mkdocs/themes/readthedocs/versions.html:24
 msgid "Next"
 msgstr ""
 
@@ -72,6 +72,10 @@ msgstr ""
 #: mkdocs/themes/readthedocs/footer.html:25
 #, python-format
 msgid "Built with %(mkdocs_link)s using a %(sphinx_link)s provided by %(rtd_link)s."
+msgstr ""
+
+#: mkdocs/themes/readthedocs/footer.html:25
+msgid "theme"
 msgstr ""
 
 #: mkdocs/themes/readthedocs/search.html:5
@@ -102,3 +106,4 @@ msgstr ""
 #: mkdocs/themes/readthedocs/versions.html:1
 msgid "Versions"
 msgstr ""
+


### PR DESCRIPTION
Hello, I added `.po` files with Polish language strings for the two built-in themes.
Unfortunately, lunr-languages doesn't support Polish but I think this is out of scope for this pull request.

I also noticed that in the "ReadTheDocs" theme, in the footer the word "theme" is not added as a translatable string:

> Built with [MkDocs](https://www.mkdocs.org/) using a [theme](https://github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](https://readthedocs.org/).

Therefore it gets translated to:

> Zbudowano przy użyciu [MkDocs](https://www.mkdocs.org/) z pomocą [theme](https://github.com/readthedocs/sphinx_rtd_theme) dostarczonego przez [Read the Docs](https://readthedocs.org/).

 Would it be OK to modify `footer.html` within this PR so that the word "theme" gets added to `messages.pot`?