### PR TITLE
Dedent configured pathspec patterns

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -6,6 +6,7 @@ import logging
 import os
 import string
 import sys
+import textwrap
 import traceback
 import types
 import warnings
@@ -1221,6 +1222,8 @@ class PathSpec(BaseConfigOption[pathspec.gitignore.GitIgnoreSpec]):
         if not isinstance(value, str):
             raise ValidationError(f'Expected a multiline string, but a {type(value)} was given.')
         try:
-            return pathspec.gitignore.GitIgnoreSpec.from_lines(lines=value.splitlines())
+            return pathspec.gitignore.GitIgnoreSpec.from_lines(
+                lines=textwrap.dedent(value).splitlines()
+            )
         except ValueError as e:
             raise ValidationError(str(e))

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -978,6 +978,28 @@ class FilesystemObjectTest(TestCase):
             )
 
 
+class PathSpecTest(TestCase):
+    def test_indented_multiline_patterns(self) -> None:
+        class Schema(Config):
+            option = c.PathSpec()
+
+        conf = self.get_config(
+            Schema,
+            {
+                'option': '''
+                    # Exclude unpublished pages.
+                    *_unpublished.md
+
+                    # But keep this one.
+                    !/foo_unpublished.md
+                '''
+            },
+        )
+
+        self.assertFalse(conf.option.match_file('foo_unpublished.md'))
+        self.assertTrue(conf.option.match_file('other_unpublished.md'))
+
+
 class ListOfPathsTest(TestCase):
     def test_valid_path(self) -> None:
         paths = [os.path.dirname(__file__)]


### PR DESCRIPTION
## Summary

- Dedent multiline `PathSpec` config values before compiling them as gitignore-style patterns.
- Add regression coverage for indented multiline patterns with comments and negation.

This fixes the current `draft_docs` behavior where indented examples such as the user-guide-style config no longer match paths with newer `pathspec`.

## Tests

- `python -m unittest mkdocs.tests.config.config_options_tests.PathSpecTest.test_indented_multiline_patterns`
- `python -m unittest mkdocs.tests.build_tests.BuildTests.test_draft_docs_with_comments_from_user_guide`
- `python -m compileall -q mkdocs/config/config_options.py mkdocs/tests/config/config_options_tests.py`
- `git diff --check`

AI assistance was used to help prepare this change.
