### PR TITLE
Avoid nav warnings for page anchor links

### DIFF
--- a/mkdocs/structure/nav.py
+++ b/mkdocs/structure/nav.py
@@ -177,12 +177,33 @@ def get_navigation(files: Files, config: MkDocsConfig) -> Navigation:
                 "configuration, which presumably points to an external resource.",
             )
         else:
-            log.log(
-                config.validation.nav.not_found,
-                f"A reference to '{link.url}' is included in the 'nav' "
-                "configuration, which is not found in the documentation files.",
-            )
+            if not _link_path_matches_documentation_page(path, files, config):
+                log.log(
+                    config.validation.nav.not_found,
+                    f"A reference to '{link.url}' is included in the 'nav' "
+                    "configuration, which is not found in the documentation files.",
+                )
     return Navigation(items, pages)
+
+
+def _link_path_matches_documentation_page(path: str, files: Files, config: MkDocsConfig) -> bool:
+    """Return whether a nav link path points at a known documentation page."""
+    if not path:
+        return False
+    if (
+        path.startswith('/')
+        and config.validation.nav.absolute_links is _AbsoluteLinksValidationValue.RELATIVE_TO_DOCS
+    ):
+        path = path.lstrip('/')
+
+    if files.get_file_from_path(path):
+        return True
+
+    normalized_path = path.rstrip('/')
+    return any(
+        normalized_path in (file.url.rstrip('/'), file.dest_uri.rstrip('/'))
+        for file in files.documentation_pages()
+    )
 
 
 def _data_to_navigation(data, files: Files, config: MkDocsConfig):

--- a/mkdocs/tests/structure/nav_tests.py
+++ b/mkdocs/tests/structure/nav_tests.py
@@ -198,6 +198,29 @@ class SiteNavigationTests(unittest.TestCase):
         self.assertEqual(len(site_navigation.items), 3)
         self.assertEqual(len(site_navigation.pages), 1)
 
+    def test_nav_anchor_link_to_existing_page(self):
+        nav_cfg = [
+            {'Home': 'index.md'},
+            {'Heading': 'guide/#heading'},
+        ]
+        expected = dedent(
+            """
+            Page(title='Home', url='/')
+            Link(title='Heading', url='guide/#heading')
+            """
+        )
+        cfg = load_config(nav=nav_cfg, site_url='http://example.com/')
+        fs = [
+            File('index.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+            File('guide.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls),
+        ]
+        files = Files(fs)
+        with self.assertNoLogs('mkdocs', level='WARNING'):
+            site_navigation = get_navigation(files, cfg)
+        self.assertEqual(str(site_navigation).strip(), expected)
+        self.assertEqual(len(site_navigation.items), 2)
+        self.assertEqual(len(site_navigation.pages), 1)
+
     def test_indented_nav(self):
         nav_cfg = [
             {'Home': 'index.md'},


### PR DESCRIPTION
## Summary

- Avoid warning that a nav link is missing when its path points at an existing documentation page and only adds an anchor fragment.
- Add regression coverage for a `guide/#heading` nav entry.

Fixes #4026.

## Tests

- `python -m unittest mkdocs.tests.structure.nav_tests.SiteNavigationTests.test_nav_anchor_link_to_existing_page`
- `python -m unittest mkdocs.tests.structure.nav_tests`
- `python -m compileall -q mkdocs/structure/nav.py mkdocs/tests/structure/nav_tests.py`
- `git diff --check`

AI assistance was used to help prepare this change.
