### PR TITLE
Skip missing static files instead of aborting the build

### DIFF
--- a/mkdocs/structure/files.py
+++ b/mkdocs/structure/files.py
@@ -485,6 +485,12 @@ class File:
                 utils.copy_file(self.abs_src_path, output_path)
             except shutil.SameFileError:
                 pass  # Let plugins write directly into site_dir.
+            except FileNotFoundError:
+                # Dangling symlink or a file that vanished after discovery.
+                log.warning(
+                    f"Skipped copying file '{self.src_uri}'. "
+                    f"The source '{self.abs_src_path}' does not exist."
+                )
         elif isinstance(content, str):
             with open(output_path, 'w', encoding='utf-8') as output_file:
                 output_file.write(content)
@@ -496,8 +502,14 @@ class File:
         if self._content is not None:
             return True
         assert self.abs_src_path is not None
+        try:
+            src_mtime = os.path.getmtime(self.abs_src_path)
+        except OSError:
+            # Missing source or dangling symlink: treat as modified so copy_file
+            # can emit a warning instead of crashing in dirty/serve rebuilds.
+            return True
         if os.path.isfile(self.abs_dest_path):
-            return os.path.getmtime(self.abs_dest_path) < os.path.getmtime(self.abs_src_path)
+            return os.path.getmtime(self.abs_dest_path) < src_mtime
         return True
 
     def is_documentation_page(self) -> bool:

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -586,7 +586,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
             docs_dir=docs_dir,
             site_dir=site_dir,
             use_directory_urls=False,
-            draft_docs='''
+            draft_docs=textwrap.dedent(
+                '''
                 # A "drafts" directory anywhere.
                 drafts/
 
@@ -595,7 +596,8 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
 
                 # But keep this particular file.
                 !/foo_unpublished.md
-            ''',
+                '''
+            ),
         )
 
         with self.subTest(serve_url=None):

--- a/mkdocs/tests/structure/file_tests.py
+++ b/mkdocs/tests/structure/file_tests.py
@@ -708,6 +708,50 @@ class TestFiles(PathAssertionMixin, unittest.TestCase):
         with open(dest_path, encoding='utf-8') as f:
             self.assertEqual(f.read(), 'ö')
 
+    @tempdir()
+    @tempdir()
+    def test_copy_file_dangling_symlink(self, src_dir, dest_dir):
+        link_path = os.path.join(src_dir, 'broken.jpg')
+        try:
+            os.symlink(os.path.join(src_dir, 'missing-target.jpg'), link_path)
+        except OSError:
+            self.skipTest("Creating symlinks not supported")
+        file = File('broken.jpg', src_dir, dest_dir, use_directory_urls=False)
+        dest_path = os.path.join(dest_dir, 'broken.jpg')
+        with self.assertLogs('mkdocs', level='WARNING') as cm:
+            file.copy_file()
+        self.assertPathNotExists(dest_path)
+        self.assertTrue(any('broken.jpg' in msg for msg in cm.output))
+
+    @tempdir()
+    @tempdir(files={'gone.txt': 'source content'})
+    def test_copy_file_missing_source(self, src_dir, dest_dir):
+        file = File('gone.txt', src_dir, dest_dir, use_directory_urls=False)
+        os.remove(os.path.join(src_dir, 'gone.txt'))
+        dest_path = os.path.join(dest_dir, 'gone.txt')
+        with self.assertLogs('mkdocs', level='WARNING') as cm:
+            file.copy_file()
+        self.assertPathNotExists(dest_path)
+        self.assertTrue(any('gone.txt' in msg for msg in cm.output))
+
+    @tempdir(files={'stale.txt': 'old destination'})
+    @tempdir()
+    def test_copy_file_dangling_symlink_dirty(self, src_dir, dest_dir):
+        link_path = os.path.join(src_dir, 'stale.txt')
+        try:
+            os.symlink(os.path.join(src_dir, 'missing-target.txt'), link_path)
+        except OSError:
+            self.skipTest("Creating symlinks not supported")
+        file = File('stale.txt', src_dir, dest_dir, use_directory_urls=False)
+        dest_path = os.path.join(dest_dir, 'stale.txt')
+        self.assertTrue(file.is_modified())
+        with self.assertLogs('mkdocs', level='WARNING') as cm:
+            file.copy_file(dirty=True)
+        self.assertPathIsFile(dest_path)
+        with open(dest_path, encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'old destination')
+        self.assertTrue(any('stale.txt' in msg for msg in cm.output))
+
     def test_files_append_remove_src_paths(self):
         fs = [
             File('index.md', '/path/to/docs', '/path/to/site', use_directory_urls=True),


### PR DESCRIPTION
Fixes #4048.

`File.copy_file` currently lets `shutil.copyfile` raise `FileNotFoundError` for a dangling symlink or a source that disappeared after discovery. That aborts `mkdocs build` / `mkdocs serve` even with `strict: false`.

This catches the missing source, logs a warning, and continues. `is_modified()` also treats an unreadable source as modified so a dirty rebuild takes the same warning path instead of crashing on `os.path.getmtime`.

Tests cover a dangling symlink, a deleted source file, and a dirty rebuild that already has a destination copy.
