### PR TITLE
Preserve setext headings with colon titles

### DIFF
--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -391,6 +391,10 @@ class UtilsTests(unittest.TestCase):
         doc = '\nfoo: bar\nDoc body'
         self.assertEqual(meta.get_data(doc), (doc.lstrip(), {}))
 
+    def test_mm_meta_data_ignores_setext_heading(self):
+        doc = 'Foo: Bar\n===\n\nDoc body'
+        self.assertEqual(meta.get_data(doc), (doc, {}))
+
     def test_yaml_meta_data(self):
         doc = dedent(
             """

--- a/mkdocs/utils/meta.py
+++ b/mkdocs/utils/meta.py
@@ -51,6 +51,7 @@ except ImportError:  # pragma: no cover
 YAML_RE = re.compile(r'^-{3}[ \t]*\n(.*?\n)(?:\.{3}|-{3})[ \t]*\n', re.UNICODE | re.DOTALL)
 META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
 META_MORE_RE = re.compile(r'^([ ]{4}|\t)(\s*)(?P<value>.*)')
+SETEXT_HEADING_RE = re.compile(r'^[ ]{0,3}(=+|-+)[ \t]*$')
 
 
 def get_data(doc: str) -> tuple[str, dict[str, Any]]:
@@ -83,6 +84,9 @@ def get_data(doc: str) -> tuple[str, dict[str, Any]]:
         if line.strip() == '':
             break  # blank line - done
         if m1 := META_RE.match(line):
+            if lines and SETEXT_HEADING_RE.match(lines[0]):
+                lines.insert(0, line)
+                break  # setext heading, not meta data
             key = m1.group('key').lower().strip()
             value = m1.group('value').strip()
             if key in data:


### PR DESCRIPTION
## Summary
- preserve colon-containing setext headings like `Foo: Bar` instead of treating them as MultiMarkdown metadata
- add regression coverage for the metadata parser behavior

Fixes #4079.

## Tests
- `PYTHONPATH=/Volumes/STOREJET/Documents/OSC/repos/mkdocs-list-rendering /Volumes/STOREJET/Documents/OSC/repos/mkdocs/.venv-codex/bin/python -m unittest mkdocs.tests.utils.utils_tests.UtilsTests.test_mm_meta_data_ignores_setext_heading mkdocs.tests.utils.utils_tests.UtilsTests.test_mm_meta_data mkdocs.tests.utils.utils_tests.UtilsTests.test_mm_meta_data_blank_first_line mkdocs.tests.utils.utils_tests.UtilsTests.test_yaml_meta_data mkdocs.tests.utils.utils_tests.UtilsTests.test_no_meta_data`
- `PYTHONPATH=/Volumes/STOREJET/Documents/OSC/repos/mkdocs-list-rendering /Volumes/STOREJET/Documents/OSC/repos/mkdocs/.venv-codex/bin/python -m unittest mkdocs.tests.utils.utils_tests`
- `PYTHONPATH=/Volumes/STOREJET/Documents/OSC/repos/mkdocs-list-rendering /Volumes/STOREJET/Documents/OSC/repos/mkdocs/.venv-codex/bin/python -m compileall -q mkdocs/utils/meta.py mkdocs/tests/utils/utils_tests.py`