### PR TITLE
Restrict click dependency version to `<=8.2.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
-    "click >=7.0, <8.3.0",
+    "click >=7.0, <=8.2.1",
     "Jinja2 >=2.11.1",
     "markupsafe >=2.0.1",
     "Markdown >=3.3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
-    "click >=7.0",
+    "click >=7.0, <8.3.0",
     "Jinja2 >=2.11.1",
     "markupsafe >=2.0.1",
     "Markdown >=3.3.6",


### PR DESCRIPTION
Closes #4032

As requested by a maintainer:

- https://github.com/mkdocs/mkdocs/issues/4032#issuecomment-3490948321