### PR TITLE
Resolve `SOURCE_DATE_EPOCH=0` bug.

### DIFF
--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -53,10 +53,10 @@ def get_build_timestamp(*, pages: Collection[Page] | None = None) -> int:
     if pages:
         # Lexicographic comparison is OK for ISO date.
         date_string = max(p.update_date for p in pages)
-        dt = datetime.fromisoformat(date_string)
+        dt = datetime.fromisoformat(date_string).replace(tzinfo=timezone.utc)
     else:
         dt = get_build_datetime()
-    return max(int(dt.timestamp()), 0)
+    return int(dt.timestamp())
 
 
 def get_build_datetime() -> datetime:

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -56,7 +56,7 @@ def get_build_timestamp(*, pages: Collection[Page] | None = None) -> int:
         dt = datetime.fromisoformat(date_string)
     else:
         dt = get_build_datetime()
-    return int(dt.timestamp())
+    return max(int(dt.timestamp()), 0)
 
 
 def get_build_datetime() -> datetime:


### PR DESCRIPTION
Closes #3794 

Not clear to me if...

* There may also be a timezone issue here leading to the negative value.

And furthermore...

* Non-integer values will still raise an exception here.

But this does at least resolve the immediate issue.

Thanks to @vedranmiletic for raising the issue and @pawamoy for the confimation.