### PR TITLE
Fix for showing repository icon even when a file has no edit_uri

### DIFF
--- a/mkdocs/themes/mkdocs/base.html
+++ b/mkdocs/themes/mkdocs/base.html
@@ -156,11 +156,11 @@
                             <li class="nav-item">
                                 <a href="{{ config.repo_url }}" class="nav-link">
                                     {%- if config.repo_name == 'GitHub' -%}
-                                        <i class="fa fa-github"></i> {{ config.repo_name }}
+                                        <i class="fa-brands fa-github"></i> {{ config.repo_name }}
                                     {%- elif config.repo_name == 'Bitbucket' -%}
-                                        <i class="fa fa-bitbucket"></i> {{ config.repo_name }}
+                                        <i class="fa-brands fa-bitbucket"></i> {{ config.repo_name }}
                                     {%- elif config.repo_name == 'GitLab' -%}
-                                        <i class="fa fa-gitlab"></i> {{ config.repo_name }}
+                                        <i class="fa-brands fa-gitlab"></i> {{ config.repo_name }}
                                     {%- else -%}
                                     {{ config.repo_name }}
                                     {%- endif -%}


### PR DESCRIPTION
This needed to be updated when upgrading the mkdocs theme to newer Bootstrap but got missed.

Only one branch was updated https://github.com/mkdocs/mkdocs/commit/694a6028f649de6881ddc13496077856dcb3abc6#diff-d1c13966984c4c14f25c9d8ee66694e694dd9c4756a6d706fbc20135ff4ba3dcR142

Right now it shows up as a missing glyph.
