### PR TITLE
Fix issue with handling `</>`

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -542,6 +542,13 @@ class _HTMLHandler(markdown.htmlparser.htmlparser.HTMLParser):  # type: ignore[n
         super().__init__()
         self.present_anchor_ids: set[str] = set()
 
+    def parse_starttag(self, i: int) -> int:
+        # Treat `</>` as normal data as it is not a real tag.
+        if self.rawdata[i:i + 3] == '</>':
+            self.handle_data(self.rawdata[i:i + 3])
+            return i + 3
+        return super().parse_starttag(i)
+
     def handle_starttag(self, tag: str, attrs: Sequence[tuple[str, str]]) -> None:
         for k, v in attrs:
             if k == 'id' or (k == 'name' and tag == 'a'):


### PR DESCRIPTION
Markdown recently made a fix for an issue handling `</>` which would get stripped out of content. Reference:
https://github.com/Python-Markdown/markdown/commit/64a3c0fbc00327fbfee1fd6b44da0e5453287fe4

MkDocs uses Markdown's monkey-patched HTMLParser, but does not use the HTML extractor that has the logic to handle the things that have been monkey-patched in. Because of this, MkDocs now fails when parsing `</>`. This fixes the issue by adding the same logic to handle the issue that Markdown uses.