### PR TITLE
Add back funding/sponsor button pointing to OpenCollective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: mkdocs


### PR DESCRIPTION
Since we already have an account on OpenCollective, we might as well use it.

Closes #892