### PR TITLE
fix: Fixed directory cleanup after terminated by signal (#3905)

### DIFF
--- a/mkdocs/commands/serve.py
+++ b/mkdocs/commands/serve.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import logging
 import shutil
+import sys
 import tempfile
 from os.path import isdir, isfile, join
+from signal import SIGINT, SIGTERM, signal
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
@@ -78,7 +80,47 @@ def serve(
                     return f.read()
         return None
 
+    def handle_signal(signum, frame) -> None:
+
+        from signal import strsignal
+
+        signal_name = strsignal(signum)
+        log.info(f"Received signal '{signal_name}'")
+
+        shutdown()
+
+    def shutdown() -> None:
+        if not server.is_active:
+            return
+
+        log.info("Shutting down...")
+
+        try:
+            server.shutdown()
+        finally:
+            config.plugins.on_shutdown()
+
+        if isdir(site_dir):
+            shutil.rmtree(site_dir)
+
     server.error_handler = error_handler
+
+    signal(SIGTERM, handle_signal)
+    signal(SIGINT, handle_signal)
+
+    if sys.platform == "linux":
+        from signal import SIGHUP, SIGQUIT, SIGUSR1, SIGUSR2
+
+        signal(SIGHUP, handle_signal)
+        signal(SIGUSR1, handle_signal)
+        signal(SIGUSR2, handle_signal)
+        signal(SIGQUIT, handle_signal)
+    elif sys.platform == "win32":
+        from signal import CTRL_BREAK_EVENT, CTRL_C_EVENT, SIGBREAK
+
+        signal(SIGBREAK, handle_signal)
+        signal(CTRL_C_EVENT, handle_signal)
+        signal(CTRL_BREAK_EVENT, handle_signal)
 
     try:
         # Perform the initial build
@@ -100,13 +142,7 @@ def serve(
             for item in config.watch:
                 server.watch(item)
 
-        try:
-            server.serve(open_in_browser=open_in_browser)
-        except KeyboardInterrupt:
-            log.info("Shutting down...")
-        finally:
-            server.shutdown()
+        server.serve(open_in_browser=open_in_browser)
+
     finally:
-        config.plugins.on_shutdown()
-        if isdir(site_dir):
-            shutil.rmtree(site_dir)
+        shutdown()

--- a/mkdocs/livereload/__init__.py
+++ b/mkdocs/livereload/__init__.py
@@ -21,6 +21,7 @@ import urllib.parse
 import webbrowser
 import wsgiref.simple_server
 import wsgiref.util
+from os import getpid
 from typing import Any, BinaryIO, Callable, Iterable
 
 import watchdog.events
@@ -111,6 +112,8 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
                 self.address_family = socket.AF_INET6
         except Exception:
             pass
+
+        self._is_active = False
         self.root = os.path.abspath(root)
         self.mount_path = _normalize_mount_path(mount_path)
         self.url = _serve_url(host, port, mount_path)
@@ -170,6 +173,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
             self.observer.unschedule(self._watch_refs.pop(path))
 
     def serve(self, *, open_in_browser=False):
+        self._is_active = True
         self.server_bind()
         self.server_activate()
 
@@ -178,6 +182,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
 
             paths_str = ", ".join(f"'{_try_relativize_path(path)}'" for path in self._watched_paths)
             log.info(f"Watching paths for changes: {paths_str}")
+
 
         if open_in_browser:
             log.info(f"Serving on {self.url} and opening it in a browser")
@@ -225,6 +230,7 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
                 self._epoch_cond.notify_all()
 
     def shutdown(self, wait=False) -> None:
+        self._is_active = False
         self.observer.stop()
         with self._rebuild_cond:
             self._shutdown = True
@@ -260,6 +266,10 @@ class LiveReloadServer(socketserver.ThreadingMixIn, wsgiref.simple_server.WSGISe
 
         start_response(msg, [("Content-Type", "text/html")])
         return [error_content]
+
+    @property
+    def is_active(self) -> bool:
+        return self._is_active
 
     def _serve_request(self, environ, start_response) -> Iterable[bytes] | None:
         # https://bugs.python.org/issue16679


### PR DESCRIPTION
- Now the directory is cleanup when receive any 'terminate' class signal
- The 'Server' class have an attribute 'is_active' to know the server state
