### PR TITLE
feat: default project_directory to current dir in `mkdocs new`

### DIFF
--- a/mkdocs/__main__.py
+++ b/mkdocs/__main__.py
@@ -357,7 +357,7 @@ def get_deps_command(config_file, projects_file):
 
 
 @cli.command(name="new")
-@click.argument("project_directory")
+@click.argument("project_directory", default=".")
 @common_options
 def new_command(project_directory):
     """Create a new MkDocs project."""

--- a/mkdocs/tests/cli_tests.py
+++ b/mkdocs/tests/cli_tests.py
@@ -382,6 +382,13 @@ class CLITests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_new.assert_called_once_with('project')
 
+    @mock.patch('mkdocs.commands.new.new', autospec=True)
+    def test_new_default(self, mock_new):
+        result = self.runner.invoke(cli.cli, ["new"], catch_exceptions=False)
+
+        self.assertEqual(result.exit_code, 0)
+        mock_new.assert_called_once_with('.')
+
     @mock.patch('mkdocs.config.load_config', autospec=True)
     @mock.patch('mkdocs.commands.build.build', autospec=True)
     @mock.patch('mkdocs.commands.gh_deploy.gh_deploy', autospec=True)

--- a/mkdocs/tests/new_tests.py
+++ b/mkdocs/tests/new_tests.py
@@ -22,3 +22,17 @@ class NewTests(unittest.TestCase):
 
             for expected_path in expected_paths:
                 self.assertTrue(os.path.exists(expected_path))
+
+    @tempdir()
+    def test_new_current_dir(self, temp_dir):
+        with change_dir(temp_dir):
+            new.new(".")
+
+            expected_paths = [
+                os.path.join(temp_dir, "mkdocs.yml"),
+                os.path.join(temp_dir, "docs"),
+                os.path.join(temp_dir, "docs", "index.md"),
+            ]
+
+            for expected_path in expected_paths:
+                self.assertTrue(os.path.exists(expected_path))


### PR DESCRIPTION
## Summary

When running `mkdocs new` without specifying a project directory, the command currently raises an error because `project_directory` is a required argument. This PR makes the argument optional by defaulting to `'.'` (the current working directory), so `mkdocs new` behaves identically to `mkdocs new .`.

This is a small quality-of-life improvement that reduces friction for users who want to initialize a project in their current directory.

## Changes

- **`mkdocs/__main__.py`**: Added `default='.'` to the `project_directory` click argument.
- **`mkdocs/tests/cli_tests.py`**: Added `test_new_default` to verify the CLI defaults to `'.'` when no argument is provided.
- **`mkdocs/tests/new_tests.py`**: Added `test_new_current_dir` to verify `new('.')` correctly creates `mkdocs.yml` and `docs/index.md` in the current directory.

## Motivation

Closes #1988

As noted in the issue, running `mkdocs new` without a path should default to `'.'` rather than requiring the user to explicitly type `mkdocs new .`. This matches the behavior of similar CLI tools (e.g., `git init`, `npm init`) that default to the current directory.