### PR TITLE
Fix strict mode in Docker by removing 0.0.0.0 warning

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -488,16 +488,6 @@ class IpAddress(OptionallyRequired[_IpAddressValue]):
 
         return _IpAddressValue(host, port)
 
-    def post_validation(self, config: Config, key_name: str):
-        host = config[key_name].host
-        if key_name == 'dev_addr' and host in ['0.0.0.0', '::']:
-            self.warnings.append(
-                f"The use of the IP address '{host}' suggests a production environment "
-                "or the use of a proxy to connect to the MkDocs server. However, "
-                "the MkDocs' server is intended for local development purposes only. "
-                "Please use a third party production-ready server instead."
-            )
-
 
 class URL(OptionallyRequired[str]):
     """

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -351,6 +351,28 @@ class IpAddressTest(TestCase):
         self.assertEqual(conf['option'].host, '127.0.0.1')
         self.assertEqual(conf['option'].port, 8000)
 
+    def test_bind_all_IPv4_address(self):
+        addr = '0.0.0.0:8000'
+
+        class Schema:
+            option = c.IpAddress(default=addr)
+
+        conf = self.get_config(Schema, {'option': None})
+        self.assertEqual(str(conf['option']), addr)
+        self.assertEqual(conf['option'].host, '0.0.0.0')
+        self.assertEqual(conf['option'].port, 8000)
+
+    def test_bind_all_IPv6_address(self):
+        addr = ':::8000'
+
+        class Schema:
+            option = c.IpAddress(default=addr)
+
+        conf = self.get_config(Schema, {'option': None})
+        self.assertEqual(str(conf['option']), addr)
+        self.assertEqual(conf['option'].host, '::')
+        self.assertEqual(conf['option'].port, 8000)
+
     @unittest.skipIf(
         sys.version_info < (3, 9, 5),
         "Leading zeros allowed in IP addresses before Python3.9.5",
@@ -380,37 +402,6 @@ class IpAddressTest(TestCase):
     def test_invalid_address_missing_port(self):
         with self.expect_error(option="Must be a string of format 'IP:PORT'"):
             self.get_config(self.Schema, {'option': '127.0.0.1'})
-
-    def test_unsupported_address(self):
-        class Schema:
-            dev_addr = c.IpAddress()
-
-        self.get_config(
-            Schema,
-            {'dev_addr': '0.0.0.0:8000'},
-            warnings=dict(
-                dev_addr="The use of the IP address '0.0.0.0' suggests a production "
-                "environment or the use of a proxy to connect to the MkDocs "
-                "server. However, the MkDocs' server is intended for local "
-                "development purposes only. Please use a third party "
-                "production-ready server instead."
-            ),
-        )
-
-    def test_unsupported_IPv6_address(self):
-        class Schema:
-            dev_addr = c.IpAddress()
-
-        self.get_config(
-            Schema,
-            {'dev_addr': ':::8000'},
-            warnings=dict(
-                dev_addr="The use of the IP address '::' suggests a production environment "
-                "or the use of a proxy to connect to the MkDocs server. However, "
-                "the MkDocs' server is intended for local development purposes "
-                "only. Please use a third party production-ready server instead."
-            ),
-        )
 
 
 class URLTest(TestCase):

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -339,6 +339,28 @@ class IpAddressTest(TestCase):
         self.assertEqual(conf.option.host, '127.0.0.1')
         self.assertEqual(conf.option.port, 8000)
 
+    def test_bind_all_IPv4_address(self):
+        addr = '0.0.0.0:8000'
+
+        class Schema(Config):
+            option = c.IpAddress(default=addr)
+
+        conf = self.get_config(Schema, {'option': None})
+        self.assertEqual(str(conf['option']), addr)
+        self.assertEqual(conf['option'].host, '0.0.0.0')
+        self.assertEqual(conf['option'].port, 8000)
+
+    def test_bind_all_IPv6_address(self):
+        addr = ':::8000'
+
+        class Schema(Config):
+            option = c.IpAddress(default=addr)
+
+        conf = self.get_config(Schema, {'option': None})
+        self.assertEqual(str(conf['option']), addr)
+        self.assertEqual(conf['option'].host, '::')
+        self.assertEqual(conf['option'].port, 8000)
+
     @unittest.skipIf(
         sys.version_info < (3, 9, 5),
         "Leading zeros allowed in IP addresses before Python3.9.5",
@@ -368,37 +390,6 @@ class IpAddressTest(TestCase):
     def test_invalid_address_missing_port(self) -> None:
         with self.expect_error(option="Must be a string of format 'IP:PORT'"):
             self.get_config(self.Schema, {'option': '127.0.0.1'})
-
-    def test_unsupported_address(self) -> None:
-        class Schema(Config):
-            dev_addr = c.IpAddress()
-
-        self.get_config(
-            Schema,
-            {'dev_addr': '0.0.0.0:8000'},
-            warnings=dict(
-                dev_addr="The use of the IP address '0.0.0.0' suggests a production "
-                "environment or the use of a proxy to connect to the MkDocs "
-                "server. However, the MkDocs' server is intended for local "
-                "development purposes only. Please use a third party "
-                "production-ready server instead."
-            ),
-        )
-
-    def test_unsupported_IPv6_address(self) -> None:
-        class Schema(Config):
-            dev_addr = c.IpAddress()
-
-        self.get_config(
-            Schema,
-            {'dev_addr': ':::8000'},
-            warnings=dict(
-                dev_addr="The use of the IP address '::' suggests a production environment "
-                "or the use of a proxy to connect to the MkDocs server. However, "
-                "the MkDocs' server is intended for local development purposes "
-                "only. Please use a third party production-ready server instead."
-            ),
-        )
 
 
 class URLTest(TestCase):


### PR DESCRIPTION
Fixes #3724 and #2108. Consensus for this change was reached in https://github.com/mkdocs/mkdocs/issues/3724#issuecomment-2178996420

> I'd suggest we simply don't enforce the check against 0.0.0.0. (https://github.com/mkdocs/mkdocs/pull/2022)
Less config is better. Less code is better.