### PR TITLE
Drop `changefreq` from `sitemap.xml`.

### DIFF
--- a/mkdocs/templates/sitemap.xml
+++ b/mkdocs/templates/sitemap.xml
@@ -5,7 +5,6 @@
     <url>
          <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
          {% if file.page.update_date %}<lastmod>{{file.page.update_date}}</lastmod>{% endif %}
-         <changefreq>daily</changefreq>
     </url>
     {%- endif -%}
 {% endfor %}


### PR DESCRIPTION
Closes #3516.

In brief...

> I've noticed that in the sitemap.xml template file [...], the tag is hard-coded to "daily"

> I'd vouch for removing changefreq altogether. It's optional anyway, and I doubt that any of the big relevant search engines will use it when deciding when to re-index your site

Seems like a reasonable tweak to me.

Should this pull request also update the [release notes](https://github.com/mkdocs/mkdocs/blob/master/docs/about/release-notes.md) or are we waiting until we push a release before we collate those?