### PR TITLE
fix:Verbose flag overrides --strict flag. #3991

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ target/
 # virtualenv
 venv/
 ENV/
+.venv/
 
 # MkDocs documentation
 site*/

--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -343,7 +343,9 @@ def get_deps_command(config_file, projects_file):
 
     warning_counter = utils.CountHandler()
     warning_counter.setLevel(logging.WARNING)
-    logging.getLogger('mkdocs').addHandler(warning_counter)
+    # Attach to the root logger so the counter sees all messages regardless
+    # of package logger configuration done by CLI options (e.g. -v/-q).
+    logging.getLogger().addHandler(warning_counter)
 
     with get_projects_file(projects_file) as p:
         with _open_config_file(config_file) as f:

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -248,13 +248,17 @@ def _build_page(
 
 def build(config: MkDocsConfig, *, serve_url: str | None = None, dirty: bool = False) -> None:
     """Perform a full site build."""
-    logger = logging.getLogger('mkdocs')
+    # Use the root logger for the warning counter so it sees messages even when
+    # command-line options (like -v) change the configuration of the package
+    # logger (which may affect propagation/handlers). The counter is only used
+    # for strict mode checks below.
+    root_logger = logging.getLogger()
 
     # Add CountHandler for strict mode
     warning_counter = utils.CountHandler()
     warning_counter.setLevel(logging.WARNING)
     if config.strict:
-        logging.getLogger('mkdocs').addHandler(warning_counter)
+        root_logger.addHandler(warning_counter)
 
     inclusion = InclusionLevel.is_in_serve if serve_url else InclusionLevel.is_included
 
@@ -361,7 +365,7 @@ def build(config: MkDocsConfig, *, serve_url: str | None = None, dirty: bool = F
         raise
 
     finally:
-        logger.removeHandler(warning_counter)
+        root_logger.removeHandler(warning_counter)
 
 
 def site_directory_contains_stale_files(site_directory: str) -> bool:

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -4,6 +4,7 @@ Standalone file utils.
 Nothing in this module should have an knowledge of config or the layout
 and structure of the site and pages in the site.
 """
+
 from __future__ import annotations
 
 import functools
@@ -375,6 +376,13 @@ class CountHandler(logging.NullHandler):
         super().__init__(**kwargs)
 
     def handle(self, record):
+        # Only count messages originating from the mkdocs package. The
+        # CountHandler is attached to the root logger so it sees all
+        # messages; restrict counting to avoid unrelated external warnings
+        # affecting strict mode behavior.
+        if not record.name.startswith('mkdocs'):
+            return False
+
         rv = self.filter(record)
         if rv:
             # Use levelno for keys so they can be sorted later


### PR DESCRIPTION
fix: https://github.com/mkdocs/mkdocs/issues/3991

Root cause: the strict-mode warning counter was attached to the 'mkdocs' logger. CLI options like -v change package logger configuration such that some warnings didn't reach that handler, producing different exit codes with/without -v.

Fix: attach the CountHandler to the root logger so it reliably sees MkDocs messages, and restrict the counter to only count records so unrelated warnings aren't counted.

Files modified:
build.py: Use the root logger for the strict-mode CountHandler and remove it from the root logger in the finally block.
__main__.py : In the get-deps command, attach the temporary CountHandler to the root logger as well (consistent behavior).
__init__.py : CountHandler.handle() now ignores records that are not from the mkdocs package so that only MkDocs-originating warnings are counted.