### PR TITLE
add on_page_template event

### DIFF
--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -207,10 +207,14 @@ def _build_page(
         context = get_context(nav, doc_files, config, page)
 
         # Allow 'template:' override in md source files.
-        template = env.get_template(page.meta.get('template', 'main.html'))
+        template_file = page.meta.get('template', 'main.html')
+        template = env.get_template(template_file)
 
         # Run `page_context` plugin events.
         context = config.plugins.on_page_context(context, page=page, config=config, nav=nav)
+
+        # Run `page_template`
+        template = config.plugins.on_page_template(template, template_file=template_file, page=page, config=config, nav=nav)
 
         if excluded:
             page.content = (

--- a/mkdocs/plugins.py
+++ b/mkdocs/plugins.py
@@ -398,6 +398,25 @@ class BasePlugin(Generic[SomeConfig]):
         """
         return context
 
+    def on_page_template(
+            self, template: jinja2.Template, template_file: str, page: Page, config: MkDocsConfig, nav: Navigation
+    ) -> jinja2.Template:
+        """
+        The `page_template` event is called after the template for a page is created
+        from a theme and can be used to alter the template for that specific page only.
+
+        Args:
+            template: a Jinja2 [Template](https://jinja.palletsprojects.com/en/latest/api/#jinja2.Template) object
+            template_file: relative or absolute path to an html file used as template
+            page: `mkdocs.structure.pages.Page` instance
+            config: global configuration objet
+            nav: global navigation object
+
+        Returns:
+            a Jinja2 [Template](https://jinja.palletsprojects.com/en/latest/api/#jinja2.Template) object
+        """
+        return template
+
     def on_post_page(self, output: str, /, *, page: Page, config: MkDocsConfig) -> str | None:
         """
         The `post_page` event is called after the template is rendered, but
@@ -641,6 +660,11 @@ class PluginCollection(dict, MutableMapping[str, BasePlugin]):
         self, context: TemplateContext, *, page: Page, config: MkDocsConfig, nav: Navigation
     ) -> TemplateContext:
         return self.run_event('page_context', context, page=page, config=config, nav=nav)
+
+    def on_page_template(
+        self, template: jinja2.Template, *, template_file: str, page: Page, config: MkDocsConfig, nav: Navigation
+    ) -> jinja2.Template:
+        return self.run_event('page_template', template, template_file=template_file, page=page, config=config, nav=nav)
 
     def on_post_page(self, output: str, *, page: Page, config: MkDocsConfig) -> str:
         return self.run_event('post_page', output, page=page, config=config)


### PR DESCRIPTION
By adding this new event, i'd like to allow plugins to change template based on the page being built.

An example of usage can be seen in this in-development plugin: [mkdocs_multi_theme_plugin](https://github.com/carlocastoldi/mkdocs-multi-theme-plugin/blob/master/mkdocs_multi_theme_plugin/plugin.py)

Before resorting to this upstream change, i have considered using other events (e.g. `on_env`), but I am afraid none allow per-page editing of the templates from the ground up.