### PR TITLE
docs: clarify site_url sitemap behavior

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -38,6 +38,10 @@ path taken from the path component of the URL, e.g. `some/page.md` will be
 served from `http://127.0.0.1:8000/foo/some/page/` to mimic the expected remote
 layout.
 
+If `site_url` is not set, some features that need an absolute canonical URL can
+behave unexpectedly when building the site, such as generating empty sitemap
+`<loc>` entries.
+
 **default**: `null`
 
 ### repo_url

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -582,20 +582,21 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
     )
     @tempdir()
     def test_draft_docs_with_comments_from_user_guide(self, site_dir, docs_dir):
+        draft_docs = (
+            '# A "drafts" directory anywhere.\n'
+            'drafts/\n'
+            '\n'
+            '# A Markdown file ending in _unpublished.md anywhere.\n'
+            '*_unpublished.md\n'
+            '\n'
+            '# But keep this particular file.\n'
+            '!/foo_unpublished.md\n'
+        )
         cfg = load_config(
             docs_dir=docs_dir,
             site_dir=site_dir,
             use_directory_urls=False,
-            draft_docs='''
-                # A "drafts" directory anywhere.
-                drafts/
-
-                # A Markdown file ending in _unpublished.md anywhere.
-                *_unpublished.md
-
-                # But keep this particular file.
-                !/foo_unpublished.md
-            ''',
+            draft_docs=draft_docs,
         )
 
         with self.subTest(serve_url=None):


### PR DESCRIPTION
## Summary
Clarify that `site_url` affects build-time sitemap generation and that missing it can produce empty `<loc>` entries.

Fixes #1783

## Validation
- Reviewed the issue discussion
- Updated `docs/user-guide/configuration.md`
- Ran `git diff --check`
