### PR TITLE
add `headers` config options for `mkdocs serve`

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -67,7 +67,12 @@ def serve(
         build(config, serve_url=None if is_clean else serve_url, dirty=is_dirty)
 
     server = LiveReloadServer(
-        builder=builder, host=host, port=port, root=site_dir, mount_path=mount_path
+        builder=builder,
+        host=host,
+        port=port,
+        root=site_dir,
+        mount_path=mount_path,
+        headers=config.headers,
     )
 
     def error_handler(code) -> bytes | None:

--- a/mkdocs/config/defaults.py
+++ b/mkdocs/config/defaults.py
@@ -166,6 +166,9 @@ class MkDocsConfig(base.Config):
     watch = c.ListOfPaths(default=[])
     """A list of extra paths to watch while running `mkdocs serve`."""
 
+    headers = c.Type(dict, default={})
+    """A dict of custom HTTP headers used when running `mkdocs serve`."""
+
     class Validation(base.Config):
         class NavValidation(base.Config):
             omitted_files = _LogLevel(default='info')

--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -104,6 +104,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
         mount_path: str = "/",
         polling_interval: float = 0.5,
         shutdown_delay: float = 0.25,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self.builder = builder
         try:
@@ -135,6 +136,8 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
 
         self._watched_paths: dict[str, int] = {}
         self._watch_refs: dict[str, Any] = {}
+
+        self._headers: dict[str, str] = headers or {}
 
     def watch(self, path: str, func: None = None, *, recursive: bool = True) -> None:
         """Add the 'path' to watched paths, call the function and reload when any file changes under it."""
@@ -320,7 +323,12 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
 
         content_type = self._guess_type(file_path)
         start_response(
-            "200 OK", [("Content-Type", content_type), ("Content-Length", str(content_length))]
+            "200 OK",
+            [
+                ("Content-Type", content_type),
+                ("Content-Length", str(content_length)),
+                *self._headers.items(),
+            ],
         )
         return wsgiref.util.FileWrapper(file)
 

--- a/mkdocs/tests/__init__.py
+++ b/mkdocs/tests/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import unittest.util
 
-unittest.util._MAX_LENGTH = 100000
+unittest.util._MAX_LENGTH = 100000  # type: ignore[misc]
 
 
 class DisallowLogsHandler(logging.Handler):


### PR DESCRIPTION
this changes allows to specifiy custom HTTP headers to be sent when using `mkdocs serve`

This new options is needed, when you need extra HTTP headers like [CORS](https://de.wikipedia.org/wiki/Cross-Origin_Resource_Sharing)

With this change these headers can be specified in `mkdocs.yaml` like this:
```yaml
headers:
  Access-Control-Allow-Origin: "*"
```