### PR TITLE
utils: fix broken symlink copy exception

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -29,8 +29,7 @@ The current and past members of the MkDocs team.
 
 ## Version 1.6.1 (2024-07-??)
 
-* Fix copy failure due to broken symlinks. Provide warning if symlink is not
-    available, but continue copy instead of exception.
+*   Fix copy failure due to broken symlinks. Provide warning if symlink is not available, but continue copy instead of exception.
 
 ## Version 1.6.0 (2024-04-20)
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -29,7 +29,7 @@ The current and past members of the MkDocs team.
 
 ## Version 1.6.1 (2024-07-??)
 
-*   Fix copy failure due to broken symlinks. Provide warning if symlink is not available, but continue copy instead of exception.
+* Fix copy failure due to broken symlinks. Provide warning if symlink is not available, but continue copy instead of exception.
 
 ## Version 1.6.0 (2024-04-20)
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -27,6 +27,11 @@ The current and past members of the MkDocs team.
 * [@oprypin](https://github.com/oprypin/)
 * [@ultrabug](https://github.com/ultrabug/)
 
+## Version 1.6.1 (2024-07-??)
+
+* Fix copy failure due to broken symlinks. Provide warning if symlink is not
+    available, but continue copy instead of exception.
+
 ## Version 1.6.0 (2024-04-20)
 
 ### Local preview

--- a/mkdocs/__init__.py
+++ b/mkdocs/__init__.py
@@ -2,4 +2,4 @@
 
 
 # For acceptable version formats, see https://www.python.org/dev/peps/pep-0440/
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -122,7 +122,7 @@ def copy_file(source_path: str, output_path: str) -> None:
         output_path = os.path.join(output_path, os.path.basename(source_path))
     if os.path.islink(source_path):
         if not os.path.exists(os.readlink(source_path)):
-            log.warning("Symlink broken, not copy file: %s" % source_path)
+            log.warning("Symlink broken, could not copy file: %s" % source_path)
             return
     shutil.copyfile(source_path, output_path)
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -120,6 +120,10 @@ def copy_file(source_path: str, output_path: str) -> None:
     os.makedirs(output_dir, exist_ok=True)
     if os.path.isdir(output_path):
         output_path = os.path.join(output_path, os.path.basename(source_path))
+    if os.path.islink(source_path):
+        if not os.path.exists(os.readlink(source_path)):
+            log.warning( f"Symlink broken, not copy file: %s" % source_path)
+            return
     shutil.copyfile(source_path, output_path)
 
 

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -122,7 +122,7 @@ def copy_file(source_path: str, output_path: str) -> None:
         output_path = os.path.join(output_path, os.path.basename(source_path))
     if os.path.islink(source_path):
         if not os.path.exists(os.readlink(source_path)):
-            log.warning( f"Symlink broken, not copy file: %s" % source_path)
+            log.warning("Symlink broken, not copy file: %s" % source_path)
             return
     shutil.copyfile(source_path, output_path)
 


### PR DESCRIPTION
First of all: Thanks for your project and awesome work behind MkDocs!

### Issue

The pull request fixes an exception with broken symlinks. Broken symlinks were mentioned multiple times in the past in various places. I run into the same with a broken symlink in a recent project with the most recent release.

### Expected behavior

Site is built/served without the broken symlink but a warning is provided to the user (also useful for CI/CD checks etc.).

### Solution

Based on https://github.com/mkdocs/mkdocs/pull/668 I added the required check in the utils -> copy_file function to report an warning if a symlink is broken and its file was not found, but continue with the copy and serving/building of the site instead of an exception.

After the fix, it looks like this

```
% mkdocs serve                                                             
INFO    -  Building documentation...
INFO    -  Cleaning site directory
WARNING -  Symlink broken, not copy file: /awesome-mkdocs/docs/mylink
INFO    -  Documentation built in 0.05 seconds
INFO    -  [08:44:05] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO    -  [08:44:05] Serving on http://127.0.0.1:8000
```

### How to reproduce

- simple mkdocs config with just site_name in the config.
- Add symlink to non-existing file into docs dir.
    `ln -s ../not-existing mylink`

#### Exception

```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: ...
[...]
Traceback (most recent call last):
  File "/usr/local/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/mkdocs/__main__.py", line 284, in build_command
    build.build(cfg, dirty=not clean)
  File "/usr/local/lib/python3.10/dist-packages/mkdocs/commands/build.py", line 325, in build
    files.copy_static_files(dirty=dirty, inclusion=inclusion)
  File "/usr/local/lib/python3.10/dist-packages/mkdocs/structure/files.py", line 122, in copy_static_files
    file.copy_file(dirty)
  File "/usr/local/lib/python3.10/dist-packages/mkdocs/structure/files.py", line 485, in copy_file
    utils.copy_file(self.abs_src_path, output_path)
  File "/usr/local/lib/python3.10/dist-packages/mkdocs/utils/__init__.py", line 123, in copy_file
    shutil.copyfile(source_path, output_path)
  File "/usr/lib/python3.10/shutil.py", line 254, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '...'
```

Refs: #1753 #639

---

I read https://www.mkdocs.org/about/contributing/ but was unsure if I should open the PR against master or another branch. We could make that clear in the contributing guidelines.