### PR TITLE
Fix validation.links.not_found level always capped to INFO for links to excluded pages

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -506,7 +506,7 @@ class _RelativePathTreeprocessor(markdown.treeprocessors.Treeprocessor):
             if self.file.inclusion.is_excluded():
                 warning_level = logging.DEBUG
             else:
-                warning_level = min(logging.INFO, self.config.validation.links.not_found)
+                warning_level = self.config.validation.links.not_found
             warning = (
                 f"Doc file '{self.file.src_uri}' contains a link to "
                 f"'{target_uri}' which is excluded from the built site."

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -650,7 +650,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
 
         with self.subTest(serve_url=None):
             expected_logs = '''
-                INFO:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
+                WARNING:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
             '''
             with self._assert_build_logs(expected_logs):
                 build.build(cfg)
@@ -662,7 +662,7 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         with self.subTest(serve_url=serve_url):
             expected_logs = '''
                 INFO:Doc file 'test/bar.md' contains a link 'nonexistent.md', but the target 'test/nonexistent.md' is not found among documentation files.
-                INFO:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
+                WARNING:Doc file 'test/foo.md' contains a link to 'test/bar.md' which is excluded from the built site.
                 INFO:The following pages are being built only for the preview but will be excluded from `mkdocs build` per `draft_docs` config:
                   - http://localhost:123/documentation/test/bar.html
                   - http://localhost:123/documentation/test/baz.html

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -9,7 +9,7 @@ from unittest import mock
 import markdown
 
 from mkdocs.config.defaults import MkDocsConfig
-from mkdocs.structure.files import File, Files
+from mkdocs.structure.files import File, Files, InclusionLevel
 from mkdocs.structure.pages import Page, _ExtractTitleTreeprocessor, _RelativePathTreeprocessor
 from mkdocs.tests.base import dedent, tempdir
 
@@ -1239,6 +1239,31 @@ class RelativePathExtensionTests(unittest.TestCase):
             ),
             '<a href="mail@example.com">contact</a>',
         )
+
+    def test_link_to_excluded_page_respects_not_found_level(self):
+        # Included page linking to an excluded page must use the configured
+        # not_found level; it should NOT be silently capped to INFO.
+        for level, expected_levelname in [('warn', 'WARNING'), ('info', 'INFO')]:
+            with self.subTest(level=level):
+                cfg = load_config(validation=dict(links=dict(not_found=level)))
+                fs = [
+                    File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+                    File('excluded.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+                ]
+                fs[1].inclusion = InclusionLevel.EXCLUDED
+                pg = Page('Foo', fs[0], cfg)
+                with mock.patch(
+                    'mkdocs.structure.files.open', mock.mock_open(read_data='[link](excluded.md)')
+                ):
+                    pg.read_source(cfg)
+                with self.assertLogs('mkdocs.structure.pages') as cm:
+                    pg.render(cfg, Files(fs))
+                msgs = [f'{r.levelname}:{r.message}' for r in cm.records]
+                self.assertEqual(
+                    '\n'.join(msgs),
+                    f"{expected_levelname}:Doc file 'index.md' contains a link to"
+                    " 'excluded.md' which is excluded from the built site.",
+                )
 
     def test_possible_target_uris(self):
         def test(paths, expected='', exp_true=None, exp_false=None):


### PR DESCRIPTION
Fixes #3900.

## Problem

When an *included* page links to an *excluded* page, the warning level was computed as:

```python
warning_level = min(logging.INFO, self.config.validation.links.not_found)
```

`logging.INFO` is `20`, so any level ≥ `WARNING` (30) gets silently capped to `INFO`. This means setting `validation.links.not_found: warn` (or `error`) has no effect for links pointing to excluded pages — the message always appears at `INFO`.

The parallel branch for *excluded*-to-excluded links (a few lines above) correctly uses `logging.DEBUG` with no cap against the config value, so the inconsistency was unintentional.

## Fix

Remove the `min(logging.INFO, …)` cap and use the configured level directly:

```python
# before
warning_level = min(logging.INFO, self.config.validation.links.not_found)
# after
warning_level = self.config.validation.links.not_found
```

## Tests

Added `test_link_to_excluded_page_respects_not_found_level` which renders an included page that links to a file marked as `InclusionLevel.EXCLUDED` and asserts the log record appears at the configured level (`warn` → `WARNING`, `info` → `INFO`). Before the fix, the `warn` sub-test would fail because the log appeared at `INFO` instead of `WARNING`.