### PR TITLE
Fix: Decrase anchor validation treeprocessor prioriy

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -340,9 +340,9 @@ class _ExtractAnchorsTreeprocessor(markdown.treeprocessors.Treeprocessor):
                     add(anchor)
 
     def _register(self, md: markdown.Markdown) -> None:
-        md.treeprocessors.register(
-            self, "mkdocs_extract_anchors", priority=3.9
-        )  # decreased from 5 (see: #3690)
+        # Priority 3.9 to run *after* PyMDown Extensions' `tab` (4), which runs after `toc` (5),
+        # see https://github.com/mkdocs/mkdocs/issues/3690.
+        md.treeprocessors.register(self, "mkdocs_extract_anchors", priority=3.9)
 
 
 class _RelativePathTreeprocessor(markdown.treeprocessors.Treeprocessor):


### PR DESCRIPTION
Resolves #3690 

> (...) the suggested solution is to decrease the treeprocessor processor priority to 3.9:

https://github.com/mkdocs/mkdocs/blob/fb1d106747930b094bc464189d4b1c349fc541c6/mkdocs/structure/pages.py#L343

