### PR TITLE
Pin codespell dependancie

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ format = [
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-    "codespell",
+    "codespell==2.2.6",
 ]
 [tool.hatch.envs.lint.scripts]
 spelling = 'codespell mkdocs docs *.* -S LC_MESSAGES -S "*.min.js" -S "lunr*.js" -S fontawesome-webfont.svg -S tinyseg.js -S "*.map"'


### PR DESCRIPTION
Fixes including #3729 and #3730 are currently blocked on CI failures.
Failure is due to https://github.com/codespell-project/codespell/issues/3430
Attempt to resolve this by pining the codespell [to the previous release](https://pypi.org/project/codespell/#history).

Really I'd like us to switch to a simpler CI workflow, tho let's deal with the immediate issue first.