### PR TITLE
A Possible Version for Chinese Search Support

### DIFF
--- a/mkdocs/contrib/search/__init__.py
+++ b/mkdocs/contrib/search/__init__.py
@@ -37,7 +37,7 @@ class LangOption(c.OptionallyRequired[List[str]]):
         if not isinstance(value, list):
             raise c.ValidationError('Expected a list of language codes.')
         for lang in value[:]:
-            if lang != 'en':
+            if lang != 'en' and lang != 'cn':
                 lang_detected = self.get_lunr_supported_lang(lang)
                 if not lang_detected:
                     log.info(f"Option search.lang '{lang}' is not supported, falling back to 'en'")

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -405,6 +405,43 @@ class SearchIndexTests(unittest.TestCase):
             self.assertEqual(strip_whitespace(index._entries[3]['text']), "Content3")
             self.assertEqual(index._entries[3]['location'], f"{loc}#heading-3")
 
+    def test_create_chinese_search_index(self):
+        base_cfg = load_config()
+        pages = [
+            Page(
+                '简单的首页',
+                File('index.md', base_cfg.docs_dir, base_cfg.site_dir, base_cfg.use_directory_urls),
+                base_cfg,
+            ),
+            Page(
+                '其他页面',
+                File('etc.md', base_cfg.docs_dir, base_cfg.site_dir, base_cfg.use_directory_urls),
+                base_cfg,
+            ),
+        ]
+
+        full_content = ''.join(f"标题{i}内容{i}" for i in range(1, 4))
+
+        plugin = search.SearchPlugin()
+        errors, warnings = plugin.load_config({
+            'lang': 'cn',
+            # 'indexing': 'title'
+        })
+
+        index = search_index.SearchIndex(**plugin.config)
+        for page in pages:
+            page.content = "<p>人生苦短，我用python</p>"
+            index.add_entry_from_context(page)
+
+        self.assertEqual(len(index._entries), 2)
+        self.assertEqual(index._entries[0]['title'], '简单 的 首页')
+        self.assertEqual(index._entries[0]['text'], "人生 苦短 ， 我用 python")
+        self.assertEqual(index._entries[0]['location'], '')
+
+        self.assertEqual(index._entries[1]['title'], '其他 页面')
+        self.assertEqual(index._entries[1]['text'], "人生 苦短 ， 我用 python")
+        self.assertEqual(index._entries[1]['location'], 'etc/')
+
     def test_search_indexing_options(self):
         def test_page(title, filename, config):
             test_page = Page(

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -25,7 +25,7 @@
 # - pyyaml-env-tag>=0.1
 # - pyyaml>=5.1
 # - watchdog>=2.0
-#
+# - jieba>=0.42.1
 
 click==8.1.7
     # via
@@ -131,4 +131,7 @@ six==1.16.0
 watchdog==3.0.0
     # via
     #   hatch.envs.docs
+    #   mkdocs
+jieba>=0.42.1
+    # via
     #   mkdocs


### PR DESCRIPTION
# Brief Mechanism

Use jieba to segment titles and text when creating search index and use Intl, a native API of JavaScript to segment query string.

# Steps

## Configure `mkdocs.yml`

```

plugins:
  - search:
      lang: 
        - cn
      separator: '[\s\-\.]+'

```

## Override `transform`

The steps for overriding refer to [here](https://mkdoc-material.llango.com/setup/setting-up-site-search/#query-transformation)

``` html

{% extends "base.html" %}

{% block config %}
  <script>
    var search = {
        transform: function(query) {
            query = query + ' astopwordflagbylorenzo'; // Trigger stop-word mechanism
            return query
                .replace(/(?:^|\s+)[*+-:^~]+(?=\s+|$)/g, "")
                .trim()
                .replace(/\s+|\b$/g, "* ")
        }
    }
  </script>
{% endblock %}
```

# Result

![image](https://github.com/mkdocs/mkdocs/assets/42567930/bc6809f7-6bed-4d29-b331-183df796c159)
