### PR TITLE
Fix submenu marker color in mkdocs theme

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -6,6 +6,7 @@ import logging
 import os
 import string
 import sys
+import textwrap
 import traceback
 import types
 import warnings
@@ -1221,6 +1222,8 @@ class PathSpec(BaseConfigOption[pathspec.gitignore.GitIgnoreSpec]):
         if not isinstance(value, str):
             raise ValidationError(f'Expected a multiline string, but a {type(value)} was given.')
         try:
-            return pathspec.gitignore.GitIgnoreSpec.from_lines(lines=value.splitlines())
+            return pathspec.gitignore.GitIgnoreSpec.from_lines(
+                lines=textwrap.dedent(value).splitlines()
+            )
         except ValueError as e:
             raise ValidationError(str(e))

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -1115,6 +1115,29 @@ class SiteDirTest(TestCase):
                 self.get_config(self.Schema, test_config)
 
 
+class PathSpecTest(TestCase):
+    def test_dedent_multiline_patterns(self) -> None:
+        class Schema(Config):
+            option = c.PathSpec()
+
+        conf = self.get_config(
+            Schema,
+            {
+                'option': '''
+                    # Markdown files ending in _unpublished.md anywhere.
+                    *_unpublished.md
+
+                    # But keep this particular file.
+                    !/foo_unpublished.md
+                ''',
+            },
+        )
+
+        self.assertFalse(conf.option.match_file('foo_unpublished.md'))
+        self.assertTrue(conf.option.match_file('other_unpublished.md'))
+        self.assertTrue(conf.option.match_file('test/other_unpublished.md'))
+
+
 class ThemeTest(TestCase):
     def test_theme_as_string(self) -> None:
         class Schema(Config):

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -1,4 +1,5 @@
 import os
+import re
 import unittest
 from unittest import mock
 
@@ -39,6 +40,29 @@ class ThemeTests(unittest.TestCase):
                 'nav_style': 'primary',
                 'shortcuts': {'help': 191, 'next': 78, 'previous': 80, 'search': 83},
             },
+        )
+
+    def test_mkdocs_theme_submenu_marker_uses_visible_default_color(self):
+        with open(
+            os.path.join(theme_dir, 'mkdocs', 'css', 'base.css'), encoding='utf-8'
+        ) as css_file:
+            css = css_file.read()
+
+        self.assertRegex(
+            css,
+            re.compile(
+                r'\.dropdown-submenu > a::after \{[^}]*'
+                r'border-left-color: var\(--bs-dropdown-link-color\);',
+                re.DOTALL,
+            ),
+        )
+        self.assertRegex(
+            css,
+            re.compile(
+                r'\.dropdown-submenu:hover > a::after \{[^}]*'
+                r'border-left-color: var\(--bs-dropdown-link-active-color\);',
+                re.DOTALL,
+            ),
         )
 
     @tempdir()

--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -323,7 +323,7 @@ details h4, details h5, details h6 {
     border-color: transparent;
     border-style: solid;
     border-width: 5px 0 5px 5px;
-    border-left-color: var(--bs-dropdown-link-active-color);
+    border-left-color: var(--bs-dropdown-link-color);
     margin-top: 5px;
     margin-right: -10px;
 }


### PR DESCRIPTION
Fixes #3909

## Summary

The submenu arrow in the built-in `mkdocs` theme was using the active dropdown link color in its default state, which makes it white on a white menu background. This changes the default marker to use the regular dropdown link color, while keeping the active color for hover.

I also added a regression test around the CSS rule so the default and hover colors stay distinct.

While checking the full CI run, the `draft_docs` user-guide example failed with indented multiline path patterns. This also dedents `PathSpec` config values before passing them to `pathspec`, with a focused regression test for indented patterns.

## Tests

- `UV_CACHE_DIR=/tmp/mkdocs-4125-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mkdocs-4125-venv uv run python -m unittest mkdocs.tests.config.config_options_tests.PathSpecTest mkdocs.tests.build_tests.BuildTests.test_draft_docs_with_comments_from_user_guide mkdocs.tests.theme_tests.ThemeTests.test_mkdocs_theme_submenu_marker_uses_visible_default_color`
- `UV_CACHE_DIR=/tmp/mkdocs-4125-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mkdocs-4125-venv-pyyaml6 uv run --with 'PyYAML==6.0.3' python -m unittest mkdocs.tests.config.config_options_tests.PathSpecTest mkdocs.tests.build_tests.BuildTests.test_draft_docs_with_comments_from_user_guide`
- `UV_CACHE_DIR=/tmp/mkdocs-4125-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mkdocs-4125-venv uv run python -m unittest mkdocs.tests.config.config_options_tests mkdocs.tests.theme_tests`
- `UV_CACHE_DIR=/tmp/mkdocs-4125-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/mkdocs-4125-venv-ruff014 uv run --with 'ruff==0.1.14' ruff check mkdocs/config/config_options.py mkdocs/tests/config/config_options_tests.py mkdocs/tests/theme_tests.py`
- `git diff --check`