### PR TITLE
Handle invalid page URLs as warnings

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -417,7 +417,15 @@ class _RelativePathTreeprocessor(markdown.treeprocessors.Treeprocessor):
                     tried.add(guess)
 
     def path_to_url(self, url: str) -> str:
-        scheme, netloc, path, query, anchor = urlsplit(url)
+        try:
+            scheme, netloc, path, query, anchor = urlsplit(url)
+        except ValueError as e:
+            log.log(
+                self.config.validation.links.not_found,
+                f"Doc file '{self.file.src_uri}' contains an invalid URL '{url}', "
+                f"it was left as is: {e}",
+            )
+            return url
 
         absolute_link = None
         warning_level, warning = 0, ''

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -1093,6 +1093,19 @@ class RelativePathExtensionTests(unittest.TestCase):
             '<a href="http://example.com/index.md">external</a>',
         )
 
+    def test_invalid_url_is_preserved_and_warned(self):
+        self.assertEqual(
+            self.get_rendered_result(
+                content='[invalid](http://[example.com)',
+                files=['index.md'],
+                logs=(
+                    "WARNING:Doc file 'index.md' contains an invalid URL "
+                    "'http://[example.com', it was left as is: Invalid IPv6 URL"
+                ),
+            ),
+            '<a href="http://[example.com">invalid</a>',
+        )
+
     def test_absolute_link_with_suggestion(self):
         self.assertEqual(
             self.get_rendered_result(


### PR DESCRIPTION
## Summary

- preserve malformed page links that `urllib.parse.urlsplit()` rejects instead of aborting page rendering
- log the malformed URL through link validation so strict builds can still fail on the warning
- add a regression test for an invalid IPv6-style URL in Markdown content

Fixes #3939.

## Tests

- `PYTHONPATH=/Volumes/STOREJET/Documents/OSC/repos/mkdocs-invalid-url-warning /Volumes/STOREJET/Documents/OSC/repos/mkdocs/.venv-codex/bin/python -m unittest mkdocs.tests.structure.page_tests.RelativePathExtensionTests.test_invalid_url_is_preserved_and_warned`
- `PYTHONPATH=/Volumes/STOREJET/Documents/OSC/repos/mkdocs-invalid-url-warning /Volumes/STOREJET/Documents/OSC/repos/mkdocs/.venv-codex/bin/python -m unittest mkdocs.tests.structure.page_tests.RelativePathExtensionTests`
- `PYTHONPATH=/Volumes/STOREJET/Documents/OSC/repos/mkdocs-invalid-url-warning /Volumes/STOREJET/Documents/OSC/repos/mkdocs/.venv-codex/bin/python -m compileall -q mkdocs/structure/pages.py mkdocs/tests/structure/page_tests.py`
- `git diff --check`
